### PR TITLE
Re-enabled and fixed edi-test and edi-utils modules

### DIFF
--- a/edi/edi-test/pom.xml
+++ b/edi/edi-test/pom.xml
@@ -24,6 +24,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.16</version>
                         <configuration>
                             <environmentVariables>
                                 <org.milyn.xml.XsdValidator.SchemaFactory>
@@ -47,6 +48,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.16</version>
                         <configuration>
                             <forkMode>once</forkMode>
                             <argLine>-Xms128m -Xmx512m -XX:MaxPermSize=512m</argLine>
@@ -84,6 +86,10 @@
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jdt.core.compiler</groupId>
+            <artifactId>ecj</artifactId>
         </dependency>
     </dependencies>
 

--- a/edi/edi-test/src/test/java/org/milyn/edi/test/unedifact/d93a/D93A_Test.java
+++ b/edi/edi-test/src/test/java/org/milyn/edi/test/unedifact/d93a/D93A_Test.java
@@ -15,14 +15,10 @@
  */
 package org.milyn.edi.test.unedifact.d93a;
 
-import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Test;
 import org.milyn.edi.test.EdifactDirTestHarness;
-import org.milyn.io.StreamUtils;
-import org.milyn.payload.JavaResult;
 import org.xml.sax.SAXException;
 
-import javax.xml.transform.stream.StreamSource;
 import java.io.File;
 import java.io.IOException;
 
@@ -31,7 +27,7 @@ import java.io.IOException;
  */
 public class D93A_Test {
 
-    private static EdifactDirTestHarness d03bHarness = new EdifactDirTestHarness(new File("src/test/resources/d93a.zip"), "DESADV" , "INVOIC" ,"ORDERS");
+    private static EdifactDirTestHarness d03bHarness = new EdifactDirTestHarness(new File("src/test/resources/d93a.zip"), "DESADV", "INVOIC", "ORDERS");
 
     @Test
     public void test_DESADV_java() throws IOException {

--- a/edi/edi-test/src/test/resources/org/milyn/edi/test/build.xml
+++ b/edi/edi-test/src/test/resources/org/milyn/edi/test/build.xml
@@ -2,6 +2,7 @@
 <project name="Compile EDI Mapping Model">
 
     <property name="ejc.dir" value="./target/ejc" />
+    <property name="build.compiler" value="org.eclipse.jdt.core.JDTCompilerAdapter"/>
 
     <target name="delete">
 
@@ -17,7 +18,7 @@
         <mkdir dir="${ejc.dir}/classes" />
 
 
-        <javac srcdir="${ejc.dir}/src" destdir="${ejc.dir}/classes">
+        <javac srcdir="${ejc.dir}/src" destdir="${ejc.dir}/classes" source="1.5" debug="on" nowarn="on" target="1.5">
 
         </javac>
         <jar destfile="${ejc.dir}/ejc.jar">

--- a/edi/edi-utils/pom.xml
+++ b/edi/edi-utils/pom.xml
@@ -23,12 +23,14 @@
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
+            <version>${xerces.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.milyn.edi.unedifact</groupId>
             <artifactId>d99a-mapping</artifactId>
-            <version>${project.version}</version>
+            <version>1.4</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>
@@ -36,11 +38,14 @@
         <dependency>
             <groupId>org.milyn.edi.unedifact</groupId>
             <artifactId>d96b-mapping</artifactId>
-            <version>${project.version}</version>
+            <version>1.4</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/edi/edi-utils/src/main/java/org/milyn/edi/utils/EDISchemaEntityManager.java
+++ b/edi/edi-utils/src/main/java/org/milyn/edi/utils/EDISchemaEntityManager.java
@@ -15,14 +15,6 @@
  */
 package org.milyn.edi.utils;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.xerces.impl.XMLEntityManager;
@@ -37,105 +29,113 @@ import org.jdom.filter.ElementFilter;
 import org.jdom.input.SAXBuilder;
 import org.milyn.util.ClassUtil;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Extension of Xerces {@link XMLEntityManager} that implements
  * {@link XMLEntityResolver} which additinally able to resolve Smooks XML
  * Schemas
- * 
+ *
  * @author zubairov
  */
 public class EDISchemaEntityManager extends XMLEntityManager {
 
-	private final Map<String, String> catalog;
+    private final Map<String, String> catalog;
 
-	private static final Log log = LogFactory.getLog(EDISchemaEntityManager.class);
+    private static final Log log = LogFactory.getLog(EDISchemaEntityManager.class);
 
-	/**
-	 * Factory method to create a new instance
-	 * 
-	 * @return
-	 * @throws IOException
-	 */
-	public static EDISchemaEntityManager createInstance() throws IOException {
-		List<URL> urnFiles = ClassUtil.getResources("/fragment.xml",
-				EDISchemaEntityManager.class);
-		Map<String, String> catalog = new HashMap<String, String>();
-		log.debug("Loading XML schemas information from " + urnFiles);
-		for (URL url : urnFiles) {
-			InputStream in = url.openStream();
-			try {
-				if (in != null) {
-					SAXBuilder builder = new SAXBuilder();
-					Document document = builder.build(in);
-					@SuppressWarnings("unchecked")
-					Iterator<Element> it = document
-							.getDescendants(new ElementFilter("uri"));
-					while (it.hasNext()) {
-						Element next = it.next();
-						String uri = next.getAttributeValue("uri");
-						String name = next.getAttributeValue("name");
-						// URI is now something like platform:/fragment/org.milyn.edi.unedifact.d99a-mapping/path/path/file.xsd
-						// we need only /path/path/file.xsd
-						// cut platform:/fragment/
-						uri = uri.substring(19);
-						// cut after first '/'
-						uri = uri.substring(uri.indexOf('/'));
-						catalog.put(name, uri);
-					}
-				}
-			} catch (JDOMException e) {
-				e.printStackTrace();
-			} finally {
-				if (in != null) {
-					in.close();
-				}
-			}
-		}
-		// One resource we have to add manually
-		catalog.put("urn:org.milyn.edi.unedifact.v41",
-				"/META-INF/schema/v41-segments.xsd");
-		log.debug("Loaded " + catalog.size() + " entries");
-		return new EDISchemaEntityManager(catalog);
-	}
+    /**
+     * Factory method to create a new instance
+     *
+     * @return
+     * @throws IOException
+     */
+    public static EDISchemaEntityManager createInstance() throws IOException {
+        List<URL> urnFiles = ClassUtil.getResources("/fragment.xml",
+                EDISchemaEntityManager.class);
+        Map<String, String> catalog = new HashMap<String, String>();
+        log.debug("Loading XML schemas information from " + urnFiles);
+        for (URL url : urnFiles) {
+            InputStream in = url.openStream();
+            try {
+                if (in != null) {
+                    SAXBuilder builder = new SAXBuilder();
+                    Document document = builder.build(in);
+                    @SuppressWarnings("unchecked")
+                    Iterator<Element> it = document
+                            .getDescendants(new ElementFilter("uri"));
+                    while (it.hasNext()) {
+                        Element next = it.next();
+                        String uri = next.getAttributeValue("uri");
+                        String name = next.getAttributeValue("name");
+                        // URI is now something like platform:/fragment/org.milyn.edi.unedifact.d99a-mapping/path/path/file.xsd
+                        // we need only /path/path/file.xsd
+                        // cut platform:/fragment/
+                        uri = uri.substring(19);
+                        // cut after first '/'
+                        uri = uri.substring(uri.indexOf('/'));
+                        catalog.put(name, uri);
+                    }
+                }
+            } catch (JDOMException e) {
+                e.printStackTrace();
+            } finally {
+                if (in != null) {
+                    in.close();
+                }
+            }
+        }
+        // One resource we have to add manually
+        catalog.put("urn:org.milyn.edi.unedifact.v41",
+                "/META-INF/schema/v41-segments.xsd");
+        log.debug("Loaded " + catalog.size() + " entries");
+        return new EDISchemaEntityManager(catalog);
+    }
 
-	/**
-	 * Constructor called from {@link #createInstance()} with Map NamespaceURI
-	 * --> ResourceLocation
-	 * 
-	 * @param catalog
-	 */
-	protected EDISchemaEntityManager(Map<String, String> catalog) {
-		super();
-		this.catalog = catalog;
-	}
+    /**
+     * Constructor called from {@link #createInstance()} with Map NamespaceURI
+     * --> ResourceLocation
+     *
+     * @param catalog
+     */
+    protected EDISchemaEntityManager(Map<String, String> catalog) {
+        super();
+        this.catalog = catalog;
+    }
 
-	@Override
-	public XMLInputSource resolveEntity(XMLResourceIdentifier resourceIdentifier)
-			throws IOException, XNIException {
-		XMLInputSource result = super.resolveEntity(resourceIdentifier);
-		if (result.getPublicId() == null && result.getSystemId() == null
-				&& result.getCharacterStream() == null
-				&& result.getByteStream() == null) {
-			String ns = resourceIdentifier.getNamespace();
-			if (ns != null) {
-				log.debug("Resolving schema to namespace: " + ns);
-				if (catalog.containsKey(ns)) {
-					result = new XMLInputSource(resourceIdentifier);
-					String location = catalog.get(ns);
-					InputStream stream = EDISchemaEntityManager.class
-							.getResourceAsStream(location);
-					if (stream == null) {
-						throw new XNIException(
-								"Smooks Entity Manager was unable to find resource "
-										+ "with location: " + location);
-					}
-					result.setByteStream(stream);
-				} else {
-					throw new XNIException("Can't find schema with NS: " + ns);
-				}
-			}
-		}
-		return result;
-	}
+    @Override
+    public XMLInputSource resolveEntity(XMLResourceIdentifier resourceIdentifier)
+            throws IOException, XNIException {
+        XMLInputSource result = super.resolveEntity(resourceIdentifier);
+        if (result.getPublicId() == null && result.getSystemId() == null
+                && result.getCharacterStream() == null
+                && result.getByteStream() == null) {
+            String ns = resourceIdentifier.getNamespace();
+            if (ns != null) {
+                log.debug("Resolving schema to namespace: " + ns);
+                if (catalog.containsKey(ns)) {
+                    result = new XMLInputSource(resourceIdentifier);
+                    String location = catalog.get(ns);
+                    InputStream stream = EDISchemaEntityManager.class
+                            .getResourceAsStream(location);
+                    if (stream == null) {
+                        throw new XNIException(
+                                "Smooks Entity Manager was unable to find resource "
+                                        + "with location: " + location);
+                    }
+                    result.setByteStream(stream);
+                } else {
+                    throw new XNIException("Can't find schema with NS: " + ns);
+                }
+            }
+        }
+        return result;
+    }
 
 }

--- a/edi/pom.xml
+++ b/edi/pom.xml
@@ -19,9 +19,8 @@
         <module>ect/maven-ect-plugin</module>
         <module>ejc</module>
         <module>ejc/maven-ejc-plugin</module>
-        <!-- TODO: fix comented modules and enable -->
-        <!--<module>edi-test</module>-->
-        <!--<module>edi-utils</module>-->
+        <module>edi-test</module>
+        <module>edi-utils</module>
     </modules>
 
 </project>

--- a/smooks-all/pom.xml
+++ b/smooks-all/pom.xml
@@ -170,11 +170,6 @@
             <artifactId>mvel2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.freemarker</groupId>
-            <artifactId>freemarker</artifactId>
-            <version>${freemarker.version}</version>
-        </dependency>
-        <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
         </dependency>
@@ -277,14 +272,14 @@
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
-                        <phase>package</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>
                     </execution>
                     <execution>
                         <id>src-dependencies</id>
-                        <phase>package</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>
@@ -298,28 +293,28 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.6</version>
+                <version>1.7</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
                         <configuration>
                             <tasks>
-                                <ant dir="./" antfile="merge-jars.xml">
+                                <ant dir="${project.basedir}" antfile="merge-jars.xml">
                                     <property name="smooks.version" value="${project.version}"/>
                                 </ant>
                             </tasks>
                         </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>1.4.0</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/smooks-parent/pom.xml
+++ b/smooks-parent/pom.xml
@@ -33,7 +33,7 @@
         <groovy.version>1.5.7</groovy.version>
         <jaxen.version>1.1.1</jaxen.version>
         <javax.transaction.version>1.1</javax.transaction.version>
-        <mockito.version>1.8.0</mockito.version>
+        <mockito.version>1.8.2</mockito.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <commons-logging.version>1.1.3</commons-logging.version>
         <junit.version>4.11</junit.version>
@@ -430,6 +430,12 @@
                 <version>1.6</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.eclipse.jdt.core.compiler</groupId>
+                <artifactId>ecj</artifactId>
+                <version>4.3.1</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -467,10 +473,34 @@
                 </excludes>
             </testResource>
         </testResources>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>2.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>2.4.0</version>
+                    <extensions>true</extensions>
+                    <inherited>true</inherited>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>2.8</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
                 <configuration>
                     <source>1.5</source>
                     <target>1.5</target>
@@ -478,7 +508,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2</version>
                 <configuration>
                     <descriptor>assemblies.xml</descriptor>
                 </configuration>
@@ -486,9 +515,10 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.4.0</version>
-                <extensions>true</extensions>
-                <inherited>true</inherited>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- using eclipse compiler for java instead of sun javac - we can not determine javac location without JAVA_HOME set fixes #54
- added ecj 4.3.1 as test dependency for module
- fixed some imports
- fixed build.xml to accomodate changes
- using unedifact mapping and binding version 1.4 - they are deployed on Maven Central
- smooks-all changes:
  - maven-dependency-plugin update to 2.8
  - maven-ant-run update to 1.7
  - maven-bundle-plugin update to 2.4.0
  - moved dependency copy goal to generate-resources phase to fix concurrent exection of goals (ant-run requires dependencies in target)
