### PR TITLE
Removed unnecesarly zeros from numbers.

### DIFF
--- a/smooks-cartridges/edi/src/main/java/org/milyn/javabean/decoders/DABigDecimalDecoder.java
+++ b/smooks-cartridges/edi/src/main/java/org/milyn/javabean/decoders/DABigDecimalDecoder.java
@@ -80,7 +80,7 @@ public class DABigDecimalDecoder extends BigDecimalDecoder {
     private synchronized void setDecimalPointFormat(DecimalFormat decimalFormat, Delimiters interchangeDelimiters) {
         DecimalFormatSymbols dfs = decimalFormat.getDecimalFormatSymbols();
 
-        decimalFormat.applyPattern("#0.0#");
+        decimalFormat.applyPattern("#0.##");
         if (interchangeDelimiters != null) {
             dfs.setDecimalSeparator(interchangeDelimiters.getDecimalSeparator().charAt(0));
         }

--- a/smooks-cartridges/edi/src/test/java/org/milyn/javabean/decoders/DABigDecimalDecoderTest.java
+++ b/smooks-cartridges/edi/src/test/java/org/milyn/javabean/decoders/DABigDecimalDecoderTest.java
@@ -44,9 +44,19 @@ public class DABigDecimalDecoderTest extends TestCase {
         assertEquals("1.1", decoder.encode(BigDecimal.valueOf(11, 1), DOT_DEC_DELIMITERS));
     }
 
+    public void test_encode_decimal_point_dot_without_unnecesarly_zeros() {
+        DABigDecimalDecoder decoder = new DABigDecimalDecoder();
+        assertEquals("1", decoder.encode(new BigDecimal(1.000), DOT_DEC_DELIMITERS));
+    }
+
     public void test_encode_decimal_point_comma() {
         DABigDecimalDecoder decoder = new DABigDecimalDecoder();
         assertEquals("1,1", decoder.encode(BigDecimal.valueOf(11, 1), COMMA_DEC_DELIMITERS));
+    }
+
+    public void test_encode_decimal_point_comma_without_unnecesarly_zeros() {
+        DABigDecimalDecoder decoder = new DABigDecimalDecoder();
+        assertEquals("1", decoder.encode(new BigDecimal(1.000), COMMA_DEC_DELIMITERS));
     }
 
     class DotDABigDecimalDecoder extends DABigDecimalDecoder {


### PR DESCRIPTION
Numbers with this format 1.0 are invalid
for some EDI parsers. Fixed to output all
numbers without .0
