### PR TITLE
Passing Maven settings file from deploy script because "maven.config"…

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,0 @@
---settings ./.mvn/settings.xml

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mvn clean deploy -Dgpg.skip=false -DskipTests=true -Dmaven.javadoc.skip=true -B
+mvn clean deploy --settings=.mvn/settings.xml -Dgpg.skip=false -DskipTests=true -Dmaven.javadoc.skip=true -B


### PR DESCRIPTION
… doesn't handle multi-module projects well