### PR TITLE
MILYN-579: EDIParser fails under JDK 1.5 because of a bug in Attributes2Impl

### DIFF
--- a/edi/edisax/parser/src/main/java/org/milyn/edisax/EDIParser.java
+++ b/edi/edisax/parser/src/main/java/org/milyn/edisax/EDIParser.java
@@ -28,7 +28,6 @@ import org.milyn.javabean.DataDecodeException;
 import org.milyn.lang.MutableInt;
 import org.milyn.resource.URIResourceLocator;
 import org.xml.sax.*;
-import org.xml.sax.ext.Attributes2Impl;
 import org.xml.sax.helpers.AttributesImpl;
 
 import java.io.*;
@@ -837,7 +836,7 @@ public class EDIParser implements XMLReader {
             if (!declareNamespace) {
             	contentHandler.startElement(namespace, elementName, alias + ":" + elementName, EMPTY_ATTRIBS);
             } else {
-            	Attributes2Impl attrs = new Attributes2Impl();
+            	AttributesImpl attrs = new AttributesImpl();
             	attrs.addAttribute(null, "xmlns:" + alias, "xmlns:" + alias, "CDATA", namespace);
             	contentHandler.startElement(namespace, elementName, alias + ":" + elementName, attrs);
             }

--- a/edi/edisax/parser/src/main/java/org/milyn/edisax/unedifact/UNEdifactInterchangeParser.java
+++ b/edi/edisax/parser/src/main/java/org/milyn/edisax/unedifact/UNEdifactInterchangeParser.java
@@ -42,7 +42,6 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
-import org.xml.sax.ext.Attributes2Impl;
 import org.xml.sax.helpers.AttributesImpl;
 
 /**
@@ -85,7 +84,7 @@ public class UNEdifactInterchangeParser implements XMLReader, HierarchyChangeRea
 	        
 	        contentHandler.startDocument();
 	        contentHandler.startPrefixMapping("h", ControlBlockHandler.NAMESPACE);
-	        Attributes2Impl attrs = new Attributes2Impl();
+	        AttributesImpl attrs = new AttributesImpl();
 	        attrs.addAttribute(XMLConstants.NULL_NS_URI, "xmlns:h", "xmlns:h", "CDATA", ControlBlockHandler.NAMESPACE);
 	        contentHandler.startElement(ControlBlockHandler.NAMESPACE, "unEdifact", "h:unEdifact", attrs);
 	


### PR DESCRIPTION
http://jira.codehaus.org/browse/MILYN-579
