### PR TITLE
Fix issue #129 - Allow UNEdifactInterchangeParser to be extended with…

### DIFF
--- a/edi/edisax/src/main/java/org/milyn/edisax/unedifact/UNEdifactInterchangeParser.java
+++ b/edi/edisax/src/main/java/org/milyn/edisax/unedifact/UNEdifactInterchangeParser.java
@@ -107,7 +107,7 @@ public class UNEdifactInterchangeParser implements XMLReader, NamespaceDeclarati
                     // Add the UN/EDIFACT namespace to the namespace stack...
                     namespaceDeclarationStack.pushNamespaces(envElementQName, handlerFactory.getNamespace(), attrs);
 
-                    ControlBlockHandler handler = handlerFactory.getControlBlockHandler(segCode);
+                    ControlBlockHandler handler = interchangeContext.getControlBlockHandler(segCode);
 
 					interchangeContext.indentDepth.value++;
 		        	handler.process(interchangeContext);


### PR DESCRIPTION
… other syntax identifier codes

Change UNEdifactInterchangeParser to use InterchangeContext to get control block handler. This way it's possible to use a special UNBHandler with new syntax identifiers.

With this change it's possible to add PADIS `IATA` and `IATB` syntax identifiers like:
```:java
public class PadisReader extends UNEdifactReader {
    private static Segment unbSegment;

    private static Segment unzSegment;

    private static final HashMap<String, Charset> toCharsetMapping;

    static {
        try {
            Edimap controlBlockSegments = EDIConfigDigester
                    .digestConfig(UNEdifact41ControlBlockHandlerFactory.class.getResourceAsStream("v41-segments.xml"));
            List<SegmentGroup> segments = controlBlockSegments.getSegments().getSegments();
            for (SegmentGroup segment : segments) {
                if (segment.getSegcode().equals("UNB")) {
                    unbSegment = (Segment) segment;
                } else if (segment.getSegcode().equals("UNZ")) {
                    unzSegment = (Segment) segment;
                }
            }
        } catch (Exception e) {
            throw new SmooksConfigurationException("Unexpected exception reading UN/EDIFACT v4.1 segment definitions.", e);
        }

        toCharsetMapping = new HashMap<String, Charset>();
        toCharsetMapping.put("IATA", StandardCharsets.US_ASCII);
        toCharsetMapping.put("IATB", StandardCharsets.US_ASCII);
    }

    private ExecutionContext executionContext;

    public PadisReader() {
        this.registry = new PadisMappingsRegistry();
    }

    public void setExecutionContext(ExecutionContext executionContext) {
        this.executionContext = executionContext;
        super.setExecutionContext(executionContext);
    }

    @Override
    protected InterchangeContext createInterchangeContext(
            BufferedSegmentReader segmentReader, boolean validate,
            ControlBlockHandlerFactory controlBlockHandlerFactory, NamespaceDeclarationStack namespaceDeclarationStack) {

        return new PadisInterchangeContext(segmentReader, registry, getContentHandler(), getFeatures(), controlBlockHandlerFactory, namespaceDeclarationStack, validate);
    }

    class PadisInterchangeContext extends InterchangeContext {

        PadisInterchangeContext(BufferedSegmentReader segmentReader, MappingsRegistry registry, ContentHandler contentHandler, Map<String, Boolean> parserFeatures, ControlBlockHandlerFactory controlBlockHandlerFactory, NamespaceDeclarationStack namespaceDeclarationStack, boolean validate) {
            super(segmentReader, registry, contentHandler, parserFeatures, controlBlockHandlerFactory, namespaceDeclarationStack, validate);
        }

        // From UNEdifactReader
        @Override
        public void pushDelimiters(Delimiters delimiters) {
            super.pushDelimiters(delimiters);
            executionContext.getBeanContext().addBean(
                    "interchangeDelimiters", delimiters);
        }

        public ControlBlockHandler getControlBlockHandler(String segCode) throws SAXException {
            if ("UNB".equals(segCode)) {
                return new UNBHandler(unbSegment, unzSegment, toCharsetMapping);
            }
            return super.getControlBlockHandler(segCode);
        }
    }
}

```
