### PR TITLE
Fix issue #132 EJCExecutor generates message definitions for the __mo…

### DIFF
--- a/edi/ejc/src/main/java/org/milyn/ejc/EJCExecutor.java
+++ b/edi/ejc/src/main/java/org/milyn/ejc/EJCExecutor.java
@@ -78,7 +78,7 @@ public class EJCExecutor {
         for(Map.Entry<String, EdifactModel> model : modelSet) {
             Description description = model.getValue().getDescription();
 
-            if(description.equals(EDIUtils.MODEL_SET_DEFINITIONS_DESCRIPTION_LOOKUP_NAME)) {
+            if(definitionsModel != null && definitionsModel.getDescription().equals(description)) {
                 // Already done (above).  Skip it...
                 continue;
             }


### PR DESCRIPTION
…delset_definitions

Use description to description equals and compare against the just generate common modelset