### PR TITLE
Maven edi build issue

### DIFF
--- a/edi/ect/maven-ect-plugin/pom.xml
+++ b/edi/ect/maven-ect-plugin/pom.xml
@@ -5,6 +5,7 @@
         <groupId>org.milyn</groupId>
         <artifactId>milyn</artifactId>
         <version>1.5-SNAPSHOT</version> <!-- base pom version - do not remove this comment -->
+		<relativePath>../../../pom.xml</relativePath>
     </parent>
     <name>Edifact Convertion Tool - Maven Plugin Mojo</name>
     <groupId>org.milyn</groupId>

--- a/edi/ect/pom.xml
+++ b/edi/ect/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>	
 	<parent>
         <groupId>org.milyn</groupId>
-        <artifactId>milyn</artifactId>
+        <artifactId>milyn-edi</artifactId>
         <version>1.5-SNAPSHOT</version> <!-- base pom version - do not remove this comment -->
     </parent>
     <name>Edifact Conversion Tool</name>

--- a/edi/edisax/pom.xml
+++ b/edi/edisax/pom.xml
@@ -4,8 +4,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.milyn</groupId>
-        <artifactId>milyn</artifactId>
+        <artifactId>milyn-edi</artifactId>
         <version>1.5-SNAPSHOT</version> <!-- base pom version - do not remove this comment -->
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <name>Milyn EdiSax</name>
     <groupId>org.milyn</groupId>

--- a/edi/ejc/maven-ejc-plugin/pom.xml
+++ b/edi/ejc/maven-ejc-plugin/pom.xml
@@ -5,6 +5,7 @@
         <groupId>org.milyn</groupId>
         <artifactId>milyn</artifactId>
         <version>1.5-SNAPSHOT</version> <!-- base pom version - do not remove this comment -->
+		<relativePath>../../../pom.xml</relativePath>
     </parent>
     <name>Edifact Java Compiler - Maven Plugin Mojo</name>
     <groupId>org.milyn</groupId>

--- a/edi/ejc/pom.xml
+++ b/edi/ejc/pom.xml
@@ -5,6 +5,7 @@
         <groupId>org.milyn</groupId>
         <artifactId>milyn</artifactId>
         <version>1.5-SNAPSHOT</version> <!-- base pom version - do not remove this comment -->
+		<relativePath>../../pom.xml</relativePath>
     </parent>
     <name>Edifact Java Compiler</name>
 	<groupId>org.milyn</groupId>

--- a/edi/pom.xml
+++ b/edi/pom.xml
@@ -2,6 +2,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.milyn</groupId>
+		<artifactId>milyn</artifactId>
+		<version>1.5-SNAPSHOT</version> <!-- base pom version - do not remove this comment -->
+	</parent>
     <groupId>org.milyn</groupId>
     <artifactId>milyn-edi</artifactId>
     <packaging>pom</packaging>


### PR DESCRIPTION
When I run a 'mvn clean install' an prior to that remove the org/milyn group from my local maven repository the build fails with the following error msg:

<pre>
Downloading: http://snapshots.repository.codehaus.org/org/milyn/milyn/1.5-SNAPSHOT/milyn-1.5-SNAPSHOT.pom
[ERROR] The build could not read 5 projects -> [Help 1]
[ERROR]   
[ERROR]   The project org.milyn:milyn-edisax:1.5-SNAPSHOT (/Users/danbev/work/smooks/git/smooks/edi/edisax/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM: Could not find artifact org.milyn:milyn:pom:1.5-SNAPSHOT in codehaus.m2.snapshots (http://snapshots.repository.codehaus.org) and 'parent.relativePath' points at wrong local POM @ line 5, column 13 -> [Help 2]
[ERROR]   
[ERROR]   The project org.milyn:milyn-smooks-ect:${milyn.smooks.core.version} (/Users/danbev/work/smooks/git/smooks/edi/ect/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM: Could not find artifact org.milyn:milyn:pom:1.5-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 4, column 10 -> [Help 2]
[ERROR]   
[ERROR]   The project org.milyn:maven-ect-plugin:1.5-SNAPSHOT (/Users/danbev/work/smooks/git/smooks/edi/ect/maven-ect-plugin/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM: Could not find artifact org.milyn:milyn:pom:1.5-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 4, column 13 -> [Help 2]
[ERROR]   
[ERROR]   The project org.milyn:milyn-smooks-ejc:${milyn.smooks.core.version} (/Users/danbev/work/smooks/git/smooks/edi/ejc/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM: Could not find artifact org.milyn:milyn:pom:1.5-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 4, column 10 -> [Help 2]
[ERROR]   
[ERROR]   The project org.milyn:maven-ejc-plugin:1.5-SNAPSHOT (/Users/danbev/work/smooks/git/smooks/edi/ejc/maven-ejc-plugin/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM: Could not find artifact org.milyn:milyn:pom:1.5-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 4, column 13 -> [Help 2]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
</pre>

This work fixes the issue.
