### PR TITLE
fixed osgi feature and dependencies

### DIFF
--- a/smooks-all/pom.xml
+++ b/smooks-all/pom.xml
@@ -36,6 +36,7 @@
         <spring.commons.logging.version>1.1.1</spring.commons.logging.version>
         <spring.groovy.version>1.5.7</spring.groovy.version>
         <spring.log4j.version>1.2.15</spring.log4j.version>
+        <ow2.opencsv.version>1.0.36</ow2.opencsv.version>
     </properties>
 
     <dependencies>

--- a/smooks-all/src/main/resources/features.xml
+++ b/smooks-all/src/main/resources/features.xml
@@ -3,7 +3,7 @@
 
   <feature name="smooks" version="${project.version}">
     <bundle>mvn:org.antlr/com.springsource.antlr/${spring.antlr.version}</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.freemarker/2.3.20_1</bundle>
+    <bundle>mvn:org.freemarker/freemarker/${freemarker.version}</bundle>
     <!-- Karaf comes with pax-logging and slf4j; the following logging jars should not be required -->
     <!--<bundle>mvn:org.apache.commons/com.springsource.org.apache.commons.logging/${spring.commons.logging.version}</bundle>-->
     <!--<bundle>mvn:org.apache.log4j/com.springsource.org.apache.log4j/${spring.log4j.version}</bundle>-->
@@ -13,8 +13,8 @@
     <bundle>mvn:org.objectweb.asm/com.springsource.org.objectweb.asm.tree/${spring.objectweb.version}</bundle>
     <bundle>mvn:org.objectweb.asm/com.springsource.org.objectweb.asm.tree.analysis/${spring.objectweb.version}</bundle>
     <bundle>mvn:org.objectweb.asm/com.springsource.org.objectweb.asm.util/${spring.objectweb.version}</bundle>
-    <bundle>mvn:commons-lang/commons-lang/${commons.lang.version}</bundle>
-    <bundle>mvn:org.ow2.bundles/ow2-bundles-externals-opencsv/${opencsv.version}</bundle>
+    <bundle>mvn:commons-lang/commons-lang/${commons_lang.version}</bundle>
+    <bundle>mvn:org.ow2.bundles/ow2-bundles-externals-opencsv/${ow2.opencsv.version}</bundle>
     <bundle>mvn:org.milyn/milyn-smooks-all/${project.version}</bundle>
   </feature>
 


### PR DESCRIPTION
we've just upgraded to smooks 1.6-SNAPSHOT and noticed that some osgi dependencies didn't work/could be improved:
1. since version 2.3.20 freemarker is a bundle
2. commons.lang.version variable name was wrong
3. there was no correct opencsv version defined for the ow2 bundle
