### PR TITLE
Fix #146 SmooksRoutingException when multiple threads create same directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
 
 notifications:

--- a/smooks-cartridges/routing/src/main/java/org/milyn/routing/file/FileOutputStreamResource.java
+++ b/smooks-cartridges/routing/src/main/java/org/milyn/routing/file/FileOutputStreamResource.java
@@ -225,7 +225,8 @@ public class FileOutputStreamResource extends AbstractOutputStreamResource
             throw new SmooksRoutingException("The file routing target directory '" + destinationDirectory.getAbsolutePath() + "' exist but is not a directory. destinationDirectoryPattern: '" + destinationDirectoryPattern + "'");
         }
         if(!destinationDirectory.exists()) {
-            if(!destinationDirectory.mkdirs()) {
+			if (!destinationDirectory.mkdirs()
+					&& !(destinationDirectory.exists() && destinationDirectory.isDirectory())) {
                 throw new SmooksRoutingException("Failed to create file routing target directory '" + destinationDirectory.getAbsolutePath() + "'. destinationDirectoryPattern: '" + destinationDirectoryPattern + "'");
             }
         }


### PR DESCRIPTION
There is race condition below. Easy fix is not throwing exeption if mkdirs return false but the directory already exists.
```
if(!destinationDirectory.exists()) {
            if(!destinationDirectory.mkdirs()) {
                throw new SmooksRoutingException("Failed to create file routing target directory '" + destinationDirectory.getAbsolutePath() + "'. destinationDirectoryPattern: '" + destinationDirectoryPattern + "'");
            }
        }
```