### PR TITLE
Adding a few optional ConfigGenerator properties

### DIFF
--- a/smooks-cartridges/javabean/src/main/java/org/milyn/javabean/gen/model/BindingConfig.java
+++ b/smooks-cartridges/javabean/src/main/java/org/milyn/javabean/gen/model/BindingConfig.java
@@ -26,18 +26,28 @@ public class BindingConfig {
 
     private Field property;
     private String wireBeanId;
+    private boolean isWiring;
 
     public BindingConfig(Field property) {
         this.property = property;
+        this.isWiring = false;
     }
 
     public BindingConfig(String wireBeanId) {
         this.wireBeanId = wireBeanId;
+        this.isWiring = (wireBeanId != null);
     }
 
     public BindingConfig(Field property, String wireBeanId) {
         this.property = property;
         this.wireBeanId = wireBeanId;
+        this.isWiring = (wireBeanId != null);
+    }
+
+    public BindingConfig(Field property, String wireBeanId, boolean isWiring) {
+        this.property = property;
+        this.wireBeanId = isWiring ? wireBeanId : capitalizeFirstLetter(wireBeanId);
+        this.isWiring = isWiring;
     }
 
     public Field getProperty() {
@@ -53,7 +63,7 @@ public class BindingConfig {
     }
 
     public boolean isWiring() {
-        return (wireBeanId != null);
+        return isWiring;
     }
 
     public boolean isBoundToProperty() {
@@ -78,5 +88,18 @@ public class BindingConfig {
         }
 
         return "$TODO$";
+    }
+
+    private String capitalizeFirstLetter(String text) {
+        if (text != null && text.length() > 0) {
+            String cap = text.substring(0, 1).toUpperCase();
+            if (text.length() > 1) {
+                cap = cap + text.substring(1);
+            }
+            return cap;
+        }
+        else {
+            return text;
+        }
     }
 }

--- a/smooks-cartridges/javabean/src/test/java/org/milyn/javabean/extendedconfig11/BeanBindingExtendedConfigTest.java
+++ b/smooks-cartridges/javabean/src/test/java/org/milyn/javabean/extendedconfig11/BeanBindingExtendedConfigTest.java
@@ -55,7 +55,15 @@ public class BeanBindingExtendedConfigTest {
         assertOrderOK(order, true);
 
         Map headerHash = (Map) result.getBean("headerBeanHash");
-        assertEquals("{privatePerson=, customer=Joe, date=Wed Nov 15 13:45:28 EST 2006}", headerHash.toString());
+        Object privatePerson = headerHash.get("privatePerson");
+        assertNotNull(privatePerson);
+        assertEquals("", privatePerson.toString());
+        Object customer = headerHash.get("customer");
+        assertNotNull(customer);
+        assertEquals("Joe", customer.toString());
+        Object date = headerHash.get("date");
+        assertNotNull(date);
+        assertEquals("Wed Nov 15 13:45:28 EST 2006", date.toString());
     }
 
 	/**

--- a/smooks-cartridges/javabean/src/test/java/org/milyn/javabean/extendedconfig13/BeanBindingExtendedConfigTest.java
+++ b/smooks-cartridges/javabean/src/test/java/org/milyn/javabean/extendedconfig13/BeanBindingExtendedConfigTest.java
@@ -54,7 +54,15 @@ public class BeanBindingExtendedConfigTest {
         assertOrderOK(order, true);
 
         Map headerHash = (Map) result.getBean("headerBeanHash");
-        assertEquals("{privatePerson=, customer=Joe, date=Wed Nov 15 13:45:28 EST 2006}", headerHash.toString());
+        Object privatePerson = headerHash.get("privatePerson");
+        assertNotNull(privatePerson);
+        assertEquals("", privatePerson.toString());
+        Object customer = headerHash.get("customer");
+        assertNotNull(customer);
+        assertEquals("Joe", customer.toString());
+        Object date = headerHash.get("date");
+        assertNotNull(date);
+        assertEquals("Wed Nov 15 13:45:28 EST 2006", date.toString());
     }
 
 	/**

--- a/smooks-cartridges/javabean/src/test/java/org/milyn/javabean/gen/ConfigGeneratortTest.java
+++ b/smooks-cartridges/javabean/src/test/java/org/milyn/javabean/gen/ConfigGeneratortTest.java
@@ -29,13 +29,33 @@ public class ConfigGeneratortTest {
         java.io.StringWriter writer = new java.io.StringWriter();
 
         properties.setProperty(ConfigGenerator.ROOT_BEAN_CLASS, org.milyn.javabean.Order.class.getName());
+        properties.setProperty(ConfigGenerator.INHERIT_FIELDS, Boolean.FALSE.toString());
 
         ConfigGenerator generator = new ConfigGenerator(properties, writer);
 
         generator.generate();
 
         String expected = org.milyn.io.StreamUtils.readStreamAsString(getClass().getResourceAsStream("expected-01.xml"));
-        assertTrue("Generated config not as expected.", org.milyn.io.StreamUtils.compareCharStreams(new java.io.StringReader(expected), new java.io.StringReader(writer.toString())));
+        String result = writer.toString();
+        assertTrue("Generated config not as expected.", org.milyn.io.StreamUtils.compareCharStreams(new java.io.StringReader(expected), new java.io.StringReader(result)));
+    }
+
+    @Test
+    public void testWithValueSelector() throws ClassNotFoundException, java.io.IOException {
+        java.util.Properties properties = new java.util.Properties();
+        java.io.StringWriter writer = new java.io.StringWriter();
+
+        properties.setProperty(ConfigGenerator.ROOT_BEAN_CLASS, org.milyn.javabean.Order.class.getName());
+        properties.setProperty(ConfigGenerator.INHERIT_FIELDS, Boolean.TRUE.toString());
+        properties.setProperty(ConfigGenerator.USE_BEAN_ID_AS_XML_SELECTOR, Boolean.TRUE.toString());
+
+        ConfigGenerator generator = new ConfigGenerator(properties, writer);
+
+        generator.generate();
+
+        String expected = org.milyn.io.StreamUtils.readStreamAsString(getClass().getResourceAsStream("expected-02.xml"));
+        String result = writer.toString();
+        assertTrue("Generated config not as expected.", org.milyn.io.StreamUtils.compareCharStreams(new java.io.StringReader(expected), new java.io.StringReader(result)));
     }
 
     @Test

--- a/smooks-cartridges/javabean/src/test/java/org/milyn/javabean/gen/expected-02.xml
+++ b/smooks-cartridges/javabean/src/test/java/org/milyn/javabean/gen/expected-02.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<smooks-resource-list xmlns="http://www.milyn.org/xsd/smooks-1.1.xsd" xmlns:jb="http://www.milyn.org/xsd/smooks/javabean-1.2.xsd">
+
+    <!-- TODO:
+            THIS IS A CONFIGURATION TEMPLATE!!  It is not the finished article.
+
+            1. For each <jb:bindings> element, set the createOnElement attribute to the event element that should
+               be used to create the bean instance.
+            2. Update the <jb:value data> attributes to select the event element/attribute supplying the binding
+               data for that bean property.
+            3. Check the <jb:value decoder> attributes.  Not all will be set, depending on the actual property type.
+               These must be configured by hand e.g. you may need to configure <jb:decodeParam>
+               sub-elements for the decoder on some of the bindings.  E.g. for a date field:
+                    <jb:value property="date" data="header/date" decoder="Date">
+                        <jb:decodeParam name="format">EEE MMM dd HH:mm:ss z yyyy</jb:decodeParam>
+                    </jb:value>
+            4. Double-check the binding config elements (<jb:value> and <jb:wiring>), making sure all Java properties
+               have been covered in the generated configuration.
+
+            Determining appropriate values for the <jb:bean createOnElement> and <jb:value data> attributes can
+            sometimes be difficult, especially for non XML Sources (Java etc).  The Html Reporting tool can be a great
+            help here because it helps you visualise the input message model (against which the selectors will be
+            applied) as seen by Smooks.  So, first off, generate a report using your Source data, but with an empty
+            transformation configuration.  In the report, you can see the model against which you need to add your
+            configurations.  Add the configurations one at a time, rerunning the report to check they are being applied.
+
+            For details on how to run a report, see the Smooks User Guide (http://milyn.codehaus.org/Smooks+User+Guide#SmooksUserGuide-CheckingtheSmooksExecutionProcess).
+    -->
+
+
+    <jb:bean beanId="order" class="org.milyn.javabean.Order" createOnElement="$TODO$">
+        <jb:wiring property="header" beanIdRef="header" />
+        <jb:wiring property="orderItems" beanIdRef="orderItems" />
+        <jb:wiring property="orderItemsArray" beanIdRef="orderItemsArray" />
+    </jb:bean>
+
+    <jb:bean beanId="header" class="org.milyn.javabean.Header" createOnElement="$TODO$">
+        <jb:value property="date" decoder="$TODO$" data="Date" />
+        <jb:value property="customerNumber" decoder="Long" data="CustomerNumber" />
+        <jb:value property="customerName" decoder="String" data="CustomerName" />
+        <jb:value property="privatePerson" decoder="Boolean" data="PrivatePerson" />
+        <jb:wiring property="order" beanIdRef="order" />
+    </jb:bean>
+
+    <jb:bean beanId="orderItems" class="java.util.ArrayList" createOnElement="$TODO$">
+        <jb:wiring beanIdRef="orderItems_entry" />
+    </jb:bean>
+
+    <jb:bean beanId="orderItems_entry" class="org.milyn.javabean.OrderItem" createOnElement="$TODO$">
+        <jb:value property="productId" decoder="Long" data="ProductId" />
+        <jb:value property="quantity" decoder="Integer" data="Quantity" />
+        <jb:value property="price" decoder="Double" data="Price" />
+        <jb:wiring property="order" beanIdRef="order" />
+    </jb:bean>
+
+    <jb:bean beanId="orderItemsArray" class="org.milyn.javabean.OrderItem[]" createOnElement="$TODO$">
+        <jb:wiring beanIdRef="orderItemsArray_entry" />
+    </jb:bean>
+
+    <jb:bean beanId="orderItemsArray_entry" class="org.milyn.javabean.OrderItem" createOnElement="$TODO$">
+        <jb:value property="productId" decoder="Long" data="ProductId" />
+        <jb:value property="quantity" decoder="Integer" data="Quantity" />
+        <jb:value property="price" decoder="Double" data="Price" />
+        <jb:wiring property="order" beanIdRef="order" />
+    </jb:bean>
+
+</smooks-resource-list>


### PR DESCRIPTION
Properties:
inheritFields
POJO's with inheritance would exclude the inherited fields because of Class.getDeclaredFields().  This optionally allows for including those fields by recursing the super class and calling Class.getDeclaredFields() on each.

useBeanIdAsXmlSelector
I have an XML configuration for EDI to XML where the fields in the POJO match the element name.  This allows for using the field name instead of just filling TODO, resulting in a lot less cleanup of the generated configuration.
