### PR TITLE
because codehaus's maven repositories had terminated.

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -10,7 +10,7 @@
                 <repository>
                     <id>codehaus-snapshots</id>
                     <name>Codehaus Snapshots</name>
-                    <url>http://nexus.codehaus.org/snapshots/</url>
+                    <url>https://repository-master.mulesoft.org/nexus/content/repositories/public/</url>
                     <releases>
                         <enabled>false</enabled>
                     </releases>

--- a/smooks-parent/pom.xml
+++ b/smooks-parent/pom.xml
@@ -17,7 +17,7 @@
     <version>1.7-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Milyn :: Parent POM</name>
-    <url>http://milyn.codehaus.org</url>
+    <url>https://repository-master.mulesoft.org/nexus/content/groups/public/</url>
 
     <description>
         Milyn parent pom. Provides unified dependency information and build configuration for sub-modules.
@@ -1125,7 +1125,7 @@
         </repository>
         <repository>
             <id>mvel</id>
-            <url>http://repository.codehaus.org</url>
+            <url>https://repository-master.mulesoft.org/nexus/content/groups/public/</url>
         </repository>
         <repository>
             <id>smooks</id>
@@ -1173,7 +1173,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>codehaus</id>
-            <url>http://repository.codehaus.org</url>
+            <url>https://repository-master.mulesoft.org/nexus/content/repositories/public/</url>
         </pluginRepository>
         <pluginRepository>
             <id>jibx.sf.net</id>


### PR DESCRIPTION
update maven repositories to fix build issue. update URL from http://milyn.codehaus.org to
https://repository-master.mulesoft.org/nexus/content/groups/public/
https://repository-master.mulesoft.org/nexus/content/repositories/public/

see:
http://www.codehaus.org/
All Codehaus services have now been terminated.

http://www.codehaus.org/mechanics/maven/
Now that Codehaus no longer serves up Maven repositories, you will need to change your configuration.
