### PR TITLE
Fixes issue #143 - TravisCI builds fail under openjdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: java
 
+# workaround for travis-ci/travis-ci#5227
+# See https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913
+addons:
+  hosts:
+    - smooks
+  hostname: smooks
+
 jdk:
   - oraclejdk8
   - oraclejdk7


### PR DESCRIPTION
Added workaround from https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913