### PR TITLE
refactor: return a TypeConverter in TypeConverterFactory.createTypeCo…

### DIFF
--- a/commons/src/main/java/org/smooks/converter/factory/TypeConverterFactory.java
+++ b/commons/src/main/java/org/smooks/converter/factory/TypeConverterFactory.java
@@ -47,7 +47,7 @@ import org.smooks.converter.TypeConverterDescriptor;
 
 public interface TypeConverterFactory<S, T> {
     
-    TypeConverter<S, T> createTypeConverter();
+    TypeConverter<? super S, ? extends T> createTypeConverter();
     
     TypeConverterDescriptor<Class<S>, Class<T>> getTypeConverterDescriptor();
 }

--- a/core/src/main/java/org/smooks/converter/factory/PreprocessTypeConverter.java
+++ b/core/src/main/java/org/smooks/converter/factory/PreprocessTypeConverter.java
@@ -75,7 +75,7 @@ public class PreprocessTypeConverter implements Configurable, TypeConverter<Stri
     @Inject
     private ApplicationContext applicationContext;
     private Properties properties;
-    private TypeConverter<String, Object> delegateTypeConverter;
+    private TypeConverter<? super String, ?> delegateTypeConverter;
 
     @PostConstruct
     public void postConstruct() {
@@ -102,11 +102,11 @@ public class PreprocessTypeConverter implements Configurable, TypeConverter<Stri
         }
     }
 
-    public TypeConverter<String, Object> getDelegateTypeConverter() {
+    public TypeConverter<? super String, ?> getDelegateTypeConverter() {
         return delegateTypeConverter;
     }
 
-    public void setDelegateTypeConverter(final TypeConverter<String, Object> delegateTypeConverter) {
+    public void setDelegateTypeConverter(final TypeConverter<? super String, ?> delegateTypeConverter) {
         this.delegateTypeConverter = delegateTypeConverter;
     }
 

--- a/core/src/main/java/org/smooks/delivery/nested/NestedExecutionVisitor.java
+++ b/core/src/main/java/org/smooks/delivery/nested/NestedExecutionVisitor.java
@@ -152,7 +152,7 @@ public class NestedExecutionVisitor implements SAXVisitBefore, VisitLifecycleCle
         // the content handler and redirect the reader events to it...
     }
 
-    public Set<? extends Object> getProducts() {
+    public Set<?> getProducts() {
         return CollectionsUtil.toSet(mapBeans);
     }
 

--- a/core/src/main/java/org/smooks/delivery/ordering/Producer.java
+++ b/core/src/main/java/org/smooks/delivery/ordering/Producer.java
@@ -70,5 +70,5 @@ public interface Producer extends Visitor {
      * Get the set of products produced by this producer instance.
      * @return The set the set of products produced by this producer instance.
      */
-    Set<? extends Object> getProducts();
+    Set<?> getProducts();
 }

--- a/core/src/main/java/org/smooks/javabean/context/StandaloneBeanContext.java
+++ b/core/src/main/java/org/smooks/javabean/context/StandaloneBeanContext.java
@@ -42,6 +42,8 @@
  */
 package org.smooks.javabean.context;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.smooks.assertion.AssertArgument;
 import org.smooks.container.ExecutionContext;
 import org.smooks.delivery.Fragment;
@@ -50,8 +52,6 @@ import org.smooks.javabean.lifecycle.BeanContextLifecycleObserver;
 import org.smooks.javabean.lifecycle.BeanLifecycle;
 import org.smooks.javabean.repository.BeanId;
 import org.smooks.util.MultiLineToStringBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.Map.Entry;
@@ -641,10 +641,10 @@ public class StandaloneBeanContext implements BeanContext {
 		 *
 		 * @see java.util.Map#putAll(java.util.Map)
 		 */
-		public void putAll(Map<? extends String, ? extends Object> map) {
+		public void putAll(Map<? extends String, ?> map) {
 			AssertArgument.isNotNull(map, "map");
 
-			for (Entry<? extends String, ? extends Object> entry : map
+			for (Entry<? extends String, ?> entry : map
 					.entrySet()) {
 
 				addBean(entry.getKey(), entry.getValue(), null);

--- a/core/src/main/java/org/smooks/util/MultiLineToStringBuilder.java
+++ b/core/src/main/java/org/smooks/util/MultiLineToStringBuilder.java
@@ -42,20 +42,15 @@
  */
 package org.smooks.util;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Stack;
-import java.util.Map.Entry;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.commons.lang.StringUtils;
 import org.smooks.container.ExecutionContext;
 import org.smooks.payload.FilterResult;
 import org.smooks.payload.FilterSource;
+
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Static utility class for generating JSON like multi line Strings
@@ -124,7 +119,7 @@ public class MultiLineToStringBuilder {
      * @param map The Map to create the string from
      * @return The String representation of the Map
      */
-    public static String toString(Map<? extends Object, ? extends Object> map) {
+    public static String toString(Map<?, ?> map) {
     	return toString(map, Collections.emptyList());
 	}
 
@@ -135,7 +130,7 @@ public class MultiLineToStringBuilder {
      * @param filterKeyList A list of objects that are ignored when encountered as keys
      * @return The String representation of the Map
      */
-    public static String toString(Map<? extends Object, ? extends Object> map, List<?> filterKeyList) {
+    public static String toString(Map<?, ?> map, List<?> filterKeyList) {
 		Stack<Object> stack = new Stack<Object>();
 		stack.add(new Object()); // A little hack to make sure that the first level is rendered correctly
     	return toString(map, stack, filterKeyList);
@@ -147,7 +142,7 @@ public class MultiLineToStringBuilder {
      * @param map The Map to create the string from
      * @return The String representation of the Map
      */
-	public static String toString(Collection<? extends Object> collection) {
+	public static String toString(Collection<?> collection) {
 		return toString(collection, Collections.emptyList());
 	}
 
@@ -158,7 +153,7 @@ public class MultiLineToStringBuilder {
      * @param filterKeyList A list of objects that are ignored when encountered as keys
      * @return The String representation of the Map
      */
-	public static String toString(Collection<? extends Object> collection, List<?> filterKeyList) {
+	public static String toString(Collection<?> collection, List<?> filterKeyList) {
 		Stack<Object> stack = new Stack<Object>();
 		stack.add(new Object()); // A little hack to make sure that the first level is rendered correctly
 
@@ -196,7 +191,7 @@ public class MultiLineToStringBuilder {
      * @param filterKeyList A list of objects that are ignored when encountered as keys
      * @return The String representation of the Map
      */
-	private static String toString(Map<? extends Object, ? extends Object> map, Stack<Object> parentStack, List<?> filterKeys) {
+	private static String toString(Map<?, ?> map, Stack<Object> parentStack, List<?> filterKeys) {
     	StringBuilder builder = new StringBuilder();
     	builder.append(CURLY_BRACKET_OPEN);
 
@@ -205,7 +200,7 @@ public class MultiLineToStringBuilder {
 
     	int i = 0;
     	int size = map.entrySet().size();
-    	for(Entry<? extends Object, ? extends Object> entry : map.entrySet()) {
+    	for(Entry<?, ?> entry : map.entrySet()) {
     		String key = entry.getKey().toString();
 
     		if(filterKeys.contains(key)) {
@@ -248,7 +243,7 @@ public class MultiLineToStringBuilder {
 
 
 
-    private static String toString(Collection<? extends Object> collection, Stack<Object> parentStack, List<?> filterKeys) {
+    private static String toString(Collection<?> collection, Stack<Object> parentStack, List<?> filterKeys) {
     	StringBuilder builder = new StringBuilder();
     	builder.append(SQUARE_BRACKET_OPEN);
 
@@ -340,11 +335,11 @@ public class MultiLineToStringBuilder {
 	private static void processValue(Object current, Object value, String key, Stack<Object> parentStack, StringBuilder builder, List<?> filterKeys) {
 		if(value instanceof Map<?, ?>) {
 			parentStack.push(current);
-			builder.append(toString((Map<? extends Object, ? extends Object>) value, parentStack, filterKeys));
+			builder.append(toString((Map<?, ?>) value, parentStack, filterKeys));
 			parentStack.pop();
 		} else if(value instanceof Collection<?>) {
 			parentStack.push(current);
-			builder.append(toString((Collection<? extends Object>) value, parentStack, filterKeys));
+			builder.append(toString((Collection<?>) value, parentStack, filterKeys));
 			parentStack.pop();
 		} else if(value.getClass().isArray()) {
 			parentStack.push(current);

--- a/core/src/test/java/org/smooks/cdr/registry/lookup/converter/SourceTargetTypeConverterFactoryLookupTest.java
+++ b/core/src/test/java/org/smooks/cdr/registry/lookup/converter/SourceTargetTypeConverterFactoryLookupTest.java
@@ -40,11 +40,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.cdr.registry.lookup;
+package org.smooks.cdr.registry.lookup.converter;
 
 import org.junit.Test;
-import org.smooks.cdr.registry.lookup.converter.SourceTargetTypeConverterFactoryLookup;
-import org.smooks.cdr.registry.lookup.converter.TypeConverterFactoryLookup;
 import org.smooks.converter.TypeConverter;
 import org.smooks.converter.TypeConverterDescriptor;
 import org.smooks.converter.factory.TypeConverterFactory;
@@ -88,7 +86,7 @@ public class SourceTargetTypeConverterFactoryLookupTest {
         }});
 
         SourceTargetTypeConverterFactoryLookup<String, Integer> sourceTargetTypeConverterFactoryLookup = new SourceTargetTypeConverterFactoryLookup<>(String.class, Integer.class);
-        TypeConverter<String, Integer> typeConverter = sourceTargetTypeConverterFactoryLookup.apply(registryEntries).createTypeConverter();
+        TypeConverter<? super String, ? extends Integer> typeConverter = sourceTargetTypeConverterFactoryLookup.apply(registryEntries).createTypeConverter();
         assertNotNull(typeConverter);
         assertNotNull(typeConverter.convert("1"));
     }
@@ -139,7 +137,7 @@ public class SourceTargetTypeConverterFactoryLookupTest {
         ((Set<TypeConverterFactory<?, ?>>) registryEntries.get(TypeConverterFactoryLookup.TYPE_CONVERTER_FACTORY_REGISTRY_KEY)).add(mediumPriorityTypeConverterFactory);
 
         SourceTargetTypeConverterFactoryLookup<String, Integer> sourceTargetTypeConverterFactoryLookup = new SourceTargetTypeConverterFactoryLookup<>(String.class, Integer.class);
-        TypeConverter<String, Integer> typeConverter = sourceTargetTypeConverterFactoryLookup.apply(registryEntries).createTypeConverter();
+        TypeConverter<? super String, ? extends Integer> typeConverter = sourceTargetTypeConverterFactoryLookup.apply(registryEntries).createTypeConverter();
         assertNotNull(typeConverter.convert("1"));
     }
 }

--- a/core/src/test/java/org/smooks/delivery/ordering/testvisitors/TestProducer.java
+++ b/core/src/test/java/org/smooks/delivery/ordering/testvisitors/TestProducer.java
@@ -44,9 +44,9 @@ package org.smooks.delivery.ordering.testvisitors;
 
 import org.smooks.delivery.ordering.Producer;
 
-import java.util.Set;
-import java.util.HashSet;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:tom.fennelly@jboss.com">tom.fennelly@jboss.com</a>
@@ -59,7 +59,7 @@ public class TestProducer implements Producer {
         this.products.addAll(Arrays.asList(products));
     }
 
-    public Set<? extends Object> getProducts() {
+    public Set<?> getProducts() {
         return products;
     }
 }

--- a/core/src/test/java/org/smooks/delivery/ordering/testvisitors/TestProducerConsumer.java
+++ b/core/src/test/java/org/smooks/delivery/ordering/testvisitors/TestProducerConsumer.java
@@ -42,13 +42,13 @@
  */
 package org.smooks.delivery.ordering.testvisitors;
 
-import org.smooks.delivery.ordering.Producer;
 import org.smooks.delivery.ordering.Consumer;
+import org.smooks.delivery.ordering.Producer;
 
-import java.util.Set;
-import java.util.HashSet;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:tom.fennelly@jboss.com">tom.fennelly@jboss.com</a>
@@ -68,7 +68,7 @@ public class TestProducerConsumer implements Producer, Consumer {
         return this;
     }
 
-    public Set<? extends Object> getProducts() {
+    public Set<?> getProducts() {
         return products;
     }
 

--- a/scribe/core/src/test/java/org/smooks/scribe/register/AbstractDaoAdapterRegisterTest.java
+++ b/scribe/core/src/test/java/org/smooks/scribe/register/AbstractDaoAdapterRegisterTest.java
@@ -42,12 +42,12 @@
  */
 package org.smooks.scribe.register;
 
-import static org.junit.Assert.*;
+import org.testng.annotations.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.testng.annotations.Test;
+import static org.junit.Assert.assertSame;
 
 /**
  * @author <a href="mailto:maurice.zeijen@smies.com">maurice.zeijen@smies.com</a>
@@ -106,12 +106,12 @@ public class AbstractDaoAdapterRegisterTest {
 
 	private static class Mock extends AbstractDaoAdapterRegister<Object, Object> {
 
-		public Mock(Map<String, ? extends Object> adaptableMap) {
+		public Mock(Map<String, ?> adaptableMap) {
 			super(adaptableMap);
 		}
 
 		public Mock(Object defaultAdaptable,
-				Map<String, ? extends Object> adaptableMap) {
+				Map<String, ?> adaptableMap) {
 			super(defaultAdaptable, adaptableMap);
 		}
 


### PR DESCRIPTION
…nverter that can convert an object which has its class inherited from the source class

simplify redundant "? extends Object" declarations

move SourceTargetTypeConverterFactoryLookupTest to class under test's corresponding test package