### PR TITLE
fix: solve broken behaviour for traversing ancestors and restoring me…

### DIFF
--- a/commons/src/main/java/org/smooks/assertion/AssertArgument.java
+++ b/commons/src/main/java/org/smooks/assertion/AssertArgument.java
@@ -65,8 +65,7 @@ public abstract class AssertArgument {
 	public static void isNotNull(Object arg, String argName)
 			throws IllegalArgumentException {
 		if (arg == null) {
-			throw new IllegalArgumentException("null '" + argName
-					+ "' arg in method call.");
+			throw new IllegalArgumentException("Undefined '" + argName + "' argument in method call.");
 		}
 	}
 
@@ -83,8 +82,7 @@ public abstract class AssertArgument {
 	public static void isNotEmpty(String arg, String argName)
 			throws IllegalArgumentException {
 		if (arg != null && arg.trim().length() == 0) {
-			throw new IllegalArgumentException("Not null, but empty '"
-					+ argName + "' arg in method call.");
+			throw new IllegalArgumentException("Not undefined, but empty '" + argName + "' argument in method call.");
 		}
 	}
 
@@ -101,8 +99,7 @@ public abstract class AssertArgument {
 	public static void isNotNullAndNotEmpty(String arg, String argName)
 			throws IllegalArgumentException {
 		if (arg == null || arg.trim().length() == 0) {
-			throw new IllegalArgumentException("null or empty '" + argName
-					+ "' arg in method call.");
+			throw new IllegalArgumentException("Undefined or empty '" + argName + "' argument in method call.");
 		}
 	}
 
@@ -115,7 +112,7 @@ public abstract class AssertArgument {
 	 */
 	public static void isNotNullAndNotEmpty(Object[] arg, String argName) throws IllegalArgumentException {
 		if (arg == null || arg.length == 0) {
-			throw new IllegalArgumentException("null or empty '" + argName + "' arg in method call.");
+			throw new IllegalArgumentException("Undefined or empty '" + argName + "' argument in method call.");
 		}
 	}
 
@@ -128,7 +125,7 @@ public abstract class AssertArgument {
 	 */
 	public static void isNotNullAndNotEmpty(Collection<?> arg, String argName) throws IllegalArgumentException {
 		if (arg == null || arg.isEmpty()) {
-			throw new IllegalArgumentException("null or empty '" + argName + "' arg in method call.");
+			throw new IllegalArgumentException("Undefined or empty '" + argName + "' argument in method call.");
 		}
 	}
 
@@ -141,7 +138,7 @@ public abstract class AssertArgument {
 	 */
 	public static void isNotNullAndNotEmpty(Map<?, ?> arg, String argName) throws IllegalArgumentException {
 		if (arg == null || arg.isEmpty()) {
-			throw new IllegalArgumentException("null or empty '" + argName + "' arg in method call.");
+			throw new IllegalArgumentException("Undefined or empty '" + argName + "' argument in method call.");
 		}
 	}
 

--- a/core/src/main/java/org/smooks/container/MementoCaretaker.java
+++ b/core/src/main/java/org/smooks/container/MementoCaretaker.java
@@ -56,30 +56,32 @@ public interface MementoCaretaker {
     /**
      * Stores a copy of a <code>VisitorMemento</code>. It is the client's responsibility to remove the saved 
      * <code>VisitorMemento</code> once it is no longer needed either by calling {@link #forget(Fragment)} or 
-     * {@link #remove(VisitorMemento)}.
+     * {@link #forget(VisitorMemento)}.
      * 
      * @param visitorMemento  the <code>VisitorMemento</code> to copy and store. After saving, mutations to this 
      *                        <code>VisitorMemento</code> should not alter the saved copy.
      */
-    void save(VisitorMemento visitorMemento);
+    void capture(VisitorMemento visitorMemento);
 
     /**
      * Mutates a <code>VisitorMemento</code> to match the state of a saved <code>VisitorMemento</code>. The 
      * <code>VisitorMemento</code> parameter is restored from a saved <code>VisitorMemento</code> having an ID equal to 
-     * its ID as returned by {@link VisitorMemento#getId()}. The <code>VisitorMemento</code> parameter remains unchanged 
+     * its ID as returned by {@link VisitorMemento#getAnchor()}. The <code>VisitorMemento</code> parameter remains unchanged 
      * if no such saved <code>VisitorMemento</code> exists. 
      * 
      * @param visitorMemento  the <code>VisitorMemento</code> to restore
      */
     void restore(VisitorMemento visitorMemento);
 
+    boolean exists(VisitorMemento visitorMemento);
+
     /**
      * Removes the <code>VisitorMemento</code> having an ID equal to the <code>VisitorMemento</code> parameter's ID as 
-     * returned by {@link VisitorMemento#getId()}.
+     * returned by {@link VisitorMemento#getAnchor()}.
      * 
      * @param visitorMemento  the <code>VisitorMemento</code> to be removed
      */
-    void remove(VisitorMemento visitorMemento);
+    void forget(VisitorMemento visitorMemento);
 
     /**
      * Removes all <code>VisitorMemento</code>s bound to the <code>Fragment</code> parameter.
@@ -103,7 +105,7 @@ public interface MementoCaretaker {
      *                               <code>VisitorMemento replacing the earlier memento</code>
      * 
      * @see #restore(VisitorMemento)
-     * @see #save(VisitorMemento)
+     * @see #capture(VisitorMemento)
      */
     <T extends VisitorMemento> T stash(T defaultVisitorMemento, Function<T, T> function);
 }

--- a/core/src/main/java/org/smooks/container/MockExecutionContext.java
+++ b/core/src/main/java/org/smooks/container/MockExecutionContext.java
@@ -165,6 +165,11 @@ public class MockExecutionContext implements ExecutionContext {
 	}
 
 	@Override
+	public <T> T getOrDefault(TypedKey<T> key, T value) {
+		return executionContext.getOrDefault(key, value);
+	}
+
+	@Override
 	public Map<TypedKey<Object>, Object> getAll() {
 		return executionContext.getAll();
 	}

--- a/core/src/main/java/org/smooks/container/TypedMap.java
+++ b/core/src/main/java/org/smooks/container/TypedMap.java
@@ -72,6 +72,8 @@ public interface TypedMap {
 	 */
     <T> T get(TypedKey<T> key);
 
+	<T> T getOrDefault(TypedKey<T> key, T value);
+	
 	/**
 	 * Returns the Map of attributes bound in this {@link TypedMap}
 	 * @return Map of all objects bound in this {@link TypedMap}

--- a/core/src/main/java/org/smooks/container/standalone/DefaultMementoCaretaker.java
+++ b/core/src/main/java/org/smooks/container/standalone/DefaultMementoCaretaker.java
@@ -64,23 +64,23 @@ public class DefaultMementoCaretaker implements MementoCaretaker {
     }
     
     @Override
-    public void save(final VisitorMemento visitorMemento) {
-        mementoIds.computeIfAbsent(visitorMemento.getFragment(), o -> new HashSet<>()).add(visitorMemento.getId());
-        typedMap.put(new TypedKey<>(visitorMemento.getId()), visitorMemento.copy());
+    public void capture(final VisitorMemento visitorMemento) {
+        mementoIds.computeIfAbsent(visitorMemento.getFragment(), o -> new HashSet<>()).add(visitorMemento.getAnchor());
+        typedMap.put(new TypedKey<>(visitorMemento.getAnchor()), visitorMemento.copy());
     }
 
     @Override
     public <T extends VisitorMemento> T stash(final T defaultVisitorMemento, final Function<T, T> function) {
         restore(defaultVisitorMemento);
         T newVisitorMemento = function.apply(defaultVisitorMemento);
-        save(newVisitorMemento);
+        capture(newVisitorMemento);
         
         return newVisitorMemento;
     }
     
     @Override
     public void restore(final VisitorMemento visitorMemento) {
-        final String visitorMementoId = visitorMemento.getId();
+        final String visitorMementoId = visitorMemento.getAnchor();
         final TypedKey<VisitorMemento> visitorMementoTypedKey = new TypedKey<>(visitorMementoId);
         final VisitorMemento restoredVisitorMemento = typedMap.get(visitorMementoTypedKey);
         if (restoredVisitorMemento != null) {
@@ -89,11 +89,16 @@ public class DefaultMementoCaretaker implements MementoCaretaker {
             typedMap.put(visitorMementoTypedKey, visitorMemento);
         }
     }
-    
+
     @Override
-    public void remove(final VisitorMemento visitorMemento) {
-        typedMap.remove(new TypedKey<>(visitorMemento.getId()) );
-        mementoIds.getOrDefault(visitorMemento.getFragment(), new HashSet<>()).remove(visitorMemento.getId());
+    public boolean exists(VisitorMemento visitorMemento) {
+        return typedMap.get(new TypedKey<>(visitorMemento.getAnchor())) != null;
+    }
+
+    @Override
+    public void forget(final VisitorMemento visitorMemento) {
+        typedMap.remove(new TypedKey<>(visitorMemento.getAnchor()) );
+        mementoIds.getOrDefault(visitorMemento.getFragment(), new HashSet<>()).remove(visitorMemento.getAnchor());
     }
 
     @Override

--- a/core/src/main/java/org/smooks/container/standalone/StandaloneExecutionContext.java
+++ b/core/src/main/java/org/smooks/container/standalone/StandaloneExecutionContext.java
@@ -56,7 +56,6 @@ import org.smooks.javabean.context.StandaloneBeanContextFactory;
 import org.smooks.profile.ProfileSet;
 import org.smooks.profile.UnknownProfileMemberException;
 
-import java.io.Writer;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
@@ -81,7 +80,6 @@ public class StandaloneExecutionContext implements ExecutionContext {
 	private String contentEncoding;
     private Throwable terminationError;
     private BeanContext beanContext;
-	private Writer writer;
 
 	/**
 	 * Public Constructor.
@@ -175,7 +173,7 @@ public class StandaloneExecutionContext implements ExecutionContext {
 	 */
 	@Override
 	public String getContentEncoding() {
-		return (contentEncoding == null)?"UTF-8":contentEncoding;
+		return (contentEncoding == null) ? "UTF-8" : contentEncoding;
 	}
 
 	@Override
@@ -214,6 +212,11 @@ public class StandaloneExecutionContext implements ExecutionContext {
 		return (T) attributes.get(key);
 	}
 
+	@Override
+	public <T> T getOrDefault(TypedKey<T> key, T value) {
+		return (T) attributes.getOrDefault(key, value);
+	}
+
 	/* (non-Javadoc)
 	 * @see org.smooks.container.BoundAttributeStore#removeAttribute(java.lang.Object)
 	 */
@@ -234,7 +237,7 @@ public class StandaloneExecutionContext implements ExecutionContext {
 
 	@Override
 	public BeanContext getBeanContext() {
-		if(beanContext == null) {
+		if (beanContext == null) {
 			beanContext = StandaloneBeanContextFactory.create(this);
 		}
 		return beanContext;

--- a/core/src/main/java/org/smooks/delivery/memento/Memento.java
+++ b/core/src/main/java/org/smooks/delivery/memento/Memento.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * Smooks Core
  * %%
- * Copyright (C) 2020 Smooks
+ * Copyright (C) 2020 - 2021 Smooks
  * %%
  * Licensed under the terms of the Apache License Version 2.0, or
  * the GNU Lesser General Public License version 3.0 or later.
@@ -42,37 +42,36 @@
  */
 package org.smooks.delivery.memento;
 
-import org.smooks.assertion.AssertArgument;
 import org.smooks.delivery.Visitor;
 import org.smooks.delivery.fragment.Fragment;
 
-public abstract class AbstractVisitorMemento implements VisitorMemento {
-    protected final Fragment fragment;
-    protected final Visitor visitor;
-    protected String anchor;
-
-    public AbstractVisitorMemento(final Fragment fragment, final Visitor visitor) {
-        AssertArgument.isNotNull(fragment, "fragment");
-        AssertArgument.isNotNull(visitor, "visitor");
-        
-        this.fragment = fragment;
-        this.visitor = visitor;
-    }
+public class Memento<T> extends AbstractVisitorMemento {
     
-    @Override
-    public Visitor getVisitor() {
-        return visitor;
+    private T state;
+    
+    public Memento(Fragment fragment, Visitor visitor, T state) {
+        super(fragment, visitor);
+        this.state = state;
     }
 
     @Override
-    public Fragment getFragment() {
-        return fragment;
+    public VisitorMemento copy() {
+        return new Memento<>(fragment, visitor, state);
+    }
+
+    @Override
+    public void restore(VisitorMemento visitorMemento) {
+        state = (T) ((Memento) visitorMemento).getState();
+    }
+
+    public T getState() {
+        return state;
     }
 
     @Override
     public String getAnchor() {
         if (anchor == null) {
-            anchor = fragment.getId() + "@" + visitor.getClass().getName() + "@" + getClass().getName() + "@" + System.identityHashCode(visitor);
+            anchor = state.getClass().getName() + "@" + fragment.getId() + "@" + visitor.getClass().getName() + "@" + getClass().getName() + "@" + System.identityHashCode(visitor);
         }
         return anchor;
     }

--- a/core/src/main/java/org/smooks/delivery/memento/VisitorMemento.java
+++ b/core/src/main/java/org/smooks/delivery/memento/VisitorMemento.java
@@ -80,11 +80,11 @@ public interface VisitorMemento  {
     Fragment getFragment();
 
     /**
-     * Gets the ID of this <code>VisitorMemento</code>. <code>VisitorMemento</code>s with equal IDs are considered to be 
-     * capturing the state of the same object but at different points in time.
+     * Gets the anchor value of this <code>VisitorMemento</code>. <code>VisitorMemento</code>s with equal anchor values 
+     * are considered to be capturing the state of the same object but at different points in time.
      * 
      * @return the ID of this <code>VisitorMemento</code>
      */
-    String getId();
+    String getAnchor();
     
 }

--- a/core/src/main/java/org/smooks/delivery/sax/ng/SaxNgSerializerVisitor.java
+++ b/core/src/main/java/org/smooks/delivery/sax/ng/SaxNgSerializerVisitor.java
@@ -52,12 +52,12 @@ import org.smooks.delivery.dom.DOMElementVisitor;
 import org.smooks.delivery.fragment.Fragment;
 import org.smooks.delivery.fragment.NodeFragment;
 import org.smooks.delivery.memento.AbstractVisitorMemento;
+import org.smooks.delivery.memento.Memento;
 import org.smooks.delivery.memento.VisitorMemento;
 import org.smooks.delivery.sax.SAXElement;
 import org.smooks.delivery.sax.SAXElementVisitor;
 import org.smooks.delivery.sax.SAXText;
 import org.smooks.io.FragmentWriter;
-import org.smooks.io.FragmentWriterMemento;
 import org.w3c.dom.CharacterData;
 import org.w3c.dom.*;
 
@@ -270,11 +270,12 @@ public class SaxNgSerializerVisitor implements ElementVisitor, SAXElementVisitor
     
     protected void onWrite(final Consumer<Writer> writerConsumer, final ExecutionContext executionContext, final Node node) {
         if (executionContext.getContentDeliveryRuntime().getContentDeliveryConfig() instanceof SaxNgContentDeliveryConfig) {
-            final FragmentWriterMemento fragmentWriterMemento = executionContext.
+            final NodeFragment nodeFragment = new NodeFragment(node);
+            final Memento<FragmentWriter> fragmentWriterMemento = executionContext.
                     getMementoCaretaker().
-                    stash(new FragmentWriterMemento(this, new FragmentWriter(executionContext, new NodeFragment(node))), restoredFragmentWriterMemento -> restoredFragmentWriterMemento);
+                    stash(new Memento<>(nodeFragment, this, new FragmentWriter(executionContext, new NodeFragment(node))), restoredFragmentWriterMemento -> restoredFragmentWriterMemento);
 
-            writerConsumer.accept(fragmentWriterMemento.getFragmentWriter());
+            writerConsumer.accept(fragmentWriterMemento.getState());
         }
     }
 }

--- a/core/src/main/java/org/smooks/io/ResourceWriter.java
+++ b/core/src/main/java/org/smooks/io/ResourceWriter.java
@@ -73,12 +73,16 @@ public class ResourceWriter extends Writer {
 
     @Override
     public void flush() throws IOException {
-        delegateWriter.flush();
+        if (delegateWriter != null) {
+            delegateWriter.flush();
+        }
     }
 
     @Override
     public void close() throws IOException {
-        delegateWriter.close();
+        if (delegateWriter != null) {
+            delegateWriter.close();
+        }
     }
 
     /**

--- a/core/src/main/java/org/smooks/visitors/smooks/NestedSmooksInterceptor.java
+++ b/core/src/main/java/org/smooks/visitors/smooks/NestedSmooksInterceptor.java
@@ -40,57 +40,32 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.delivery.interceptor;
+package org.smooks.visitors.smooks;
 
 import org.smooks.container.ExecutionContext;
 import org.smooks.container.TypedKey;
+import org.smooks.delivery.fragment.NodeFragment;
+import org.smooks.delivery.interceptor.AbstractInterceptorVisitor;
 import org.smooks.delivery.sax.ng.AfterVisitor;
 import org.smooks.delivery.sax.ng.BeforeVisitor;
 import org.smooks.delivery.sax.ng.ChildrenVisitor;
 import org.smooks.delivery.sax.ng.ElementVisitor;
-import org.w3c.dom.CharacterData;
-import org.w3c.dom.Element;
+import org.smooks.xml.DomUtils;
+import org.w3c.dom.*;
 
-public class VisitPhaseInterceptor extends AbstractInterceptorVisitor implements ElementVisitor {
-    public static final TypedKey<VisitPhase> VISIT_PHASE_TYPED_KEY = new TypedKey<>();
+public class NestedSmooksInterceptor extends AbstractInterceptorVisitor implements ElementVisitor {
+    public static final TypedKey<NestedSmooksInterceptorCommand> COMMAND_TYPED_KEY = new TypedKey<>();
     
-    public interface VisitPhase {
-        
-    }
-    
-    public static final class VisitBeforePhase implements VisitPhase {
-        
-    }
-
-    public static final class VisitAfterPhase implements VisitPhase {
-
+    protected boolean doVisit(final Class<? extends NestedSmooksInterceptorCommand.VisitPhase> currentVisitPhase, final Node visitedNode, final NestedSmooksInterceptorCommand nestedSmooksInterceptorCommand) {
+        return (nestedSmooksInterceptorCommand.getRequiredVisitPhase() == null || currentVisitPhase.isInstance(nestedSmooksInterceptorCommand.getRequiredVisitPhase())) && DomUtils.getDepth(visitedNode) == nestedSmooksInterceptorCommand.getRequiredNodeDepth();
     }
     
-    public static final class VisitChildTextPhase implements VisitPhase {
-
-    }
-
-    @Override
-    public void visitAfter(final Element element, final ExecutionContext executionContext) {
-        if (executionContext.get(VISIT_PHASE_TYPED_KEY) == null || executionContext.get(VISIT_PHASE_TYPED_KEY) instanceof VisitAfterPhase) {
-            intercept(new Invocation<AfterVisitor>() {
-                @Override
-                public Object invoke(final AfterVisitor visitor) {
-                    visitor.visitAfter(element, executionContext);
-                    return null;
-                }
-
-                @Override
-                public Class<AfterVisitor> getTarget() {
-                    return AfterVisitor.class;
-                }
-            });
-        }
-    }
-
     @Override
     public void visitBefore(final Element element, final ExecutionContext executionContext) {
-        if (executionContext.get(VISIT_PHASE_TYPED_KEY) == null || executionContext.get(VISIT_PHASE_TYPED_KEY) instanceof VisitBeforePhase) {
+        final NestedSmooksInterceptorCommand nestedSmooksInterceptorCommand = executionContext.getOrDefault(COMMAND_TYPED_KEY, new NestedSmooksInterceptorCommand(1, new NestedSmooksInterceptorCommand.VisitBeforePhase(), new NodeFragment(element)));
+        
+        if (doVisit(NestedSmooksInterceptorCommand.VisitBeforePhase.class, element, nestedSmooksInterceptorCommand)) {
+            copyFragmentIds(nestedSmooksInterceptorCommand.getNodeFragment(), element);
             intercept(new Invocation<BeforeVisitor>() {
                 @Override
                 public Object invoke(final BeforeVisitor visitor) {
@@ -108,7 +83,9 @@ public class VisitPhaseInterceptor extends AbstractInterceptorVisitor implements
 
     @Override
     public void visitChildText(final CharacterData characterData, final ExecutionContext executionContext) {
-        if (executionContext.get(VISIT_PHASE_TYPED_KEY) == null || executionContext.get(VISIT_PHASE_TYPED_KEY) instanceof VisitChildTextPhase) {
+        final NestedSmooksInterceptorCommand nestedSmooksInterceptorCommand = executionContext.getOrDefault(COMMAND_TYPED_KEY, new NestedSmooksInterceptorCommand(2, new NestedSmooksInterceptorCommand.VisitChildTextPhase(), new NodeFragment(characterData)));
+        if (doVisit(NestedSmooksInterceptorCommand.VisitChildTextPhase.class, characterData, nestedSmooksInterceptorCommand)) {
+            copyFragmentIds(nestedSmooksInterceptorCommand.getNodeFragment(), characterData);
             intercept(new Invocation<ChildrenVisitor>() {
                 @Override
                 public Object invoke(final ChildrenVisitor visitor) {
@@ -138,5 +115,35 @@ public class VisitPhaseInterceptor extends AbstractInterceptorVisitor implements
                 return ChildrenVisitor.class;
             }
         });
+    }
+
+    @Override
+    public void visitAfter(final Element element, final ExecutionContext executionContext) {
+        final NestedSmooksInterceptorCommand nestedSmooksInterceptorCommand = executionContext.getOrDefault(COMMAND_TYPED_KEY, new NestedSmooksInterceptorCommand(1, new NestedSmooksInterceptorCommand.VisitAfterPhase(), new NodeFragment(element)));
+        if (doVisit(NestedSmooksInterceptorCommand.VisitAfterPhase.class, element, nestedSmooksInterceptorCommand)) {
+            copyFragmentIds(nestedSmooksInterceptorCommand.getNodeFragment(), element);
+            intercept(new Invocation<AfterVisitor>() {
+                @Override
+                public Object invoke(final AfterVisitor visitor) {
+                    visitor.visitAfter(element, executionContext);
+                    return null;
+                }
+
+                @Override
+                public Class<AfterVisitor> getTarget() {
+                    return AfterVisitor.class;
+                }
+            });
+        }
+    }
+
+    protected void copyFragmentIds(final NodeFragment sourceNodeFragment, final Node destinationNode) {
+        Node parentSourceNode = (Node) sourceNodeFragment.unwrap();
+        Node parentDestinationNode = destinationNode;
+        while (parentDestinationNode != null && !parentDestinationNode.equals(destinationNode.getOwnerDocument())) {
+            parentDestinationNode.setUserData(NodeFragment.ID_USER_DATA_KEY, new NodeFragment(parentSourceNode).getId(), null);
+            parentSourceNode = parentSourceNode.getParentNode();
+            parentDestinationNode = parentDestinationNode.getParentNode();
+        }
     }
 }

--- a/core/src/main/java/org/smooks/visitors/smooks/NestedSmooksInterceptorCommand.java
+++ b/core/src/main/java/org/smooks/visitors/smooks/NestedSmooksInterceptorCommand.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * Smooks Core
  * %%
- * Copyright (C) 2020 Smooks
+ * Copyright (C) 2020 - 2021 Smooks
  * %%
  * Licensed under the terms of the Apache License Version 2.0, or
  * the GNU Lesser General Public License version 3.0 or later.
@@ -40,31 +40,46 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.io;
+package org.smooks.visitors.smooks;
 
-import org.smooks.delivery.Visitor;
-import org.smooks.delivery.memento.AbstractVisitorMemento;
-import org.smooks.delivery.memento.VisitorMemento;
+import org.smooks.delivery.fragment.NodeFragment;
 
-public class FragmentWriterMemento extends AbstractVisitorMemento {
-    private FragmentWriter fragmentWriter;
+class NestedSmooksInterceptorCommand {
 
-    public FragmentWriterMemento(Visitor visitor, FragmentWriter fragmentWriter) {
-        super(fragmentWriter.getFragment(), visitor);
-        this.fragmentWriter = fragmentWriter;
+    private final int requiredNodeDepth;
+    private final VisitPhase requiredVisitPhase;
+    private final NodeFragment nodeFragment;
+
+    public interface VisitPhase {
     }
 
-    @Override
-    public VisitorMemento copy() {
-        return new FragmentWriterMemento(visitor, fragmentWriter);
+    public static final class VisitBeforePhase implements VisitPhase {
+        
     }
 
-    @Override
-    public void restore(VisitorMemento visitorMemento) {
-        this.fragmentWriter = ((FragmentWriterMemento) visitorMemento).getFragmentWriter();
+    public static final class VisitAfterPhase implements VisitPhase {
+        
     }
 
-    public FragmentWriter getFragmentWriter() {
-        return fragmentWriter;
+    public static final class VisitChildTextPhase implements VisitPhase {
+        
+    }
+
+    public NestedSmooksInterceptorCommand(int requiredNodeDepth, VisitPhase requiredVisitPhase, NodeFragment nodeFragment) {
+        this.requiredNodeDepth = requiredNodeDepth;
+        this.requiredVisitPhase = requiredVisitPhase;
+        this.nodeFragment = nodeFragment;
+    }
+
+    public int getRequiredNodeDepth() {
+        return requiredNodeDepth;
+    }
+
+    public VisitPhase getRequiredVisitPhase() {
+        return requiredVisitPhase;
+    }
+
+    public NodeFragment getNodeFragment() {
+        return nodeFragment;
     }
 }

--- a/core/src/test/java/org/smooks/delivery/sax/ng/VisitorWriter01.java
+++ b/core/src/test/java/org/smooks/delivery/sax/ng/VisitorWriter01.java
@@ -45,8 +45,8 @@ package org.smooks.delivery.sax.ng;
 import org.smooks.SmooksException;
 import org.smooks.container.ExecutionContext;
 import org.smooks.delivery.fragment.NodeFragment;
+import org.smooks.delivery.memento.Memento;
 import org.smooks.io.FragmentWriter;
-import org.smooks.io.FragmentWriterMemento;
 import org.w3c.dom.CharacterData;
 import org.w3c.dom.Element;
 
@@ -56,9 +56,10 @@ public class VisitorWriter01 implements ElementVisitor {
     
     @Override
     public void visitAfter(Element element, ExecutionContext executionContext) {
-        executionContext.getMementoCaretaker().stash(new FragmentWriterMemento(this, new FragmentWriter(executionContext, new NodeFragment(element))), fragmentWriterVisitorMemento -> {
+        final NodeFragment nodeFragment = new NodeFragment(element);
+        executionContext.getMementoCaretaker().stash(new Memento<>(nodeFragment, this, new FragmentWriter(executionContext, nodeFragment)), fragmentWriterVisitorMemento -> {
             try {
-                fragmentWriterVisitorMemento.getFragmentWriter().write("");
+                fragmentWriterVisitorMemento.getState().write("");
             } catch (IOException e) {
                 throw new SmooksException(e.getMessage(), e);
             }
@@ -69,9 +70,10 @@ public class VisitorWriter01 implements ElementVisitor {
 
     @Override
     public void visitBefore(Element element, ExecutionContext executionContext) {
-        executionContext.getMementoCaretaker().stash(new FragmentWriterMemento(this, new FragmentWriter(executionContext, new NodeFragment(element))), fragmentWriterVisitorMemento -> {
+        final NodeFragment nodeFragment = new NodeFragment(element);
+        executionContext.getMementoCaretaker().stash(new Memento<>(nodeFragment, this, new FragmentWriter(executionContext, nodeFragment)), fragmentWriterVisitorMemento -> {
             try {
-                fragmentWriterVisitorMemento.getFragmentWriter().write("");
+                fragmentWriterVisitorMemento.getState().write("");
             } catch (IOException e) {
                 throw new SmooksException(e.getMessage(), e);
             }           


### PR DESCRIPTION
…mentos in nested smooks visitors

add ExecutionContext#getOrDefault convenience method

rename VisitorMemento#save to VisitorMemento#capture

create general-purpose Memento class

remove FragmentWriterMemento in favour of using the new Memento class

solve NullPointerExceptions in ResourceWriter

rename VisitPhaseInterceptor to NestedSmooksInterceptor

rename VisitorMemento#getId to VisitorMemento#getAnchor

rename FragmentWriter#capture and FragmentWriter#unpark to FragmentWriter#park and FragmentWriter#unpark, respectively