### PR TITLE
Removed spring-asm

### DIFF
--- a/smooks-examples/osgi/blueprint/pom.xml
+++ b/smooks-examples/osgi/blueprint/pom.xml
@@ -57,10 +57,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-asm</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
             <artifactId>spring-expression</artifactId>
         </dependency>
         <dependency>

--- a/smooks-parent/pom.xml
+++ b/smooks-parent/pom.xml
@@ -781,12 +781,6 @@
 
               <dependency>
                  <groupId>org.springframework</groupId>
-                 <artifactId>spring-asm</artifactId>
-                 <version>${spring.version}</version>
-              </dependency>
-
-              <dependency>
-                 <groupId>org.springframework</groupId>
                  <artifactId>spring-expression</artifactId>
                  <version>${spring.version}</version>
               </dependency>


### PR DESCRIPTION
Since Spring's release 3.2, spring-asm is part of spring-core, so this dependency cannot be fulfilled anymore. The dependency causes an issue in running mvn install on the blueprint example.