### PR TITLE
Adding the option for EnumDecoder to be "less strict"

### DIFF
--- a/commons/src/main/java/org/milyn/javabean/decoders/EnumDecoder.java
+++ b/commons/src/main/java/org/milyn/javabean/decoders/EnumDecoder.java
@@ -31,7 +31,7 @@ import java.util.Properties;
  * param. Enum constant value mappings can be performed as per the
  * {@link org.milyn.javabean.decoders.MappingDecoder}.
  * The "<b>strict</b>" configuration param determines how data that do not
- * map to valid enum constants will handled.  Under the default behavior, or
+ * map to valid enum constants will be handled.  Under the default behavior, or
  * when specifying strict as "true", an error will be thrown.  If strict is
  * "false" null will be returned
  *

--- a/commons/src/main/java/org/milyn/javabean/decoders/EnumDecoder.java
+++ b/commons/src/main/java/org/milyn/javabean/decoders/EnumDecoder.java
@@ -30,7 +30,11 @@ import java.util.Properties;
  * The enumeration type is specified through the "<b>enumType</b>" configuration
  * param. Enum constant value mappings can be performed as per the
  * {@link org.milyn.javabean.decoders.MappingDecoder}.
- * 
+ * The "<b>strict</b>" configuration param determines how data that do not
+ * map to valid enum constants will handled.  Under the default behavior, or
+ * when specifying strict as "true", an error will be thrown.  If strict is
+ * "false" null will be returned
+ *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
 @DecodeType({Enum.class})
@@ -39,6 +43,7 @@ public class EnumDecoder implements DataDecoder, Configurable {
     private Properties configuration;
     private Class enumType;
     private MappingDecoder mappingDecoder = new MappingDecoder();
+    private boolean strict = true;
 
     public void setConfiguration(Properties resourceConfig) throws SmooksConfigurationException {
         String enumTypeName = resourceConfig.getProperty("enumType");
@@ -57,6 +62,7 @@ public class EnumDecoder implements DataDecoder, Configurable {
         if(!Enum.class.isAssignableFrom(enumType)) {
             throw new SmooksConfigurationException("Invalid Enum decoder configuration.  Resolved 'enumType' '" + enumTypeName + "' is not a Java Enum Class.");
         }
+        strict = resourceConfig.getProperty("strict", "true").equals("true");
 
         mappingDecoder.setConfiguration(resourceConfig);
         mappingDecoder.setStrict(false);
@@ -78,7 +84,16 @@ public class EnumDecoder implements DataDecoder, Configurable {
         try {
             return Enum.valueOf(enumType, mappedValue.trim());
         } catch(IllegalArgumentException e) {
-            throw new DataDecodeException("Failed to decode '" + mappedValue + "' as a valid Enum constant of type '" + enumType.getName() + "'.");
+            if(strict) {
+                throw new DataDecodeException("Failed to decode '" + mappedValue + "' as a valid Enum constant of type '" + enumType.getName() + "'.");
+            } else {
+                return null;
+            }
+
         }
+    }
+
+    public void setStrict(boolean strict) {
+        this.strict = strict;
     }
 }

--- a/commons/src/test/java/org/milyn/javabean/decoders/EnumDecoderTest.java
+++ b/commons/src/test/java/org/milyn/javabean/decoders/EnumDecoderTest.java
@@ -50,10 +50,60 @@ public class EnumDecoderTest {
         }
     }
 
-	@Test
-    public void test_good_config() {
-        EnumDecoder decoder = new EnumDecoder();
-        Properties config = new Properties();
+    /**
+     * DOCUMENT ME!
+     */
+    @Test public void test_good_config_strict_false() {
+        final EnumDecoder decoder = new EnumDecoder();
+        final Properties config = new Properties();
+
+        config.setProperty("enumType", MyEnum.class.getName());
+        config.setProperty("strict", "false");
+        config.setProperty("val-A", "ValA");
+        config.setProperty("val-B", "ValB");
+        decoder.setConfiguration(config);
+
+        assertEquals(MyEnum.ValA, decoder.decode("ValA"));
+        assertEquals(MyEnum.ValA, decoder.decode("val-A"));
+        assertEquals(MyEnum.ValB, decoder.decode("ValB"));
+        assertEquals(MyEnum.ValB, decoder.decode("val-B"));
+        assertNull(decoder.decode("xxxxx"));
+    }
+
+    /**
+     * DOCUMENT ME!
+     */
+    @Test public void test_good_config_strict_true() {
+        final EnumDecoder decoder = new EnumDecoder();
+        final Properties config = new Properties();
+
+        config.setProperty("enumType", MyEnum.class.getName());
+        config.setProperty("strict", "true");
+        config.setProperty("val-A", "ValA");
+        config.setProperty("val-B", "ValB");
+        decoder.setConfiguration(config);
+
+        assertEquals(MyEnum.ValA, decoder.decode("ValA"));
+        assertEquals(MyEnum.ValA, decoder.decode("val-A"));
+        assertEquals(MyEnum.ValB, decoder.decode("ValB"));
+        assertEquals(MyEnum.ValB, decoder.decode("val-B"));
+
+        try {
+            decoder.decode("xxxxx");
+            fail("Expected DataDecodeException");
+        } catch (DataDecodeException e) {
+            assertEquals(
+                    "Failed to decode 'xxxxx' as a valid Enum constant of type 'org.milyn.javabean.decoders.MyEnum'.",
+                    e.getMessage());
+        }
+    }
+
+    /**
+     * DOCUMENT ME!
+     */
+    @Test public void test_good_config_strict_undefined() {
+        final EnumDecoder decoder = new EnumDecoder();
+        final Properties config = new Properties();
 
         config.setProperty("enumType", MyEnum.class.getName());
         config.setProperty("val-A", "ValA");
@@ -68,8 +118,10 @@ public class EnumDecoderTest {
         try {
             decoder.decode("xxxxx");
             fail("Expected DataDecodeException");
-        } catch(DataDecodeException e) {
-            assertEquals("Failed to decode 'xxxxx' as a valid Enum constant of type 'org.milyn.javabean.decoders.MyEnum'.", e.getMessage());
+        } catch (DataDecodeException e) {
+            assertEquals(
+                    "Failed to decode 'xxxxx' as a valid Enum constant of type 'org.milyn.javabean.decoders.MyEnum'.",
+                    e.getMessage());
         }
     }
 }


### PR DESCRIPTION
I came across a scenario where it would be helpful if the EnumDecoder was less strict...where if the data being decoded didn't map to any of the enum's constants it would return null instead of throwing an exception.

To that end I've added support for the "strict" configuration param to EnumDecoder.
This determines how data that do not map to valid enum constants will be handled.
Under the default behavior, or when specifying strict as "true", an exception will be thrown.
If strict is"false" null will be returned.

This can be used in conjunction with the java bean value binding "default" attribute to have any unmapped data mapped to the default enum constant.
