### PR TITLE
Fixed MILYN-601

### DIFF
--- a/edi/edisax/parser/src/main/java/org/milyn/edisax/unedifact/handlers/UNHHandler.java
+++ b/edi/edisax/parser/src/main/java/org/milyn/edisax/unedifact/handlers/UNHHandler.java
@@ -74,8 +74,8 @@ public class UNHHandler implements ControlBlockHandler {
             if(nameComponentIndex != -1) {
                 commonNS = namespace.substring(0, nameComponentIndex) + ":common";
                 messageNSPrefix = description.getName().toLowerCase();
-                attrs.addAttribute(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, "xmlns:c", "xmlns:c", "CDATA", commonNS);
-                attrs.addAttribute(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, "xmlns:" + messageNSPrefix, "xmlns:" + messageNSPrefix, "CDATA", namespace);
+                attrs.addAttribute(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, "c", "xmlns:c", "CDATA", commonNS);
+                attrs.addAttribute(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, messageNSPrefix, "xmlns:" + messageNSPrefix, "CDATA", namespace);
             }
         }
 
@@ -89,8 +89,6 @@ public class UNHHandler implements ControlBlockHandler {
             if(commonNS != null) {
                 parser.getNamespaceResolver().addNamespace(commonNS, "c");
                 parser.getNamespaceResolver().addNamespace(namespace, messageNSPrefix);
-                parser.getNamespaceStack().push(commonNS);
-                parser.getNamespaceStack().push(namespace);
             }
 
 			segmentReader.setSegmentListener(untSegmentListener);

--- a/edi/edisax/parser/src/main/java/org/milyn/edisax/util/NamespaceDeclarationStack.java
+++ b/edi/edisax/parser/src/main/java/org/milyn/edisax/util/NamespaceDeclarationStack.java
@@ -1,0 +1,119 @@
+/*
+ * Milyn - Copyright (C) 2006 - 2011
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License (version 2.1) as published by the Free Software
+ * Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU Lesser General Public License for more details:
+ * http://www.gnu.org/licenses/lgpl.txt
+ */
+package org.milyn.edisax.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+import javax.xml.XMLConstants;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+/**
+ * This class is responsible for managing namespace prefix mapping stack.
+ * Limitation - not supported : re-defining a namespace prefix (child element re-define namespace prefix defined by parent element)
+ * 
+ * @author zubairov
+ */
+public class NamespaceDeclarationStack {
+
+	private final ContentHandler handler;
+	
+	private final Stack<List<String>> nsStack = new Stack<List<String>>();
+	
+	public NamespaceDeclarationStack(ContentHandler handler) {
+		this.handler = handler;
+	}
+	
+	/**
+	 * Pop element out of the namespace declaration stack and notifying
+	 * {@link ContentHandler} if required
+	 * 
+	 * @throws SAXException 
+	 */
+	public void pop() throws SAXException {
+        List<String> pop = nsStack.pop();
+        Collections.reverse(pop);
+        for (String ns : pop) {
+    		handler.endPrefixMapping(ns);
+		}
+	}
+	
+	/**
+	 * Pushing a new element to the stack
+	 * 
+	 * @param attributes optional attributes or null, single element could declare multiple namespaces
+	 * @return modified attributes declaration in case additional prefix mapping should be included
+	 * @throws SAXException 
+	 */
+	public Attributes push(String prefix, String namespace, Attributes attributes) throws SAXException {
+        List<String> namespaces = new ArrayList<String>();
+        // Volatile array
+        Map<String, String> nsToURI = new HashMap<String, String>();
+    	AttributesImpl attrs;
+        if(attributes != null) {
+            attrs = new AttributesImpl(attributes);
+        } else {
+            attrs = new AttributesImpl();
+        }
+        // Gather namespace declarations from the attributes
+        for(int i=0;i<attrs.getLength();i++) {
+        	String qname = attrs.getQName(i);
+        	if (qname != null && qname.startsWith(XMLConstants.XMLNS_ATTRIBUTE + ":")) {
+        		// Add prefix to the list of declared namespaces
+        		namespaces.add(attrs.getLocalName(i));
+        		nsToURI.put(attrs.getLocalName(i), attrs.getValue(i));
+        	}
+        }
+        if (!prefixAlreadyDeclared(prefix)) {
+			// Add a new attribute to the list of attributes
+			attrs.addAttribute(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, prefix, "xmlns:" + prefix, "CDATA", namespace);
+			namespaces.add(prefix);
+			nsToURI.put(prefix, namespace);
+		}
+        nsStack.push(namespaces);
+        // Now call start prefixes if namespaces are not empty
+        for (String nsPrefix : namespaces) {
+        	String uri = nsToURI.get(nsPrefix);
+			handler.startPrefixMapping(nsPrefix, uri);
+		}
+		return attrs;
+	}
+
+	/**
+	 * This method returns true if namespace with given prefix was already declared higher
+	 * the stack
+	 * 
+	 * @param prefix
+	 * @return
+	 */
+	private boolean prefixAlreadyDeclared(String prefix) {
+		for (List<String> set : nsStack) {
+			if (set.contains(prefix)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+}

--- a/edi/edisax/parser/src/test/java/org/milyn/edisax/v1_5/namespaces/NamespaceDeclarationStackTest.java
+++ b/edi/edisax/parser/src/test/java/org/milyn/edisax/v1_5/namespaces/NamespaceDeclarationStackTest.java
@@ -1,0 +1,105 @@
+/*
+ * Milyn - Copyright (C) 2006 - 2011
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License (version 2.1) as published by the Free Software
+ * Foundation.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU Lesser General Public License for more details:
+ * http://www.gnu.org/licenses/lgpl.txt
+ */
+package org.milyn.edisax.v1_5.namespaces;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.XMLConstants;
+
+import org.milyn.edisax.util.NamespaceDeclarationStack;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+import org.xml.sax.helpers.DefaultHandler;
+
+import junit.framework.TestCase;
+
+
+public class NamespaceDeclarationStackTest extends TestCase {
+
+	public static final class MockContentHandler extends DefaultHandler {
+	
+		public List<String> history = new ArrayList<String>();
+		
+		@Override
+		public void startPrefixMapping(String prefix, String uri)
+				throws SAXException {
+			history.add("start:" + prefix + ":" + uri);
+		}
+		
+		@Override
+		public void endPrefixMapping(String prefix) throws SAXException {
+			history.add("end:" + prefix);
+		}
+		
+		
+	}
+	
+	public void testSimpleMaping() throws Exception {
+		MockContentHandler handler = new MockContentHandler();
+		NamespaceDeclarationStack nds = new NamespaceDeclarationStack(handler);
+		Attributes a1 = nds.push("a", "nsa", null);
+		nds.pop();
+		assertEquals("[start:a:nsa, end:a]", handler.history.toString());
+		assertEquals(1, a1.getLength());
+		assertEquals("xmlns:a", a1.getQName(0));
+		assertEquals("nsa", a1.getValue(0));
+	}
+	
+	public void testSimpleMaping2() throws Exception {
+		MockContentHandler handler = new MockContentHandler();
+		NamespaceDeclarationStack nds = new NamespaceDeclarationStack(handler);
+		Attributes a1 = nds.push("a", "nsa", null);
+		Attributes a2 = nds.push("a", "nsa", null);
+		nds.pop();
+		nds.pop();
+		assertEquals("[start:a:nsa, end:a]", handler.history.toString());
+		assertEquals(1, a1.getLength());
+		assertEquals("xmlns:a", a1.getQName(0));
+		assertEquals("nsa", a1.getValue(0));
+		assertEquals(0, a2.getLength());
+	}
+	
+	public void testTwoNamespacesMapping() throws Exception {
+		MockContentHandler handler = new MockContentHandler();
+		NamespaceDeclarationStack nds = new NamespaceDeclarationStack(handler);
+		Attributes a1 = nds.push("a", "nsa", null);
+		Attributes a2 = nds.push("b", "nsb", null);
+		nds.pop();
+		nds.pop();
+		assertEquals("[start:a:nsa, start:b:nsb, end:b, end:a]", handler.history.toString());
+		assertEquals(1, a1.getLength());
+		assertEquals("xmlns:a", a1.getQName(0));
+		assertEquals("nsa", a1.getValue(0));
+		assertEquals(1, a2.getLength());
+		assertEquals("xmlns:b", a2.getQName(0));
+		assertEquals("nsb", a2.getValue(0));
+	}
+	
+	public void testNamespacesWithAttributes() throws Exception {
+		AttributesImpl attrs = new AttributesImpl();
+		attrs.addAttribute(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, "b", "xmlns:b", "CDATA", "nsb");
+		MockContentHandler handler = new MockContentHandler();
+		NamespaceDeclarationStack nds = new NamespaceDeclarationStack(handler);
+		nds.push("a", "nsa", attrs);
+		nds.push("b", "nsb", null);
+		nds.pop();
+		nds.pop();
+		assertEquals("[start:b:nsb, start:a:nsa, end:a, end:b]", handler.history.toString());
+	}
+	
+}


### PR DESCRIPTION
Now SAX methods start/endPrefixMapping are called when expected.
No direct modification of nsStack is allowed anymore.
Created a new class that is handling namespace declarations and call start/endPrefixMapping methods accordingly.

http://jira.codehaus.org/browse/MILYN-601
