### PR TITLE
refactor: leverage new APIs in Java 8 for date/time type conversion

### DIFF
--- a/commons/src/main/java/org/smooks/converter/factory/system/CalendarConverterFactory.java
+++ b/commons/src/main/java/org/smooks/converter/factory/system/CalendarConverterFactory.java
@@ -49,6 +49,7 @@ import org.smooks.converter.factory.TypeConverterFactory;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
 /**
  * {@link Calendar} data decoder.
@@ -72,7 +73,11 @@ public class CalendarConverterFactory implements TypeConverterFactory<String, Ca
         return new StringToDateLocaleAwareConverter<Calendar>() {
             @Override
             protected Calendar doConvert(Date date) {
-                return (Calendar) decoder.getCalendar().clone();
+                final Calendar calendar = Calendar.getInstance(getLocale());
+                calendar.setTime(date);
+                calendar.setTimeZone(TimeZone.getTimeZone(zoneId));
+                
+                return calendar;
             }
         };
     }

--- a/commons/src/main/java/org/smooks/converter/factory/system/DateLocaleAwareTypeConverter.java
+++ b/commons/src/main/java/org/smooks/converter/factory/system/DateLocaleAwareTypeConverter.java
@@ -44,8 +44,8 @@ package org.smooks.converter.factory.system;
 
 import org.smooks.cdr.SmooksConfigurationException;
 
-import java.text.SimpleDateFormat;
-import java.util.Locale;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Properties;
 
 /**
@@ -72,6 +72,9 @@ public abstract class DateLocaleAwareTypeConverter<S, T> extends LocaleAwareType
      */
     public static final String FORMAT = "format";
 
+    public static final String ZONE_ID = "zoneId";
+
+
     /**
      * Default date format string.
      */
@@ -79,12 +82,14 @@ public abstract class DateLocaleAwareTypeConverter<S, T> extends LocaleAwareType
 
     protected String format;
 
+    protected ZoneId zoneId = ZoneId.systemDefault();
+
     /*
      * 	Need to initialize a default decoder as not calls can be make
      * 	directly to decode without calling setConfigurtion.
      */
-    protected SimpleDateFormat decoder = new SimpleDateFormat(DEFAULT_DATE_FORMAT);
-    
+    protected DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT);
+
     public void setConfiguration(Properties properties) throws SmooksConfigurationException {
         super.setConfiguration(properties);
 
@@ -94,12 +99,21 @@ public abstract class DateLocaleAwareTypeConverter<S, T> extends LocaleAwareType
                 throw new SmooksConfigurationException("Decoder must specify a 'format' parameter.");
             }
 
-            Locale configuredLocale = getLocale();
-            if (configuredLocale != null) {
-                decoder = new SimpleDateFormat(format.trim(), configuredLocale);
-            } else {
-                decoder = new SimpleDateFormat(format.trim());
+            if (properties.getProperty(ZONE_ID) != null) {
+                zoneId = ZoneId.of(properties.getProperty(ZONE_ID));
             }
+
+            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(format.trim());
+
+            if (getLocale() != null) {
+                dateTimeFormatter = dateTimeFormatter.withLocale(getLocale());
+            }
+
+            if (zoneId != null) {
+                dateTimeFormatter = dateTimeFormatter.withZone(zoneId);
+            }
+
+            this.dateTimeFormatter = dateTimeFormatter;
         }
     }
 }

--- a/commons/src/main/java/org/smooks/converter/factory/system/DateToStringLocaleAwareConverter.java
+++ b/commons/src/main/java/org/smooks/converter/factory/system/DateToStringLocaleAwareConverter.java
@@ -48,7 +48,7 @@ import java.util.Date;
 public abstract class DateToStringLocaleAwareConverter<S extends Date> extends DateLocaleAwareTypeConverter<S, String> {
     @Override
     public String convert(final Date value) {
-        return doConvert(decoder.format(value));
+        return doConvert(dateTimeFormatter.format(value.toInstant()));
     }
 
     protected abstract String doConvert(String value);

--- a/commons/src/test/java/org/smooks/converter/factory/system/CalendarConverterFactoryTest.java
+++ b/commons/src/test/java/org/smooks/converter/factory/system/CalendarConverterFactoryTest.java
@@ -73,6 +73,7 @@ public class CalendarConverterFactoryTest {
 		CalendarConverterFactory calendarConverterFactory = new CalendarConverterFactory();
 	    config.setProperty(DateLocaleAwareTypeConverter.LOCALE_LANGUAGE_CODE, "en");
 	    config.setProperty(DateLocaleAwareTypeConverter.LOCALE_COUNTRY_CODE, "IE");
+		config.setProperty(DateLocaleAwareTypeConverter.ZONE_ID, "America/New_York");
 
 		TypeConverter<String, Calendar> typeConverter = calendarConverterFactory.createTypeConverter();
 		((Configurable) typeConverter).setConfiguration(config);


### PR DESCRIPTION
allow time zone to be configurable in date/time type converters