### PR TITLE
perf: reduce CPU and memory hot spots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           mvn install -B -Dmaven.javadoc.skip=true -DskipTests
           cd benchmark
-          java -XX:+FlightRecorder -XX:StartFlightRecording=filename=recording.jfr -jar target/benchmark-app-jar-with-dependencies.jar
+          java -XX:+FlightRecorder -XX:StartFlightRecording=filename=recording.jfr -XX:+AlwaysPreTouch -XX:ParallelGCThreads=1 -jar target/benchmark-app-jar-with-dependencies.jar
           tar -czvf recording.tar.gz recording.jfr
       - name: Archive
         uses: actions/upload-artifact@v2

--- a/api/src/main/java/org/smooks/api/TypedKey.java
+++ b/api/src/main/java/org/smooks/api/TypedKey.java
@@ -47,6 +47,7 @@ import java.util.UUID;
 
 public final class TypedKey<T> {
     private final String name;
+    private int hash;
 
     public TypedKey() {
         this(UUID.randomUUID().toString());
@@ -75,7 +76,10 @@ public final class TypedKey<T> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name);
+        if (hash == 0) {
+            hash = Objects.hash(name);
+        }
+        return hash;
     }
 
     @Override

--- a/api/src/main/java/org/smooks/api/delivery/ContentDeliveryConfig.java
+++ b/api/src/main/java/org/smooks/api/delivery/ContentDeliveryConfig.java
@@ -51,7 +51,7 @@ import org.smooks.api.delivery.ordering.Consumer;
 import org.smooks.api.delivery.ordering.Producer;
 import org.smooks.api.Registry;
 
-import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.List;
 import java.util.Map;
 
@@ -63,7 +63,7 @@ import java.util.Map;
  * and other information for the targeted profile.
  * @author tfennelly
  */
-@NotThreadSafe
+@ThreadSafe
 public interface ContentDeliveryConfig {
 
     /**
@@ -113,7 +113,7 @@ public interface ContentDeliveryConfig {
 	 * @see Registry#lookup(Object)
 	 * @see #getResourceConfigs(String)
 	 */
-	List getObjects(String selector);
+	List<?> getObjects(String selector);
 
     /**
      * Get a new stream filter for the content delivery configuration.

--- a/api/src/main/java/org/smooks/api/delivery/ContentDeliveryConfigBuilder.java
+++ b/api/src/main/java/org/smooks/api/delivery/ContentDeliveryConfigBuilder.java
@@ -44,8 +44,10 @@ package org.smooks.api.delivery;
 
 import org.smooks.api.resource.visitor.Visitor;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.List;
 
+@ThreadSafe
 public interface ContentDeliveryConfigBuilder {
 
     ContentDeliveryConfig build(List<ContentHandlerBinding<Visitor>> extendedContentHandlerBindings);

--- a/api/src/main/java/org/smooks/api/delivery/Filter.java
+++ b/api/src/main/java/org/smooks/api/delivery/Filter.java
@@ -46,8 +46,9 @@ import org.smooks.api.SmooksException;
 
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
+import java.io.Closeable;
 
-public interface Filter {
+public interface Filter extends Closeable {
     /**
      * Stream filter type config parameter.
      */
@@ -83,9 +84,4 @@ public interface Filter {
      * @throws SmooksException Failed to filter.
      */
     void doFilter() throws SmooksException;
-
-    /**
-     * Cleanup the Filter.
-     */
-    void cleanup();
 }

--- a/api/src/main/java/org/smooks/api/delivery/ReaderPool.java
+++ b/api/src/main/java/org/smooks/api/delivery/ReaderPool.java
@@ -46,7 +46,18 @@ import org.xml.sax.XMLReader;
 
 public interface ReaderPool {
 
+    /**
+     * Get an {@link XMLReader} instance from the 
+     * reader pool associated with this ContentDelivery config instance.
+     * @return An XMLReader instance if the pool is not empty, otherwise null.
+     */
     XMLReader borrowXMLReader();
 
-    void returnXMLReader(XMLReader reader);
+    /**
+     * Return an {@link XMLReader} instance to the
+     * reader pool associated with this ContentDelivery config instance.
+     * @param xmlReader The XMLReader instance to be returned.  If the pool is full, the instance
+     * is left to the GC (i.e. lost).
+     */
+    void returnXMLReader(XMLReader xmlReader);
 }

--- a/api/src/main/java/org/smooks/api/lifecycle/VisitLifecycleCleanable.java
+++ b/api/src/main/java/org/smooks/api/lifecycle/VisitLifecycleCleanable.java
@@ -61,5 +61,5 @@ public interface VisitLifecycleCleanable extends Visitor {
      * @param fragment The fragment.
      * @param executionContext The ExecutionContext.
      */
-    void executeVisitLifecycleCleanup(Fragment fragment, ExecutionContext executionContext);
+    void executeVisitLifecycleCleanup(Fragment<?> fragment, ExecutionContext executionContext);
 }

--- a/api/src/main/java/org/smooks/api/resource/visitor/interceptor/InterceptorVisitor.java
+++ b/api/src/main/java/org/smooks/api/resource/visitor/interceptor/InterceptorVisitor.java
@@ -42,7 +42,6 @@
  */
 package org.smooks.api.resource.visitor.interceptor;
 
-import org.smooks.api.ApplicationContext;
 import org.smooks.api.delivery.ContentHandlerBinding;
 import org.smooks.api.resource.visitor.Visitor;
 
@@ -53,6 +52,4 @@ public interface InterceptorVisitor extends Visitor {
     ContentHandlerBinding<Visitor> getVisitorBinding();
 
     ContentHandlerBinding<Visitor> getTarget();
-
-    void setApplicationContext(ApplicationContext applicationContext);
 }

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -22,7 +22,7 @@
                     <finalName>benchmark-app</finalName>
                     <archive>
                         <manifest>
-                            <mainClass>org.smooks.BenchmarkApp</mainClass>
+                            <mainClass>org.smooks.benchmark.BenchmarkApp</mainClass>
                         </manifest>
                     </archive>
                     <descriptorRefs>
@@ -37,6 +37,15 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>main/java/com/fasterxml/**/*</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/benchmark/src/main/java/com/fasterxml/aalto/in/BenchmarkCharSourceBootstrapper.java
+++ b/benchmark/src/main/java/com/fasterxml/aalto/in/BenchmarkCharSourceBootstrapper.java
@@ -1,0 +1,382 @@
+/* Aalto XML processor
+ *
+ * Copyright (c) 2006- Tatu Saloranta, tatu.saloranta@iki.fi
+ *
+ * Licensed under the License specified in the file LICENSE which is
+ * included with the source code.
+ * You may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fasterxml.aalto.in;
+
+import com.fasterxml.aalto.impl.ErrorConsts;
+import com.fasterxml.aalto.impl.IoStreamException;
+import com.fasterxml.aalto.impl.LocationImpl;
+import com.fasterxml.aalto.util.CharsetNames;
+
+import javax.xml.stream.Location;
+import javax.xml.stream.XMLReporter;
+import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
+import java.io.Reader;
+import java.text.MessageFormat;
+
+/**
+ * Class that takes care of bootstrapping main document input from
+ * a Stream input source.
+ */
+public final class BenchmarkCharSourceBootstrapper
+    extends InputBootstrapper
+{
+    /**
+     * Whether to use a bigger (4000, ie. 8k) or smaller (2000 -> 4k)
+     * buffer size?
+     */
+    final static int DEFAULT_BUFFER_SIZE = 4000;
+
+    final static char CHAR_BOM_MARKER = (char) 0xFEFF;
+
+    /*
+    /**********************************************************************
+    /* Configuration
+    /**********************************************************************
+     */
+
+    /**
+     * Underlying Reader to use for reading content.
+     */
+    final Reader _in;
+
+    /*
+    /**********************************************************************
+    /* Input buffering
+    /**********************************************************************
+     */
+
+    final char[] _inputBuffer;
+
+    private int _inputPtr;
+
+    /**
+     * Offset of the first character after the end of valid buffer
+     * contents.
+     */
+    private int _inputLast;
+
+    /*
+    ///////////////////////////////////////////////////////////////
+    // Life-cycle
+    ///////////////////////////////////////////////////////////////
+     */
+
+    private BenchmarkCharSourceBootstrapper(ReaderConfig cfg, Reader r)
+    {
+        super(cfg);
+        _in = r;
+        _inputBuffer = cfg.allocFullCBuffer(ReaderConfig.DEFAULT_CHAR_BUFFER_LEN);
+        _inputLast = _inputPtr = 0;
+    }
+
+    private BenchmarkCharSourceBootstrapper(ReaderConfig cfg, char[] buffer, int start, int len)
+    {
+        super(cfg);
+        _in = null;
+        _inputBuffer = buffer;
+        _inputPtr = start;
+        _inputLast = start+len;            
+    }
+
+    public static BenchmarkCharSourceBootstrapper construct(ReaderConfig cfg, Reader r)
+        throws XMLStreamException
+    {
+        return new BenchmarkCharSourceBootstrapper(cfg, r);
+    }
+
+    public static BenchmarkCharSourceBootstrapper construct(ReaderConfig cfg, char[] buffer, int start, int len)
+        throws XMLStreamException
+    {
+        return new BenchmarkCharSourceBootstrapper(cfg, buffer, start, len);
+    }
+
+    @Override
+    public final XmlScanner bootstrap() throws XMLStreamException
+    {
+        try {
+            return doBootstrap();
+        } catch (IOException ioe) {
+            throw new IoStreamException(ioe);
+        } finally {
+            _config.freeSmallCBuffer(mKeyword);
+        }
+    }
+    
+    public XmlScanner doBootstrap() throws IOException, XMLStreamException
+    {
+        if (_inputPtr >= _inputLast) {
+            initialLoad(7);
+        }
+
+        String normEnc = null;
+
+        /* Only need 6 for signature ("<?xml\s"), but there may be a leading
+         * BOM in there... and a valid xml declaration has to be longer
+         * than 7 chars anyway (although, granted, shortest valid xml docl
+         * is just 4 chars... "<a/>")
+         */
+        if ((_inputLast - _inputPtr) >= 7) {
+            char c = _inputBuffer[_inputPtr];
+            
+            // BOM to skip?
+            if (c == CHAR_BOM_MARKER) {
+                c = _inputBuffer[++_inputPtr];
+            }
+            if (c == '<') {
+                if (_inputBuffer[_inputPtr+1] == '?'
+                    && _inputBuffer[_inputPtr+2] == 'x'
+                    && _inputBuffer[_inputPtr+3] == 'm'
+                    && _inputBuffer[_inputPtr+4] == 'l'
+                    && _inputBuffer[_inputPtr+5] <= 0x0020) {
+                    // Yup, got the declaration ok!
+                    _inputPtr += 6; // skip declaration
+                    readXmlDeclaration();
+                    
+                    if (mFoundEncoding != null) {
+                        normEnc = verifyXmlEncoding(mFoundEncoding);
+                    }
+                }
+            } else {
+                /* We may also get something that would be invalid xml
+                 * ("garbage" char; neither '<' nor space). If so, and
+                 * it's one of "well-known" cases, we can not only throw
+                 * an exception but also indicate a clue as to what is likely
+                 * to be wrong.
+                 */
+                /* Specifically, UTF-8 read via, say, ISO-8859-1 reader, can
+                 * "leak" marker (0xEF, 0xBB, 0xBF). While we could just eat
+                 * it, there's bound to be other problems cropping up, so let's
+                 * inform about the problem right away.
+                 */
+                if (c == 0xEF) {
+                    throw new IoStreamException("Unexpected first character (char code 0xEF), not valid in xml document: could be mangled UTF-8 BOM marker. Make sure that the Reader uses correct encoding or pass an InputStream instead");
+                }
+            }
+        }
+        _config.setActualEncoding(normEnc);
+        _config.setXmlDeclInfo(mDeclaredXmlVersion, mFoundEncoding, mStandalone);
+        return new BenchmarkReaderScanner(_config, _in, _inputBuffer, _inputPtr, _inputLast);
+    }
+
+    /*
+    ////////////////////////////////////////////////////
+    // Internal methods, main xml decl processing
+    ////////////////////////////////////////////////////
+     */
+
+    /**
+     * @return Normalized encoding name
+     */
+    protected String verifyXmlEncoding(String enc)
+        throws XMLStreamException
+    {
+        enc = CharsetNames.normalize(enc);
+
+        // Probably no point in comparing at all... is there?
+        // But we can report a possible problem?
+        String extEnc = _config.getExternalEncoding();
+        if (extEnc != null && enc != null
+            && !extEnc.equalsIgnoreCase(enc)) {
+            XMLReporter rep = _config.getXMLReporter();
+            if (rep != null) {
+                Location loc = getLocation();
+                rep.report(MessageFormat.format(ErrorConsts.W_MIXED_ENCODINGS,
+                                                new Object[] { extEnc, enc }),
+                           ErrorConsts.WT_XML_DECL,
+                           this, loc);
+            }
+        }
+
+        return enc;
+    }
+
+    /*
+    /////////////////////////////////////////////////////
+    // Internal methods, loading input data
+    /////////////////////////////////////////////////////
+    */
+
+    protected boolean initialLoad(int minimum)
+        throws IOException
+    {
+        _inputPtr = 0;
+        _inputLast = 0;
+
+        if (_in == null) { // for block sources
+            return false;
+        }
+
+        while (_inputLast < minimum) {
+            int count = _in.read(_inputBuffer, _inputLast,
+                                 _inputBuffer.length - _inputLast);
+            if (count < 1) {
+                return false;
+            }
+            _inputLast += count;
+        }
+        return true;
+    }
+
+    protected void loadMore()
+        throws IOException, XMLStreamException
+    {
+        /* Need to make sure offsets are properly updated for error
+         * reporting purposes, and do this now while previous amounts
+         * are still known.
+         */
+        _inputProcessed += _inputLast;
+        _inputRowStart -= _inputLast;
+
+        if (_in == null) { // for block sources
+            reportEof();
+        }
+
+        _inputPtr = 0;
+        _inputLast = _in.read(_inputBuffer, 0, _inputBuffer.length);
+        if (_inputLast < 1) {
+            reportEof();
+        }
+    }
+
+    /*
+    /////////////////////////////////////////////////////
+    // Implementations of abstract parsing methods
+    /////////////////////////////////////////////////////
+    */
+
+    @Override
+    protected void pushback() {
+        --_inputPtr;
+    }
+
+    @Override
+    protected int getNext() throws IOException, XMLStreamException
+    {
+        return (_inputPtr < _inputLast) ?
+            _inputBuffer[_inputPtr++] : nextChar();
+    }
+
+    @Override
+    protected int getNextAfterWs(boolean reqWs)
+        throws IOException, XMLStreamException
+    {
+        int count = 0;
+
+        while (true) {
+            char c = (_inputPtr < _inputLast) ?
+                _inputBuffer[_inputPtr++] : nextChar();
+
+            if (c > CHAR_SPACE) {
+                if (reqWs && count == 0) {
+                    reportUnexpectedChar(c, ERR_XMLDECL_EXP_SPACE);
+                }
+                return c;
+            }
+            if (c == CHAR_CR || c == CHAR_LF) {
+                skipCRLF(c);
+            } else if (c == CHAR_NULL) {
+                reportNull();
+            }
+            ++count;
+        }
+    }
+
+    /**
+     * @return First character that does not match expected, if any;
+     *    CHAR_NULL if match succeeded
+     */
+    @Override
+    protected int checkKeyword(String exp)
+        throws IOException, XMLStreamException
+    {
+        int len = exp.length();
+        
+        for (int ptr = 1; ptr < len; ++ptr) {
+            char c = (_inputPtr < _inputLast) ?
+                _inputBuffer[_inputPtr++] : nextChar();
+            
+            if (c != exp.charAt(ptr)) {
+                return c;
+            }
+            if (c == CHAR_NULL) {
+                reportNull();
+            }
+        }
+
+        return CHAR_NULL;
+    }
+
+    @Override
+    protected int readQuotedValue(char[] kw, int quoteChar)
+        throws IOException, XMLStreamException
+    {
+        int i = 0;
+        int len = kw.length;
+
+        while (true) {
+            char c = (_inputPtr < _inputLast) ?
+                _inputBuffer[_inputPtr++] : nextChar();
+            if (c == CHAR_CR || c == CHAR_LF) {
+                skipCRLF(c);
+            } else if (c == CHAR_NULL) {
+                reportNull();
+            }
+            if (c == quoteChar) {
+                return (i < len) ? i : -1;
+            }
+	    // Let's just truncate longer values, but match quote
+	    if (i < len) {
+		kw[i++] = c;
+	    }
+        }
+    }
+
+    @Override
+    protected Location getLocation()
+    {
+        return LocationImpl.fromZeroBased
+            (_config.getPublicId(), _config.getSystemId(),
+             _inputProcessed + _inputPtr, _inputRow, _inputPtr - _inputRowStart);
+    }
+
+    /*
+    /**********************************************************************
+    /* Internal methods, single-byte access methods
+    /**********************************************************************
+     */
+
+    protected char nextChar() throws IOException, XMLStreamException
+    {
+        if (_inputPtr >= _inputLast) {
+            loadMore();
+        }
+        return _inputBuffer[_inputPtr++];
+    }
+
+    protected void skipCRLF(char lf) throws IOException, XMLStreamException
+    {
+        if (lf == '\r') {
+            char c = (_inputPtr < _inputLast) ?
+                _inputBuffer[_inputPtr++] : nextChar();
+            if (c != '\n') {
+                --_inputPtr; // pushback if not 2-char/byte lf
+            }
+        }
+        ++_inputRow;
+        _inputRowStart = _inputPtr;
+    }
+}

--- a/benchmark/src/main/java/com/fasterxml/aalto/in/BenchmarkReaderScanner.java
+++ b/benchmark/src/main/java/com/fasterxml/aalto/in/BenchmarkReaderScanner.java
@@ -1,0 +1,3423 @@
+package com.fasterxml.aalto.in;
+
+import java.io.*;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.codehaus.stax2.XMLStreamLocation2;
+
+import com.fasterxml.aalto.impl.ErrorConsts;
+import com.fasterxml.aalto.impl.IoStreamException;
+import com.fasterxml.aalto.impl.LocationImpl;
+import com.fasterxml.aalto.util.DataUtil;
+import com.fasterxml.aalto.util.TextBuilder;
+import com.fasterxml.aalto.util.XmlCharTypes;
+import com.fasterxml.aalto.util.XmlChars;
+import com.fasterxml.aalto.util.XmlConsts;
+
+/**
+ * This is the concrete scanner implementation used when input comes
+ * as a {@link java.io.Reader}. In general using this scanner is quite
+ * a bit less optimal than that of {@link java.io.InputStream} based
+ * scanner. Nonetheless, it is included for completeness, since Stax
+ * interface allows passing Readers as input sources.
+ */
+public final class BenchmarkReaderScanner extends XmlScanner
+{
+    /**
+     * Although java chars are basically UTF-16 in memory, the closest
+     * match for char types is Latin1.
+     */
+    private final static XmlCharTypes sCharTypes = InputCharTypes.getLatin1CharTypes();
+
+    /*
+    /**********************************************************************
+    /* Configuration
+    /**********************************************************************
+     */
+
+    /**
+     * Underlying InputStream to use for reading content.
+     */
+    protected Reader _in;
+
+    /*
+    /**********************************************************************
+    /* Input buffering
+    /**********************************************************************
+     */
+
+    protected char[] _inputBuffer;
+
+    protected int _inputPtr;
+
+    protected int _inputEnd;
+
+    /**
+     * Storage location for a single character that can not be pushed
+     * back (for example, multi-byte char)
+     */
+    protected int mTmpChar = INT_NULL;
+
+    /*
+    /**********************************************************************
+    /* Symbol handling
+    /**********************************************************************
+    */
+
+    /**
+     * For now, symbol table contains prefixed names. In future it is
+     * possible that they may be split into prefixes and local names?
+     */
+    protected final CharBasedPNameTable _symbols;
+
+    /*
+    /**********************************************************************
+    /* Life-cycle
+    /**********************************************************************
+     */
+
+    public BenchmarkReaderScanner(ReaderConfig cfg, Reader r,
+                                  char[] buffer, int ptr, int last)
+    {
+        super(cfg);
+        _in = r;
+        _inputBuffer = buffer;
+        _inputPtr = ptr;
+        _inputEnd = last;
+        _pastBytesOrChars = 0; // should it be passed by caller?
+        _rowStartOffset = 0; // should probably be passed by caller...
+
+        _symbols = cfg.getCBSymbols();
+    }
+
+    public BenchmarkReaderScanner(ReaderConfig cfg, Reader r)
+    {
+        super(cfg);
+        _in = r;
+        _inputBuffer = cfg.allocFullCBuffer(ReaderConfig.DEFAULT_CHAR_BUFFER_LEN);
+        _inputPtr = _inputEnd = 0;
+        _pastBytesOrChars = 0; // should it be passed by caller?
+        _rowStartOffset = 0; // should probably be passed by caller...
+
+        _symbols = cfg.getCBSymbols();
+    }
+
+    @Override
+    protected void _releaseBuffers()
+    {
+        super._releaseBuffers();
+        if (_symbols.maybeDirty()) {
+            _config.updateCBSymbols(_symbols);
+        }
+        /* Note: if we have block input (_in == null), the buffer we
+         * use is not owned by scanner, can't recycle
+         * Also note that this method will always get called before
+         * _closeSource(); so that _in won't be cleared before we
+         * have a chance to see it.
+         */
+        if (_in != null) {
+            if (_inputBuffer != null) {
+                _config.freeFullCBuffer(_inputBuffer);
+                _inputBuffer = null;
+            }
+        }
+    }
+
+    @Override
+    protected void _closeSource() throws IOException
+    {
+        if (_in != null) {
+            _in.close();
+            _in = null;
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Public scanner interface (1st level parsing)
+    /**********************************************************************
+     */
+
+    @Override
+    protected final void finishToken() throws XMLStreamException
+    {
+        _tokenIncomplete = false;
+        switch (_currToken) {
+            case PROCESSING_INSTRUCTION:
+                finishPI();
+                break;
+            case CHARACTERS:
+                finishCharacters();
+                break;
+            case COMMENT:
+                finishComment();
+                break;
+            case SPACE:
+                finishSpace();
+                break;
+            case DTD:
+                finishDTD(true); // true -> get text
+                break;
+            case CDATA:
+                finishCData();
+                break;
+            default:
+                ErrorConsts.throwInternalError();
+        }
+    }
+
+    // // // First, main iteration methods
+
+    @Override
+    public final int nextFromProlog(boolean isProlog) throws XMLStreamException
+    {
+        if (_tokenIncomplete) { // left-overs from last thingy?
+            skipToken();
+        }
+
+        // First: keep track of where event started
+        setStartLocation();
+
+        // Ok: we should get a WS or '<'. So, let's skip through WS
+        while (true) {
+            // Any more data? Just need a single byte
+            if (_inputPtr >= _inputEnd) {
+                if (!loadMore()) {
+                    setStartLocation();
+                    return TOKEN_EOI;
+                }
+            }
+            int c = _inputBuffer[_inputPtr++] & 0xFF;
+
+            // Really should get white space or '<'...
+            if (c == '<') {
+                break;
+            }
+            if (c != ' ') {
+                if (c == '\n') {
+                    markLF();
+                } else if (c == '\r') {
+                    if (_inputPtr >= _inputEnd) {
+                        if (!loadMore()) {
+                            markLF();
+                            setStartLocation();
+                            return TOKEN_EOI;
+                        }
+                    }
+                    if (_inputBuffer[_inputPtr] == '\n') {
+                        ++_inputPtr;
+                    }
+                    markLF();
+                } else if (c != '\t') {
+                    reportPrologUnexpChar(isProlog, c, null);
+                }
+            }
+        }
+
+        // Ok, got LT:
+        if (_inputPtr >= _inputEnd) {
+            loadMoreGuaranteed(COMMENT);
+        }
+        char c = _inputBuffer[_inputPtr++];
+        if (c == '!') { // comment/DOCTYPE? (CDATA not legal)
+            return handlePrologDeclStart(isProlog);
+        }
+        if (c == '?') {
+            return handlePIStart();
+        }
+        /* End tag not allowed if no open tree; and only one root
+         * element (one root-level start tag)
+         */
+        if (c == '/' || !isProlog) {
+            reportPrologUnexpElement(isProlog, c);
+        }
+        return handleStartElement(c);
+    }
+
+    @Override
+    public final int nextFromTree() throws XMLStreamException
+    {
+        if (_tokenIncomplete) { // left-overs?
+            if (skipToken()) { // Figured out next event (ENTITY_REFERENCE)?
+                // !!! We don't yet parse DTD, don't know real contents
+                return _nextEntity();
+            }
+        } else { // note: START_ELEMENT/END_ELEMENT never incomplete
+            if (_currToken == START_ELEMENT) {
+                if (_isEmptyTag) {
+                    // Important: retain same start location as with START_ELEMENT, don't overwrite
+                    --_depth;
+                    return (_currToken = END_ELEMENT);
+                }
+            } else if (_currToken == END_ELEMENT) {
+                _currElem = _currElem.getParent();
+                // Any namespace declarations that need to be unbound?
+                while (_lastNsDecl != null && _lastNsDecl.getLevel() >= _depth) {
+                    _lastNsDecl = _lastNsDecl.unbind();
+                }
+            } else {
+                // It's possible CHARACTERS entity with an entity ref:
+                if (_entityPending) {
+                    _entityPending = false;
+                    return _nextEntity();
+                }
+            }
+        }
+        // and except for special cases, mark down actual start location of the event
+        setStartLocation();
+
+        /* Any more data? Although it'd be an error not to get any,
+         * let's leave error reporting up to caller
+         */
+        if (_inputPtr >= _inputEnd) {
+            if (!loadMore()) {
+                setStartLocation();
+                return TOKEN_EOI;
+            }
+        }
+        char c = _inputBuffer[_inputPtr];
+
+        /* Can get pretty much any type; start/end element, comment/PI,
+         * CDATA, text, entity reference...
+         */
+        if (c == '<') { // root element, comment, proc instr?
+            ++_inputPtr;
+            c = (_inputPtr < _inputEnd) ? _inputBuffer[_inputPtr++] : loadOne(COMMENT);
+            if (c == '!') { // comment or CDATA
+                return handleCommentOrCdataStart();
+            }
+            if (c == '?') {
+                return handlePIStart();
+            }
+            if (c == '/') {
+                return handleEndElement();
+            }
+            return handleStartElement(c);
+        }
+        if (c == '&') { // entity reference
+            ++_inputPtr;
+            /* Need to expand; should indicate either text, or an unexpanded
+             * entity reference
+             */
+            int i = handleEntityInText(false);
+            if (i == 0) { // general entity
+                return (_currToken = ENTITY_REFERENCE);
+            }
+            /* Nope, a char entity; need to indicate it came from an entity.
+             * Since we may want to store the char as is, too, let's negate
+             * entity-based char
+             */
+            mTmpChar = -i;
+        } else {
+            /* Let's store it for future reference. May or may not be used --
+             * so let's not advance input ptr quite yet.
+             */
+            mTmpChar = c;
+        }
+        // text, possibly/probably ok
+        if (_cfgLazyParsing) {
+            _tokenIncomplete = true;
+        } else {
+            finishCharacters();
+        }
+        return (_currToken = CHARACTERS);
+    }
+
+    /**
+     * Helper method used to isolate things that need to be (re)set in
+     * cases where 
+     */
+    protected int _nextEntity() {
+        // !!! Also, have to assume start location has been set or such
+        _textBuilder.resetWithEmpty();
+        // !!! TODO: handle start location?
+        return (_currToken = ENTITY_REFERENCE);
+    }
+    
+    /*
+    /**********************************************************************
+    /* 2nd level parsing
+    /**********************************************************************
+     */
+
+    protected final int handlePrologDeclStart(boolean isProlog) throws XMLStreamException
+    {
+        if (_inputPtr >= _inputEnd) {
+            loadMoreGuaranteed();
+        }
+        char c = _inputBuffer[_inputPtr++];
+        if (c == '-') { // Comment?
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            c = _inputBuffer[_inputPtr++];
+            if (c == '-') {
+                if (_cfgLazyParsing) {
+                    _tokenIncomplete = true;
+                } else {
+                    finishComment();
+                }
+                return (_currToken = COMMENT);
+            }
+        } else if (c == 'D') { // DOCTYPE?
+            if (isProlog) { // no DOCTYPE in epilog
+                handleDtdStart();
+                // incomplete flag is set by handleDtdStart
+                if (!_cfgLazyParsing) {
+                    if (_tokenIncomplete) {
+                        finishDTD(true); // must copy contents, may be needed
+                        _tokenIncomplete = false;
+                    }
+                }
+                return DTD;
+            }
+        }
+
+        /* error... for error recovery purposes, let's just pretend
+         * like it was unfinished CHARACTERS, though.
+         */
+        _tokenIncomplete = true;
+        _currToken = CHARACTERS;
+        reportPrologUnexpChar(isProlog, c, " (expected '-' for COMMENT)");
+        return _currToken; // never gets here
+    }
+
+    private final int handleDtdStart()
+            throws XMLStreamException
+    {
+        matchAsciiKeyword("DOCTYPE");
+        // And then some white space and root  name
+        char c = skipInternalWs(true, "after DOCTYPE keyword, before root name");
+        _tokenName = parsePName(c);
+        c = skipInternalWs(false, null);
+
+        //boolean gotId;
+
+        if (c == 'P') { // PUBLIC
+            matchAsciiKeyword("PUBLIC");
+            c = skipInternalWs(true, null);
+            _publicId = parsePublicId(c);
+            c = skipInternalWs(true, null);
+            _systemId = parseSystemId(c);
+            c = skipInternalWs(false, null);
+        } else if (c == 'S') { // SYSTEM
+            matchAsciiKeyword("SYSTEM");
+            c = skipInternalWs(true, null);
+            _publicId = null;
+            _systemId = parseSystemId(c);
+            c = skipInternalWs(false, null);
+        } else {
+            _publicId = _systemId = null;
+        }
+
+        /* Ok; so, need to get either an internal subset, or the
+         * end:
+         */
+        if (c == '>') { // fine, we are done
+            _tokenIncomplete = false;
+            return (_currToken = DTD);
+        }
+
+        if (c != '[') { // If not end, must have int. subset
+            String msg = (_systemId != null) ?
+                    " (expected '[' for the internal subset, or '>' to end DOCTYPE declaration)" :
+                    " (expected a 'PUBLIC' or 'SYSTEM' keyword, '[' for the internal subset, or '>' to end DOCTYPE declaration)";
+            reportTreeUnexpChar(c, msg);
+        }
+
+        /* Need not parse the int. subset yet, can leave as is, and then
+         * either skip or parse later on
+         */
+        _tokenIncomplete = true;
+        return (_currToken = DTD);
+    }
+
+    protected final int handleCommentOrCdataStart()
+            throws XMLStreamException
+    {
+        if (_inputPtr >= _inputEnd) {
+            loadMoreGuaranteed();
+        }
+        char c = _inputBuffer[_inputPtr++];
+
+        // Let's first see if it's a comment (simpler)
+        if (c == '-') { // Comment
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            c = _inputBuffer[_inputPtr++];
+            if (c != '-') {
+                reportTreeUnexpChar(c, " (expected '-' for COMMENT)");
+            }
+            if (_cfgLazyParsing) {
+                _tokenIncomplete = true;
+            } else {
+                finishComment();
+            }
+            return (_currToken = COMMENT);
+        }
+
+        // If not, should be CDATA:
+        if (c == '[') { // CDATA
+            _currToken = CDATA;
+            for (int i = 0; i < 6; ++i) {
+                if (_inputPtr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                }
+                c = _inputBuffer[_inputPtr++];
+                if (c != CDATA_STR.charAt(i)) {
+                    reportTreeUnexpChar(c, " (expected '"+CDATA_STR.charAt(i)+"' for CDATA section)");
+                }
+            }
+            if (_cfgLazyParsing) {
+                _tokenIncomplete = true;
+            } else {
+                finishCData();
+            }
+            return CDATA;
+        }
+        reportTreeUnexpChar(c, " (expected either '-' for COMMENT or '[CDATA[' for CDATA section)");
+        return TOKEN_EOI; // never gets here
+    }
+
+    protected final int handlePIStart()
+            throws XMLStreamException
+    {
+        _currToken = PROCESSING_INSTRUCTION;
+
+        // Ok, first, need a name
+        if (_inputPtr >= _inputEnd) {
+            loadMoreGuaranteed();
+        }
+        // Ok, first, need a name
+        char c = _inputBuffer[_inputPtr++];
+        _tokenName = parsePName(c);
+        { // but is it "xml" (case insensitive)?
+            String ln = _tokenName.getLocalName();
+            if (ln.length() == 3 && ln.equalsIgnoreCase("xml") &&
+                    _tokenName.getPrefix() == null) {
+                reportInputProblem(ErrorConsts.ERR_WF_PI_XML_TARGET);
+            }
+        }
+
+        /* Let's then verify that we either get a space, or closing
+         * '?>': this way we'll catch some problems right away, and also
+         * simplify actual processing of contents.
+         */
+        if (_inputPtr >= _inputEnd) {
+            loadMoreGuaranteed();
+        }
+        c = _inputBuffer[_inputPtr++];
+        if (c <= INT_SPACE) {
+            // Ok, let's skip the white space...
+            while (true) {
+                if (c == '\n') {
+                    markLF();
+                } else if (c == '\r') {
+                    if (_inputPtr >= _inputEnd) {
+                        loadMoreGuaranteed();
+                    }
+                    if (_inputBuffer[_inputPtr] == '\n') {
+                        ++_inputPtr;
+                    }
+                    markLF();
+                } else if (c != ' ' && c != '\t') {
+                    throwInvalidSpace(c);
+                }
+                if (_inputPtr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                }
+                c = _inputBuffer[_inputPtr];
+                if (c > 0x0020) {
+                    break;
+                }
+                ++_inputPtr;
+            }
+            // Ok, got non-space, need to push back:
+            if (_cfgLazyParsing) {
+                _tokenIncomplete = true;
+            } else {
+                finishPI();
+            }
+        } else {
+            if (c != INT_QMARK) {
+                reportMissingPISpace(c);
+            }
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            c = _inputBuffer[_inputPtr++];
+            if (c != '>') {
+                reportMissingPISpace(c);
+            }
+            _textBuilder.resetWithEmpty();
+            _tokenIncomplete = false;
+        }
+
+        return PROCESSING_INSTRUCTION;
+    }
+
+    /**
+     * @return Code point for the entity that expands to a valid XML
+     *    content character.
+     */
+    protected final int handleCharEntity()
+            throws XMLStreamException
+    {
+        // Hex or decimal?
+        if (_inputPtr >= _inputEnd) {
+            loadMoreGuaranteed();
+        }
+        char c = _inputBuffer[_inputPtr++];
+        int value = 0;
+        if (c == 'x') { // hex
+            while (true) {
+                if (_inputPtr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                }
+                c = _inputBuffer[_inputPtr++];
+                if (c == ';') {
+                    break;
+                }
+                value = value << 4;
+                if (c <= '9' && c >= '0') {
+                    value += (c - '0');
+                } else if (c >= 'a' && c <= 'f') {
+                    value += 10 + (c - 'a');
+                } else if (c >= 'A' && c <= 'F') {
+                    value += 10 + (c - 'A');
+                } else {
+                    throwUnexpectedChar(c, "; expected a hex digit (0-9a-fA-F)");
+                }
+                if (value > MAX_UNICODE_CHAR) { // Overflow?
+                    reportEntityOverflow();
+                }
+            }
+        } else { // numeric (decimal)
+            while (c != ';') {
+                if (c <= '9' && c >= '0') {
+                    value = (value * 10) + (c - '0');
+                    if (value > MAX_UNICODE_CHAR) { // Overflow?
+                        reportEntityOverflow();
+                    }
+                } else {
+                    throwUnexpectedChar(c, "; expected a decimal number");
+                }
+                if (_inputPtr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                }
+                c = _inputBuffer[_inputPtr++];
+            }
+        }
+
+        // Ok, and then need to check result is a valid XML content char:
+        if (value >= 0xD800) { // note: checked for overflow earlier
+            if (value < 0xE000) { // no surrogates via entity expansion
+                reportInvalidXmlChar(value);
+            }
+            if (value == 0xFFFE || value == 0xFFFF) {
+                reportInvalidXmlChar(value);
+            }
+        } else if (value < 32) {
+            // XML 1.1 allows most other chars; 1.0 does not:
+            if (value != INT_LF && value != INT_CR && value != INT_TAB) {
+                if (!_xml11 || value == 0) {
+                    reportInvalidXmlChar(value);
+                }
+            }
+        }
+        return value;
+    }
+
+    protected final int handleStartElement(char c)
+            throws XMLStreamException
+    {
+        _currToken = START_ELEMENT;
+        _currNsCount = 0;
+        PName elemName = parsePName(c);
+
+        /* Ok. Need to create a qualified name. Simplest for element
+         * in default ns (no extra work -- expressed as null binding);
+         * otherwise need to find binding
+         */
+        String prefix = elemName.getPrefix();
+        boolean allBound; // flag to check 'late' bindings
+
+        if (prefix == null) { // element in default ns
+            allBound = true; // which need not be bound
+        } else {
+            elemName = bindName(elemName, prefix);
+            allBound = elemName.isBound();
+        }
+
+        _tokenName = elemName;
+        _currElem = new ElementScope(elemName, _currElem);
+
+        // And then attribute parsing loop:
+        int attrPtr = 0;
+
+        while (true) {
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            c = _inputBuffer[_inputPtr++];
+            // Intervening space to skip?
+            if (c <= INT_SPACE) {
+                do {
+                    if (c == INT_LF) {
+                        markLF();
+                    } else if (c == INT_CR) {
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (_inputBuffer[_inputPtr] == '\n') {
+                            ++_inputPtr;
+                        }
+                        markLF();
+                    } else if (c != ' ' && c != '\t') {
+                        throwInvalidSpace(c);
+                    }
+                    if (_inputPtr >= _inputEnd) {
+                        loadMoreGuaranteed();
+                    }
+                    c = _inputBuffer[_inputPtr++];
+                } while (c <= INT_SPACE);
+            } else if (c != INT_SLASH && c != INT_GT) {
+                throwUnexpectedChar(c, " expected space, or '>' or \"/>\"");
+            }
+
+            // Ok; either need to get an attribute name, or end marker:
+            if (c == INT_SLASH) {
+                if (_inputPtr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                }
+                c = _inputBuffer[_inputPtr++];
+                if (c != '>') {
+                    throwUnexpectedChar(c, " expected '>'");
+                }
+                _isEmptyTag = true;
+                break;
+            } else if (c == '>') {
+                _isEmptyTag = false;
+                break;
+            } else if (c == '<') {
+                reportInputProblem("Unexpected '<' character in element (missing closing '>'?)");
+            }
+
+            // Ok, an attr name:
+            PName attrName = parsePName(c);
+            prefix = attrName.getPrefix();
+
+            boolean isNsDecl;
+
+            if (prefix == null) { // can be default ns decl:
+                isNsDecl = (attrName.getLocalName() == "xmlns");
+            } else {
+                // May be a namespace decl though?
+                if (prefix == "xmlns") {
+                    isNsDecl = true;
+                } else {
+                    attrName = bindName(attrName, prefix);
+                    if (allBound) {
+                        allBound = attrName.isBound();
+                    }
+                    isNsDecl = false;
+                }
+            }
+
+            // Optional space to skip again
+            while (true) {
+                if (_inputPtr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                }
+                c = _inputBuffer[_inputPtr++];
+                if (c > INT_SPACE) {
+                    break;
+                }
+                if (c == '\n') {
+                    markLF();
+                } else if (c == '\r') {
+                    if (_inputPtr >= _inputEnd) {
+                        loadMoreGuaranteed();
+                    }
+                    if (_inputBuffer[_inputPtr] == '\n') {
+                        ++_inputPtr;
+                    }
+                    markLF();
+                } else if (c != ' ' && c != '\t') {
+                    throwInvalidSpace(c);
+                }
+            }
+
+            if (c != '=') {
+                throwUnexpectedChar(c, " expected '='");
+            }
+
+            // Optional space to skip again
+            while (true) {
+                if (_inputPtr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                }
+                c = _inputBuffer[_inputPtr++];
+                if (c > INT_SPACE) {
+                    break;
+                }
+                if (c == '\n') {
+                    markLF();
+                } else if (c == '\r') {
+                    if (_inputPtr >= _inputEnd) {
+                        loadMoreGuaranteed();
+                    }
+                    if (_inputBuffer[_inputPtr] == '\n') {
+                        ++_inputPtr;
+                    }
+                    markLF();
+                } else if (c != ' ' && c != '\t') {
+                    throwInvalidSpace(c);
+                }
+            }
+
+            if (c != '"' && c != '\'') {
+                throwUnexpectedChar(c, " Expected a quote");
+            }
+
+            /* Ok, finally: value parsing. However, ns URIs are to be handled
+             * different from attribute values... let's offline URIs, since
+             * they should be less common than attribute values.
+             */
+            if (isNsDecl) { // default ns, or explicit?
+                handleNsDeclaration(attrName, c);
+                ++_currNsCount;
+            } else { // nope, a 'real' attribute:
+                attrPtr = collectValue(attrPtr, c, attrName);
+            }
+        }
+        {
+            // Note: this call also checks attribute uniqueness
+            int act = _attrCollector.finishLastValue(attrPtr);
+            if (act < 0) { // error, dup attr indicated by -1
+                act = _attrCollector.getCount(); // let's get correct count
+                reportInputProblem(_attrCollector.getErrorMsg());
+            }
+            _attrCount = act;
+        }
+        ++_depth;
+
+        /* Was there any prefix that wasn't bound prior to use?
+         * That's legal, assuming declaration was found later on...
+         * let's check
+         */
+        if (!allBound) {
+            if (!elemName.isBound()) { // element itself unbound
+                reportUnboundPrefix(_tokenName, false);
+            }
+            for (int i = 0, len = _attrCount; i < len; ++i) {
+                PName attrName = _attrCollector.getName(i);
+                if (!attrName.isBound()) {
+                    reportUnboundPrefix(attrName, true);
+                }
+            }
+        }
+
+        return START_ELEMENT;
+    }
+
+    /**
+     * This method implements the tight loop for parsing attribute
+     * values. It's off-lined from the main start element method to
+     * simplify main method, which makes code more maintainable
+     * and possibly easier for JIT/HotSpot to optimize.
+     */
+    private final int collectValue(int attrPtr, char quoteChar, PName attrName)
+            throws XMLStreamException
+    {
+        char[] attrBuffer = _attrCollector.startNewValue(attrName, attrPtr);
+        final int[] TYPES = sCharTypes.ATTR_CHARS;
+
+        value_loop:
+        while (true) {
+            char c;
+
+            ascii_loop:
+            while (true) {
+                int ptr = _inputPtr;
+                if (ptr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                    ptr = _inputPtr;
+                }
+                if (attrPtr >= attrBuffer.length) {
+                    attrBuffer = _attrCollector.valueBufferFull();
+                }
+                int max = _inputEnd;
+                {
+                    int max2 = ptr + (attrBuffer.length - attrPtr);
+                    if (max2 < max) {
+                        max = max2;
+                    }
+                }
+                while (ptr < max) {
+                    c = _inputBuffer[ptr++];
+                    if (c <= 0xFF) {
+                        if (TYPES[c] != 0) {
+                            _inputPtr = ptr;
+                            break ascii_loop;
+                        }
+                    } else if (c >= 0xD800) { // surrogates and 0xFFFE/0xFFFF
+                        _inputPtr = ptr;
+                        break ascii_loop;
+                    }
+                    attrBuffer[attrPtr++] = c;
+                }
+                _inputPtr = ptr;
+            }
+
+            if (c <= 0xFF) {
+                switch (TYPES[c]) {
+                    case XmlCharTypes.CT_INVALID:
+                        c = handleInvalidXmlChar(c);
+                    case XmlCharTypes.CT_WS_CR:
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (_inputBuffer[_inputPtr] == '\n') {
+                            ++_inputPtr;
+                        }
+                        // fall through
+                    case XmlCharTypes.CT_WS_LF:
+                        markLF();
+                        // fall through
+                    case XmlCharTypes.CT_WS_TAB:
+                        // Plus, need to convert these all to simple space
+                        c = ' ';
+                        break;
+                    case XmlCharTypes.CT_LT:
+                        throwUnexpectedChar(c, "'<' not allowed in attribute value");
+                    case XmlCharTypes.CT_AMP:
+                    {
+                        if (_config.willExpandEntities()) {
+                            int d = handleEntityInText(false);
+                            if (d == 0) { // unexpanded general entity... not good
+                                reportUnexpandedEntityInAttr(attrName, false);
+                            }
+                            // Ok; does it need a surrogate though? (over 16 bits)
+                            if ((d >> 16) != 0) {
+                                d -= 0x10000;
+                                attrBuffer[attrPtr++] = (char) (0xD800 | (d >> 10));
+                                d = 0xDC00 | (d & 0x3FF);
+                                if (attrPtr >= attrBuffer.length) {
+                                    attrBuffer = _attrCollector.valueBufferFull();
+                                }
+                            }
+                            c = (char) d;
+                        }
+                    }
+                    break;
+                    case XmlCharTypes.CT_ATTR_QUOTE:
+                        if (c == quoteChar) {
+                            break value_loop;
+                        }
+
+                        // default:
+                        // Other chars are not important here...
+                }
+            } else if (c >= 0xD800) {
+                if (c < 0xE000) {
+                    // if ok, returns second surrogate; otherwise exception
+                    char d = checkSurrogate(c);
+                    attrBuffer[attrPtr++] = c;
+                    // Need to ensure room for one more
+                    if (attrPtr >= attrBuffer.length) {
+                        attrBuffer = _attrCollector.valueBufferFull();
+                    }
+                    c = d;
+                } else if (c >= 0xFFFE) {
+                    c = handleInvalidXmlChar(c);
+                }
+            }
+            // We know there's room for at least one more char
+            attrBuffer[attrPtr++] = c;
+        }
+
+        return attrPtr;
+    }
+
+    /**
+     * Method called from the main START_ELEMENT handling loop, to
+     * parse namespace URI values.
+     */
+    private void handleNsDeclaration(PName name, char quoteChar)
+            throws XMLStreamException
+    {
+        int attrPtr = 0;
+        char[] attrBuffer = _nameBuffer;
+
+        while (true) {
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            char c = _inputBuffer[_inputPtr++];
+            if (c == quoteChar) {
+                break;
+            }
+            if (c == '&') { // entity
+                int d = handleEntityInText(false);
+                if (d == 0) { // general entity; should never happen
+                    reportUnexpandedEntityInAttr(name, true);
+                }
+                // Ok; does it need a surrogate though? (over 16 bits)
+                if ((d >> 16) != 0) {
+                    if (attrPtr >= attrBuffer.length) {
+                        _nameBuffer = attrBuffer = DataUtil.growArrayBy(attrBuffer, attrBuffer.length);
+                    }
+                    d -= 0x10000;
+                    attrBuffer[attrPtr++] = (char) (0xD800 | (d >> 10));
+                    d = 0xDC00 | (d & 0x3FF);
+                }
+                c = (char) d;
+            } else if (c == '<') { // error
+                throwUnexpectedChar(c, "'<' not allowed in attribute value");
+            } else {
+                if (c < INT_SPACE) {
+                    if (c == '\n') {
+                        markLF();
+                    } else if (c == '\r') {
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (_inputBuffer[_inputPtr] == '\n') {
+                            ++_inputPtr;
+                        }
+                        markLF();
+                        c = '\n';
+                    } else if (c != '\t') {
+                        throwInvalidSpace(c);
+                    }
+                }
+            }
+            if (attrPtr >= attrBuffer.length) {
+                _nameBuffer = attrBuffer = DataUtil.growArrayBy(attrBuffer, attrBuffer.length);
+            }
+            attrBuffer[attrPtr++] = c;
+        }
+
+        /* Simple optimization: for default ns removal (or, with
+         * ns 1.1, any other as well), will use empty value... no
+         * need to try to intern:
+         */
+        if (attrPtr == 0) {
+            bindNs(name, "");
+        } else {
+            String uri = _config.canonicalizeURI(attrBuffer, attrPtr);
+            bindNs(name, uri);
+        }
+    }
+
+    protected final int handleEndElement()
+            throws XMLStreamException
+    {
+        --_depth;
+
+        _currToken = END_ELEMENT;
+        // Ok, at this point we have seen '/', need the name
+        _tokenName = _currElem.getName();
+        String pname = _tokenName.getPrefixedName();
+        char c;
+        int i = 0;
+        int len = pname.length();
+        do {
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            c = _inputBuffer[_inputPtr++];
+            if (c != pname.charAt(i)) {
+                reportUnexpectedEndTag(pname);
+            }
+        } while (++i < len);
+
+        // Can still have a problem, if name didn't end there...
+        if (_inputPtr >= _inputEnd) {
+            loadMoreGuaranteed();
+        }
+        c = _inputBuffer[_inputPtr++];
+        if (c <= ' ') {
+            c = skipInternalWs(false, null);
+        } else if (c != '>') {
+            if (c == ':' || XmlChars.is10NameChar(c)) {
+                reportUnexpectedEndTag(pname);
+            }
+        }
+        if (c != '>') {
+            throwUnexpectedChar(c, " expected space or closing '>'");
+        }
+        return END_ELEMENT;
+    }
+
+    protected final int handleEntityInText(boolean inAttr)
+            throws XMLStreamException
+    {
+        if (_inputPtr >= _inputEnd) {
+            loadMoreGuaranteed();
+        }
+        char c = _inputBuffer[_inputPtr++];
+        if (c == '#') {
+            return handleCharEntity();
+        }
+        String start;
+        if (c == 'a') { // amp or apos?
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            c = _inputBuffer[_inputPtr++];
+            if (c == 'm') { // amp?
+                if (_inputPtr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                }
+                c = _inputBuffer[_inputPtr++];
+                if (c == 'p') {
+                    if (_inputPtr >= _inputEnd) {
+                        loadMoreGuaranteed();
+                    }
+                    c = _inputBuffer[_inputPtr++];
+                    if (c == ';') {
+                        return INT_AMP;
+                    }
+                    start = "amp";
+                } else {
+                    start = "am";
+                }
+            } else if (c == 'p') { // apos?
+                if (_inputPtr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                }
+                c = _inputBuffer[_inputPtr++];
+                if (c == 'o') {
+                    if (_inputPtr >= _inputEnd) {
+                        loadMoreGuaranteed();
+                    }
+                    c = _inputBuffer[_inputPtr++];
+                    if (c == 's') {
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        c = _inputBuffer[_inputPtr++];
+                        if (c == ';') {
+                            return INT_APOS;
+                        }
+                        start = "apos";
+                    } else {
+                        start = "apo";
+                    }
+                } else {
+                    start = "ap";
+                }
+            } else {
+                start = "a";
+            }
+        } else if (c == 'l') { // lt?
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            c = _inputBuffer[_inputPtr++];
+            if (c == 't') {
+                if (_inputPtr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                }
+                c = _inputBuffer[_inputPtr++];
+                if (c == ';') {
+                    return INT_LT;
+                }
+                start = "lt";
+            } else {
+                start = "l";
+            }
+        } else if (c == 'g') { // gt?
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            c = _inputBuffer[_inputPtr++];
+            if (c == 't') {
+                if (_inputPtr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                }
+                c = _inputBuffer[_inputPtr++];
+                if (c == ';') {
+                    return INT_GT;
+                }
+                start = "gt";
+            } else {
+                start = "g";
+            }
+        } else if (c == 'q') { // quot?
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            c = _inputBuffer[_inputPtr++];
+            if (c == 'u') {
+                if (_inputPtr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                }
+                c = _inputBuffer[_inputPtr++];
+                if (c == 'o') {
+                    if (_inputPtr >= _inputEnd) {
+                        loadMoreGuaranteed();
+                    }
+                    c = _inputBuffer[_inputPtr++];
+                    if (c == 't') {
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        c = _inputBuffer[_inputPtr++];
+                        if (c == ';') {
+                            return INT_QUOTE;
+                        }
+                        start = "quot";
+                    } else {
+                        start = "quo";
+                    }
+                } else {
+                    start = "qu";
+                }
+            } else {
+                start = "q";
+            }
+        } else {
+            start = "";
+        }
+
+        final int[] TYPES = sCharTypes.NAME_CHARS;
+
+        /* All righty: we have the beginning of the name, plus the first
+         * char too. So let's see what we can do with it.
+         */
+        char[] cbuf = _nameBuffer;
+        int cix = 0;
+        for (int len = start.length(); cix < len; ++cix) {
+            cbuf[cix] = start.charAt(cix);
+        }
+        //int colon = -1;
+        while (c != ';') {
+            boolean ok;
+
+            // Has to be a valid name start char though:
+            if (c <= 0xFF) {
+                switch (TYPES[c]) {
+                    case XmlCharTypes.CT_NAME_NONE:
+                    case XmlCharTypes.CT_NAME_COLON: // not ok for entities?
+                    case XmlCharTypes.CT_NAME_NONFIRST:
+                        ok = (cix > 0);
+                        break;
+                    case XmlCharTypes.CT_NAME_ANY:
+                        ok = true;
+                        break;
+                    default:
+                        ok = false;
+                        break;
+                }
+            } else {
+                if (c < 0xE000) {
+                    // if ok, returns second surrogate; otherwise exception
+                    int value = decodeSurrogate(c);
+                    if (cix >= cbuf.length) {
+                        _nameBuffer = cbuf = DataUtil.growArrayBy(cbuf, cbuf.length);
+                    }
+                    cbuf[cix++] = c;
+                    c = _inputBuffer[_inputPtr-1]; // was read by decode func
+                    ok = (cix == 0) ? XmlChars.is10NameStartChar(value)
+                            : XmlChars.is10NameChar(value);
+                } else if (c >= 0xFFFE) {
+                    c = handleInvalidXmlChar(c);
+                    ok = false; // never gets here
+                } else {
+                    ok = true;
+                }
+            }
+            if (!ok) {
+                reportInvalidNameChar(c, cix);
+            }
+            if (cix >= cbuf.length) {
+                _nameBuffer = cbuf = DataUtil.growArrayBy(cbuf, cbuf.length);
+            }
+            cbuf[cix++] = c;
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            c = _inputBuffer[_inputPtr++];
+        }
+
+        // Ok, let's construct a (temporary) entity name, then:
+        String pname = new String(cbuf, 0, cix);
+        // (note: hash is dummy... not to be compared to anything etc)
+        _tokenName = new PNameC(pname, null, pname, 0);
+
+        /* One more thing: do we actually allow entities in this mode
+         * and with this event?
+         */
+        if (_config.willExpandEntities()) {
+            reportInputProblem("General entity reference (&"+pname+";) encountered in entity expanding mode: operation not (yet) implemented");
+        }
+        if (inAttr) {
+            reportInputProblem("General entity reference (&"+pname+";) encountered in attribute value, in non-entity-expanding mode: no way to handle it");
+        }
+        return 0;
+    }
+
+    @Override
+    protected final void finishComment() throws XMLStreamException
+    {
+        final int[] TYPES = sCharTypes.OTHER_CHARS;
+        final char[] inputBuffer = _inputBuffer;
+        char[] outputBuffer = _textBuilder.resetWithEmpty();
+        int outPtr = 0;
+
+        main_loop:
+        while (true) {
+            char c;
+
+            // Then the tight ascii non-funny-char loop:
+            ascii_loop:
+            while (true) {
+                int ptr = _inputPtr;
+                if (ptr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                    ptr = _inputPtr;
+                }
+                if (outPtr >= outputBuffer.length) {
+                    outputBuffer = _textBuilder.finishCurrentSegment();
+                    outPtr = 0;
+                }
+                int max = _inputEnd;
+                {
+                    int max2 = ptr + (outputBuffer.length - outPtr);
+                    if (max2 < max) {
+                        max = max2;
+                    }
+                }
+                while (ptr < max) {
+                    c = inputBuffer[ptr++];
+                    if (c <= 0xFF) {
+                        if (TYPES[c] != 0) {
+                            _inputPtr = ptr;
+                            break ascii_loop;
+                        }
+                    } else if (c >= 0xD800) { // surrogates and 0xFFFE/0xFFFF
+                        _inputPtr = ptr;
+                        break ascii_loop;
+                    }
+                    outputBuffer[outPtr++] = c;
+                }
+                _inputPtr = ptr;
+            }
+
+            if (c <= 0xFF) {
+                switch (TYPES[c]) {
+                    case XmlCharTypes.CT_INVALID:
+                        c = handleInvalidXmlChar(c);
+                    case XmlCharTypes.CT_WS_CR:
+                    {
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (inputBuffer[_inputPtr] == '\n') {
+                            ++_inputPtr;
+                        }
+                        markLF();
+                    }
+                    c = '\n';
+                    break;
+                    case XmlCharTypes.CT_WS_LF:
+                        markLF();
+                        break;
+                    case XmlCharTypes.CT_HYPHEN: // '-->'?
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (_inputBuffer[_inputPtr] == '-') { // ok, must be end then
+                            ++_inputPtr;
+                            if (_inputPtr >= _inputEnd) {
+                                loadMoreGuaranteed();
+                            }
+                            if (_inputBuffer[_inputPtr++] != '>') {
+                                reportDoubleHyphenInComments();
+                            }
+                            break main_loop;
+                        }
+                        break;
+                    // default:
+                    // Other types are not important here..
+                }
+            } else if (c >= 0xD800) {  // high-range, surrogates etc
+                if (c < 0xE000) {
+                    // if ok, returns second surrogate; otherwise exception
+                    char d = checkSurrogate(c);
+                    outputBuffer[outPtr++] = c;
+                    if (outPtr >= outputBuffer.length) {
+                        outputBuffer = _textBuilder.finishCurrentSegment();
+                        outPtr = 0;
+                    }
+                    c = d;
+                } else if (c >= 0xFFFE) {
+                    c = handleInvalidXmlChar(c);
+                }
+            }
+            // We know there's room for one more:
+            outputBuffer[outPtr++] = c;
+        }
+        _textBuilder.setCurrentLength(outPtr);
+    }
+
+    @Override
+    protected final void finishPI() throws XMLStreamException
+    {
+        final int[] TYPES = sCharTypes.OTHER_CHARS;
+        final char[] inputBuffer = _inputBuffer;
+        char[] outputBuffer = _textBuilder.resetWithEmpty();
+        int outPtr = 0;
+
+        main_loop:
+        while (true) {
+            char c;
+
+            // Then the tight ascii non-funny-char loop:
+            ascii_loop:
+            while (true) {
+                int ptr = _inputPtr;
+                if (ptr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                    ptr = _inputPtr;
+                }
+                if (outPtr >= outputBuffer.length) {
+                    outputBuffer = _textBuilder.finishCurrentSegment();
+                    outPtr = 0;
+                }
+                int max = _inputEnd;
+                {
+                    int max2 = ptr + (outputBuffer.length - outPtr);
+                    if (max2 < max) {
+                        max = max2;
+                    }
+                }
+                while (ptr < max) {
+                    c = inputBuffer[ptr++];
+                    if (c <= 0xFF) {
+                        if (TYPES[c] != 0) {
+                            _inputPtr = ptr;
+                            break ascii_loop;
+                        }
+                    } else if (c >= 0xD800) { // surrogates and 0xFFFE/0xFFFF
+                        _inputPtr = ptr;
+                        break ascii_loop;
+                    }
+                    outputBuffer[outPtr++] = c;
+                }
+                _inputPtr = ptr;
+            }
+
+            if (c <= 0xFF) {
+                switch (TYPES[c]) {
+                    case XmlCharTypes.CT_WS_CR:
+                    {
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (inputBuffer[_inputPtr] == CHAR_LF) {
+                            ++_inputPtr;
+                        }
+                        markLF();
+                        c = '\n';
+                    }
+                    break;
+                    case XmlCharTypes.CT_WS_LF:
+                        markLF();
+                        break;
+                    case XmlCharTypes.CT_QMARK: // '?>'?
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (_inputBuffer[_inputPtr] == '>') {
+                            ++_inputPtr;
+                            break main_loop;
+                        }
+                        break;
+                    // default:
+                    // Other types are not important here...
+                }
+            } else if (c >= 0xD800) {  // high-range, surrogates etc
+                if (c < 0xE000) {
+                    // if ok, returns second surrogate; otherwise exception
+                    char d = checkSurrogate(c);
+                    outputBuffer[outPtr++] = c;
+                    if (outPtr >= outputBuffer.length) {
+                        outputBuffer = _textBuilder.finishCurrentSegment();
+                        outPtr = 0;
+                    }
+                    c = d;
+                } else if (c >= 0xFFFE) {
+                    c = handleInvalidXmlChar(c);
+                }
+            }
+            // We know there's room for one more:
+            outputBuffer[outPtr++] = c;
+        }
+        _textBuilder.setCurrentLength(outPtr);
+    }
+
+    @Override
+    protected final void finishDTD(boolean copyContents) throws XMLStreamException
+    {
+        char[] outputBuffer = copyContents ?
+                _textBuilder.resetWithEmpty() : null;
+        int outPtr = 0;
+
+        final int[] TYPES = sCharTypes.DTD_CHARS;
+        boolean inDecl = false; // in declaration/directive?
+        int quoteChar = 0; // inside quoted string?
+
+        main_loop:
+        while (true) {
+            char c;
+
+            /* First we'll have a quickie loop for speeding through
+             * uneventful chars...
+             */
+            ascii_loop:
+            while (true) {
+                int ptr = _inputPtr;
+                if (ptr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                    ptr = _inputPtr;
+                }
+                int max = _inputEnd;
+                if (outputBuffer != null) {
+                    if (outPtr >= outputBuffer.length) {
+                        outputBuffer = _textBuilder.finishCurrentSegment();
+                        outPtr = 0;
+                    }
+                    {
+                        int max2 = ptr + (outputBuffer.length - outPtr);
+                        if (max2 < max) {
+                            max = max2;
+                        }
+                    }
+                }
+                while (ptr < max) {
+                    c = _inputBuffer[ptr++];
+                    if (c <= 0xFF) {
+                        if (TYPES[c] != 0) {
+                            _inputPtr = ptr;
+                            break ascii_loop;
+                        }
+                    } else if (c >= 0xD800) { // surrogates and 0xFFFE/0xFFFF
+                        _inputPtr = ptr;
+                        break ascii_loop;
+                    }
+                    if (outputBuffer != null) {
+                        outputBuffer[outPtr++] = c;
+                    }
+                }
+                _inputPtr = ptr;
+            }
+
+            if (c <= 0xFF) {
+                switch (TYPES[c]) {
+                    case XmlCharTypes.CT_INVALID:
+                        c = handleInvalidXmlChar(c);
+                    case XmlCharTypes.CT_WS_CR:
+                    {
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (_inputBuffer[_inputPtr] == '\n') {
+                            ++_inputPtr;
+                        }
+                        markLF();
+                    }
+                    c = '\n';
+                    break;
+                    case XmlCharTypes.CT_WS_LF:
+                        markLF();
+                        break;
+
+                    case XmlCharTypes.CT_DTD_QUOTE: // apos or quot
+                        if (quoteChar == 0) {
+                            quoteChar = c;
+                        } else {
+                            if (quoteChar == c) {
+                                quoteChar = 0;
+                            }
+                        }
+                        break;
+
+                    case XmlCharTypes.CT_DTD_LT:
+                        if (!inDecl) {
+                            inDecl = true;
+                        }
+                        break;
+                    case XmlCharTypes.CT_DTD_GT:
+                        if (quoteChar == 0) {
+                            inDecl = false;
+                        }
+                        break;
+                    case XmlCharTypes.CT_DTD_RBRACKET:
+                        if (!inDecl && quoteChar == 0) {
+                            break main_loop;
+                        }
+                        break;
+                    // default:
+                    // Other types are not important here...
+                }
+            } else if (c >= 0xD800) {  // high-range, surrogates etc
+                if (c < 0xE000) {
+                    // if ok, returns second surrogate; otherwise exception
+                    char d = checkSurrogate(c);
+                    if (outputBuffer != null) {
+                        outputBuffer[outPtr++] = c;
+                        if (outPtr >= outputBuffer.length) {
+                            outputBuffer = _textBuilder.finishCurrentSegment();
+                            outPtr = 0;
+                        }
+                    }
+                    c = d;
+                } else if (c >= 0xFFFE) {
+                    c = handleInvalidXmlChar(c);
+                }
+            }
+
+            if (outputBuffer != null) { // has room for one more
+                outputBuffer[outPtr++] = c;
+            }
+        }
+        if (outputBuffer != null) {
+            _textBuilder.setCurrentLength(outPtr);
+        }
+
+        // but still need to match the '>'...
+        char c = skipInternalWs(false, null);
+        if (c != '>') {
+            throwUnexpectedChar(c, " expected '>' after the internal subset");
+        }
+    }
+
+    @Override
+    protected final void finishCData() throws XMLStreamException
+    {
+        final int[] TYPES = sCharTypes.OTHER_CHARS;
+        final char[] inputBuffer = _inputBuffer;
+        char[] outputBuffer = _textBuilder.resetWithEmpty();
+        int outPtr = 0;
+
+        /* At this point, space (if any) has been skipped, and we are
+         * to parse and store the contents
+         */
+        main_loop:
+        while (true) {
+            char c;
+            // Then the tight ascii non-funny-char loop:
+            ascii_loop:
+            while (true) {
+                int ptr = _inputPtr;
+                if (ptr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                    ptr = _inputPtr;
+                }
+                if (outPtr >= outputBuffer.length) {
+                    outputBuffer = _textBuilder.finishCurrentSegment();
+                    outPtr = 0;
+                }
+                int max = _inputEnd;
+                {
+                    int max2 = ptr + (outputBuffer.length - outPtr);
+                    if (max2 < max) {
+                        max = max2;
+                    }
+                }
+                while (ptr < max) {
+                    c = inputBuffer[ptr++];
+                    if (c <= 0xFF) {
+                        if (TYPES[c] != 0) {
+                            _inputPtr = ptr;
+                            break ascii_loop;
+                        }
+                    } else if (c >= 0xD800) { // surrogates and 0xFFFE/0xFFFF
+                        _inputPtr = ptr;
+                        break ascii_loop;
+                    }
+                    outputBuffer[outPtr++] = c;
+                }
+                _inputPtr = ptr;
+            }
+            // And then exceptions:
+            if (c <= 0xFF) {
+                switch (TYPES[c]) {
+                    case XmlCharTypes.CT_INVALID:
+                        c = handleInvalidXmlChar(c);
+                    case XmlCharTypes.CT_WS_CR:
+                    {
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (inputBuffer[_inputPtr] == '\n') {
+                            ++_inputPtr;
+                        }
+                        markLF();
+                    }
+                    c = '\n';
+                    break;
+                    case XmlCharTypes.CT_WS_LF:
+                        markLF();
+                        break;
+                    case XmlCharTypes.CT_RBRACKET: // close ']]>' marker?
+                        /* Ok: let's just parse all consequtive right brackets,
+                         * and see if followed by greater-than char. This because
+                         * we can only push back at most one char at a time, and
+                         * thus can't easily just check a subset
+                         */
+                        int count = 0; // ignore first bracket
+                        char d;
+
+                        do {
+                            if (_inputPtr >= _inputEnd) {
+                                loadMoreGuaranteed();
+                            }
+                            d = _inputBuffer[_inputPtr];
+                            if (d != ']') {
+                                break;
+                            }
+                            ++_inputPtr;
+                            ++count;
+                        } while (true);
+
+                        // Was the marker found?
+                        boolean ok = (d == '>' && count >= 1);
+                        if (ok) {
+                            --count;
+                        }
+                        // Brackets to copy to output?
+                        for (; count > 0; --count) {
+                            outputBuffer[outPtr++] = ']';
+                            if (outPtr >= outputBuffer.length) {
+                                outputBuffer = _textBuilder.finishCurrentSegment();
+                                outPtr = 0;
+                            }
+                        }
+                        if (ok) {
+                            ++_inputPtr; // to consume '>'
+                            break main_loop;
+                        }
+                        break;
+                    // default:
+                    // Other types are not important here...
+                }
+            } else if (c >= 0xD800) {  // high-range, surrogates etc
+                if (c < 0xE000) {
+                    // if ok, returns second surrogate; otherwise exception
+                    char d = checkSurrogate(c);
+                    outputBuffer[outPtr++] = c;
+                    if (outPtr >= outputBuffer.length) {
+                        outputBuffer = _textBuilder.finishCurrentSegment();
+                        outPtr = 0;
+                    }
+                    c = d;
+                } else if (c >= 0xFFFE) {
+                    c = handleInvalidXmlChar(c);
+                }
+            }
+            // Ok, can output the char; there's room for one char at least
+            outputBuffer[outPtr++] = c;
+        }
+
+        _textBuilder.setCurrentLength(outPtr);
+        /* 03-Feb-2009, tatu: To support coalescing mode, may need to
+         *   do some extra work
+         */
+        if (_cfgCoalescing && !_entityPending) {
+            finishCoalescedText();
+        }
+    }
+
+    @Override
+    protected final void finishCharacters() throws XMLStreamException
+    {
+        int outPtr;
+        char[] outputBuffer;
+
+        // Ok, so what was the first char / entity?
+        {
+            int c = mTmpChar;
+            if (c < 0) { // from entity; can just copy as is
+                c = -c;
+                outputBuffer = _textBuilder.resetWithEmpty();
+                outPtr = 0;
+                if ((c >> 16) != 0) { // surrogate pair?
+                    c -= 0x10000;
+                    /* Note: after resetting the buffer, it's known to have
+                     * space for more than 2 chars we need to add
+                     */
+                    outputBuffer[outPtr++] = (char) (0xD800 | (c >> 10));
+                    c = 0xDC00 | (c & 0x3FF);
+                }
+                outputBuffer[outPtr++] = (char) c;
+            } else { // white space that we are interested in?
+                if (c == INT_CR || c == INT_LF) {
+                    ++_inputPtr; // wasn't advanced yet, in this case
+                    outPtr = checkInTreeIndentation((char) c);
+                    if (outPtr < 0) {
+                        return;
+                    }
+                    // Above call also initializes the text builder appropriately
+                    outputBuffer = _textBuilder.getBufferWithoutReset();
+                } else {
+                    outputBuffer = _textBuilder.resetWithEmpty();
+                    outPtr = 0;
+                }
+            }
+        }
+
+        final int[] TYPES = sCharTypes.TEXT_CHARS;
+        final char[] inputBuffer = _inputBuffer;
+
+        main_loop:
+        while (true) {
+            char c;
+
+            // Then the tight ascii non-funny-char loop:
+            ascii_loop:
+            while (true) {
+                int ptr = _inputPtr;
+                if (ptr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                    ptr = _inputPtr;
+                }
+                if (outPtr >= outputBuffer.length) {
+                    outputBuffer = _textBuilder.finishCurrentSegment();
+                    outPtr = 0;
+                }
+                int max = _inputEnd;
+                {
+                    int max2 = ptr + (outputBuffer.length - outPtr);
+                    if (max2 < max) {
+                        max = max2;
+                    }
+                }
+                while (ptr < max) {
+                    c = inputBuffer[ptr++];
+                    if (c <= 0xFF) {
+                        if (TYPES[c] != 0) {
+                            _inputPtr = ptr;
+                            break ascii_loop;
+                        }
+                    } else if (c >= 0xD800) { // surrogates and 0xFFFE/0xFFFF
+                        _inputPtr = ptr;
+                        break ascii_loop;
+                    }
+                    outputBuffer[outPtr++] = c;
+                }
+                _inputPtr = ptr;
+            }
+            // And then exceptions:
+            if (c <= 0xFF) {
+                switch (TYPES[c]) {
+                    case XmlCharTypes.CT_INVALID:
+                        c = handleInvalidXmlChar(c);
+                    case XmlCharTypes.CT_WS_CR:
+                    {
+                        int ptr = _inputPtr;
+                        if (ptr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                            ptr = _inputPtr;
+                        }
+                        if (inputBuffer[ptr] == '\n') {
+                            ++_inputPtr;
+                        }
+                        markLF();
+                    }
+                    c = '\n';
+                    break;
+                    case XmlCharTypes.CT_WS_LF:
+                        markLF();
+                        break;
+                    case XmlCharTypes.CT_LT:
+                        --_inputPtr;
+                        break main_loop;
+                    case XmlCharTypes.CT_AMP:
+                    {
+                        int d = handleEntityInText(false);
+                        if (d == 0) { // unexpandable general parsed entity
+                            // _inputPtr set by entity expansion method
+                            _entityPending = true;
+                            break main_loop;
+                        }
+                        // Ok; does it need a surrogate though? (over 16 bits)
+                        if ((d >> 16) != 0) {
+                            d -= 0x10000;
+                            outputBuffer[outPtr++] = (char) (0xD800 | (d >> 10));
+                            // Need to ensure room for one more char
+                            if (outPtr >= outputBuffer.length) {
+                                outputBuffer = _textBuilder.finishCurrentSegment();
+                                outPtr = 0;
+                            }
+                            d = (0xDC00 | (d & 0x3FF));
+                        }
+                        c = (char) d;
+                    }
+                    break;
+                    case XmlCharTypes.CT_RBRACKET: // ']]>'?
+                    {
+                        // Let's then just count number of brackets --
+                        // in case they are not followed by '>'
+                        int count = 1;
+                        while (true) {
+                            if (_inputPtr >= _inputEnd) {
+                                loadMoreGuaranteed();
+                            }
+                            c = inputBuffer[_inputPtr];
+                            if (c != ']') {
+                                break;
+                            }
+                            ++_inputPtr; // to skip past bracket
+                            ++count;
+                        }
+                        if (c == '>' && count > 1) {
+                            reportIllegalCDataEnd();
+                        }
+                        // Nope. Need to output all brackets, then; except
+                        // for one that can be left for normal output
+                        while (count > 1) {
+                            outputBuffer[outPtr++] = ']';
+                            if (outPtr >= outputBuffer.length) {
+                                outputBuffer = _textBuilder.finishCurrentSegment();
+                                outPtr = 0;
+                            }
+                            // Need to ensure room for one more char
+                            --count;
+                        }
+                    }
+                    // Can just output the first ']' along normal output
+                    c = ']';
+                    break;
+                    // default:
+                    // Other types are not important here...
+                }
+            } else if (c >= 0xD800) {  // high-range, surrogates etc
+                if (c < 0xE000) {
+                    // if ok, returns second surrogate; otherwise exception
+                    char d = checkSurrogate(c);
+                    outputBuffer[outPtr++] = c;
+                    if (outPtr >= outputBuffer.length) {
+                        outputBuffer = _textBuilder.finishCurrentSegment();
+                        outPtr = 0;
+                    }
+                    c = d;
+                } else if (c >= 0xFFFE) {
+                    c = handleInvalidXmlChar(c);
+                }
+            }
+            outputBuffer[outPtr++] = c;
+        }
+        _textBuilder.setCurrentLength(outPtr);
+
+        // 03-Feb-2009, tatu: Need to support coalescing mode too:
+        if (_cfgCoalescing && !_entityPending) {
+            finishCoalescedText();
+        }
+    }
+
+    @Override
+    protected final void finishSpace() throws XMLStreamException
+    {
+        /* Ok: so, mTmpChar contains first space char. If it looks
+         * like indentation, we can probably optimize a bit...
+         */
+        char tmp = (char)mTmpChar;
+        char[] outputBuffer;
+        int outPtr;
+
+        if (tmp == '\r' || tmp == '\n') {
+            outPtr = checkPrologIndentation(tmp);
+            if (outPtr < 0) {
+                return;
+            }
+            // Above call also initializes the text builder appropriately
+            outputBuffer = _textBuilder.getBufferWithoutReset();
+        } else {
+            outputBuffer = _textBuilder.resetWithEmpty();
+            outputBuffer[0] = tmp;
+            outPtr = 1;
+        }
+
+        int ptr = _inputPtr;
+
+        while (true) {
+            if (ptr >= _inputEnd) {
+                if (!loadMore()) {
+                    break;
+                }
+                ptr = _inputPtr;
+            }
+            char c = _inputBuffer[ptr];
+            if (c > INT_SPACE) {
+                break;
+            }
+            ++ptr;
+
+            if (c == INT_LF) {
+                markLF(ptr);
+            } else if (c == INT_CR) {
+                if (ptr >= _inputEnd) {
+                    if (!loadMore()) { // still need to output the lf
+                        if (outPtr >= outputBuffer.length) {
+                            outputBuffer = _textBuilder.finishCurrentSegment();
+                            outPtr = 0;
+                        }
+                        outputBuffer[outPtr++] = '\n';
+                        break;
+                    }
+                    ptr = _inputPtr;
+                }
+                if (_inputBuffer[ptr] == '\n') {
+                    ++ptr;
+                }
+                markLF(ptr);
+                c = '\n'; // need to convert to canonical lf
+            } else if (c != ' ' && c != '\t') {
+                _inputPtr = ptr;
+                throwInvalidSpace(c);
+            }
+
+            // Ok, can output the char
+            if (outPtr >= outputBuffer.length) {
+                outputBuffer = _textBuilder.finishCurrentSegment();
+                outPtr = 0;
+            }
+            outputBuffer[outPtr++] = c;
+        }
+
+        _inputPtr = ptr;
+        _textBuilder.setCurrentLength(outPtr);
+    }
+
+    /*
+    /**********************************************************************
+    /* 2nd level parsing for coalesced text
+    /**********************************************************************
+     */
+
+    /**
+     * Method that gets called after a primary text segment (of type
+     * CHARACTERS or CDATA, not applicable to SPACE) has been read in
+     * text buffer. Method has to see if the following event would
+     * be textual as well, and if so, read it (and any other following
+     * textual segments).
+     */
+    protected final void finishCoalescedText()
+            throws XMLStreamException
+    {
+        while (true) {
+            // no matter what, will need (and can get) one char
+            if (_inputPtr >= _inputEnd) {
+                if (!loadMore()) { // most likely an error, will be handled later on
+                    return;
+                }
+            }
+
+            if (_inputBuffer[_inputPtr] == '<') { // markup of some kind
+                /* In worst case, need 3 chars ("<![") all in all to know
+                 * if we are getting a CDATA section
+                 */
+                if ((_inputPtr + 3) >= _inputEnd) {
+                    if (!loadAndRetain(3)) {
+                        // probably an error, but will be handled later
+                        return;
+                    }
+                }
+                if (_inputBuffer[_inputPtr+1] != '!'
+                        || _inputBuffer[_inputPtr+2] != '[') {
+                    // can't be CDATA, we are done here
+                    return;
+                }
+                // but let's verify it still:
+                _inputPtr += 3;
+                for (int i = 0; i < 6; ++i) {
+                    if (_inputPtr >= _inputEnd) {
+                        loadMoreGuaranteed();
+                    }
+                    char c = _inputBuffer[_inputPtr++];
+                    if (c != CDATA_STR.charAt(i)) {
+                        reportTreeUnexpChar(c, " (expected '"+CDATA_STR.charAt(i)+"' for CDATA section)");
+                    }
+                }
+                finishCoalescedCData();
+            } else { // textual (or entity, error etc)
+                finishCoalescedCharacters();
+                if (_entityPending) {
+                    break;
+                }
+            }
+        }
+    }
+
+    // note: code mostly copied from 'finishCharacters', just simplified
+    // in some places
+    protected final void finishCoalescedCData()
+            throws XMLStreamException
+    {
+        final int[] TYPES = sCharTypes.OTHER_CHARS;
+        final char[] inputBuffer = _inputBuffer;
+
+        char[] outputBuffer = _textBuilder.getBufferWithoutReset();
+        int outPtr = _textBuilder.getCurrentLength();
+
+        /* At this point, space (if any) has been skipped, and we are
+         * to parse and store the contents
+         */
+        main_loop:
+        while (true) {
+            char c;
+            // Then the tight ascii non-funny-char loop:
+            ascii_loop:
+            while (true) {
+                int ptr = _inputPtr;
+                if (ptr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                    ptr = _inputPtr;
+                }
+                if (outPtr >= outputBuffer.length) {
+                    outputBuffer = _textBuilder.finishCurrentSegment();
+                    outPtr = 0;
+                }
+                int max = _inputEnd;
+                {
+                    int max2 = ptr + (outputBuffer.length - outPtr);
+                    if (max2 < max) {
+                        max = max2;
+                    }
+                }
+                while (ptr < max) {
+                    c = inputBuffer[ptr++];
+                    if (c <= 0xFF) {
+                        if (TYPES[c] != 0) {
+                            _inputPtr = ptr;
+                            break ascii_loop;
+                        }
+                    } else if (c >= 0xD800) { // surrogates and 0xFFFE/0xFFFF
+                        _inputPtr = ptr;
+                        break ascii_loop;
+                    }
+                    outputBuffer[outPtr++] = c;
+                }
+                _inputPtr = ptr;
+            }
+            // And then exceptions:
+            if (c <= 0xFF) {
+                switch (TYPES[c]) {
+                    case XmlCharTypes.CT_INVALID:
+                        c = handleInvalidXmlChar(c);
+                    case XmlCharTypes.CT_WS_CR:
+                    {
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (inputBuffer[_inputPtr] == '\n') {
+                            ++_inputPtr;
+                        }
+                        markLF();
+                    }
+                    c = '\n';
+                    break;
+                    case XmlCharTypes.CT_WS_LF:
+                        markLF();
+                        break;
+                    case XmlCharTypes.CT_RBRACKET: // close ']]>' marker?
+                        /* Ok: let's just parse all consequtive right brackets,
+                         * and see if followed by greater-than char. This because
+                         * we can only push back at most one char at a time, and
+                         * thus can't easily just check a subset
+                         */
+                        int count = 0; // ignore first bracket
+                        char d;
+
+                        do {
+                            if (_inputPtr >= _inputEnd) {
+                                loadMoreGuaranteed();
+                            }
+                            d = _inputBuffer[_inputPtr];
+                            if (d != ']') {
+                                break;
+                            }
+                            ++_inputPtr;
+                            ++count;
+                        } while (true);
+
+                        // Was the marker found?
+                        boolean ok = (d == '>' && count >= 1);
+                        if (ok) {
+                            --count;
+                        }
+                        // Brackets to copy to output?
+                        for (; count > 0; --count) {
+                            outputBuffer[outPtr++] = ']';
+                            if (outPtr >= outputBuffer.length) {
+                                outputBuffer = _textBuilder.finishCurrentSegment();
+                                outPtr = 0;
+                            }
+                        }
+                        if (ok) {
+                            ++_inputPtr; // to consume '>'
+                            break main_loop;
+                        }
+                        break;
+                    // default:
+                    // Other types are not important here...
+                }
+            } else if (c >= 0xD800) {  // high-range, surrogates etc
+                if (c < 0xE000) {
+                    // if ok, returns second surrogate; otherwise exception
+                    char d = checkSurrogate(c);
+                    outputBuffer[outPtr++] = c;
+                    if (outPtr >= outputBuffer.length) {
+                        outputBuffer = _textBuilder.finishCurrentSegment();
+                        outPtr = 0;
+                    }
+                    c = d;
+                } else if (c >= 0xFFFE) {
+                    c = handleInvalidXmlChar(c);
+                }
+            }
+            // Ok, can output the char; there's room for one char at least
+            outputBuffer[outPtr++] = c;
+        }
+        _textBuilder.setCurrentLength(outPtr);
+    }
+
+    // note: code mostly copied from 'finishCharacters', just simplified
+    // in some places
+    protected final void finishCoalescedCharacters()
+            throws XMLStreamException
+    {
+        // first char can't be from (char) entity (wrt finishCharacters)
+
+        final int[] TYPES = sCharTypes.TEXT_CHARS;
+        final char[] inputBuffer = _inputBuffer;
+
+        char[] outputBuffer = _textBuilder.getBufferWithoutReset();
+        int outPtr = _textBuilder.getCurrentLength();
+
+        main_loop:
+        while (true) {
+            char c;
+
+            ascii_loop:
+            while (true) { // tight loop for ascii chars
+                int ptr = _inputPtr;
+                if (ptr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                    ptr = _inputPtr;
+                }
+                if (outPtr >= outputBuffer.length) {
+                    outputBuffer = _textBuilder.finishCurrentSegment();
+                    outPtr = 0;
+                }
+                int max = _inputEnd;
+                {
+                    int max2 = ptr + (outputBuffer.length - outPtr);
+                    if (max2 < max) {
+                        max = max2;
+                    }
+                }
+                while (ptr < max) {
+                    c = inputBuffer[ptr++];
+                    if (c <= 0xFF) {
+                        if (TYPES[c] != 0) {
+                            _inputPtr = ptr;
+                            break ascii_loop;
+                        }
+                    } else if (c >= 0xD800) { // surrogates and 0xFFFE/0xFFFF
+                        _inputPtr = ptr;
+                        break ascii_loop;
+                    }
+                    outputBuffer[outPtr++] = c;
+                }
+                _inputPtr = ptr;
+            }
+            // And then exceptions:
+            if (c <= 0xFF) {
+                switch (TYPES[c]) {
+                    case XmlCharTypes.CT_INVALID:
+                        c = handleInvalidXmlChar(c);
+                    case XmlCharTypes.CT_WS_CR:
+                    {
+                        int ptr = _inputPtr;
+                        if (ptr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                            ptr = _inputPtr;
+                        }
+                        if (inputBuffer[ptr] == '\n') {
+                            ++_inputPtr;
+                        }
+                        markLF();
+                    }
+                    c = '\n';
+                    break;
+                    case XmlCharTypes.CT_WS_LF:
+                        markLF();
+                        break;
+                    case XmlCharTypes.CT_LT:
+                        --_inputPtr;
+                        break main_loop;
+                    case XmlCharTypes.CT_AMP:
+                    {
+                        int d = handleEntityInText(false);
+                        if (d == 0) { // unexpandable general parsed entity
+                            // _inputPtr set by entity expansion method
+                            _entityPending = true;
+                            break main_loop;
+                        }
+                        // Ok; does it need a surrogate though? (over 16 bits)
+                        if ((d >> 16) != 0) {
+                            d -= 0x10000;
+                            outputBuffer[outPtr++] = (char) (0xD800 | (d >> 10));
+                            // Need to ensure room for one more char
+                            if (outPtr >= outputBuffer.length) {
+                                outputBuffer = _textBuilder.finishCurrentSegment();
+                                outPtr = 0;
+                            }
+                            d = (0xDC00 | (d & 0x3FF));
+                        }
+                        c = (char) d;
+                    }
+                    break;
+                    case XmlCharTypes.CT_RBRACKET: // ']]>'?
+                    {
+                        // Let's then just count number of brackets --
+                        // in case they are not followed by '>'
+                        int count = 1;
+                        while (true) {
+                            if (_inputPtr >= _inputEnd) {
+                                loadMoreGuaranteed();
+                            }
+                            c = inputBuffer[_inputPtr];
+                            if (c != ']') {
+                                break;
+                            }
+                            ++_inputPtr; // to skip past bracket
+                            ++count;
+                        }
+                        if (c == '>' && count > 1) {
+                            reportIllegalCDataEnd();
+                        }
+                        // Nope. Need to output all brackets, then; except
+                        // for one that can be left for normal output
+                        while (count > 1) {
+                            outputBuffer[outPtr++] = ']';
+                            if (outPtr >= outputBuffer.length) {
+                                outputBuffer = _textBuilder.finishCurrentSegment();
+                                outPtr = 0;
+                            }
+                            // Need to ensure room for one more char
+                            --count;
+                        }
+                    }
+                    // Can just output the first ']' along normal output
+                    c = ']';
+                    break;
+                    // default:
+                    // Other types are not important here...
+                }
+            } else if (c >= 0xD800) {  // high-range, surrogates etc
+                if (c < 0xE000) {
+                    // if ok, returns second surrogate; otherwise exception
+                    char d = checkSurrogate(c);
+                    outputBuffer[outPtr++] = c;
+                    if (outPtr >= outputBuffer.length) {
+                        outputBuffer = _textBuilder.finishCurrentSegment();
+                        outPtr = 0;
+                    }
+                    c = d;
+                } else if (c >= 0xFFFE) {
+                    c = handleInvalidXmlChar(c);
+                }
+            }
+            outputBuffer[outPtr++] = c;
+        }
+        _textBuilder.setCurrentLength(outPtr);
+    }
+
+    /**
+     * Method that gets called after a primary text segment (of type
+     * CHARACTERS or CDATA, not applicable to SPACE) has been skipped.
+     * Method has to see if the following event would
+     * be textual as well, and if so, skip it (and any other following
+     * textual segments).
+     *
+     * @return True if we encountered an unexpandable entity
+     */
+    @Override
+    protected final boolean skipCoalescedText()
+            throws XMLStreamException
+    {
+        while (true) {
+            // no matter what, will need (and can get) one char
+            if (_inputPtr >= _inputEnd) {
+                if (!loadMore()) { // most likely an error, will be handled later on
+                    return false;
+                }
+            }
+
+            if (_inputBuffer[_inputPtr] == '<') { // markup of some kind
+                /* In worst case, need 3 chars ("<![") all in all to know
+                 * if we are getting a CDATA section
+                 */
+                if ((_inputPtr + 3) >= _inputEnd) {
+                    if (!loadAndRetain(3)) { // probably an error, but will be handled later
+                        return false;
+                    }
+                }
+                if (_inputBuffer[_inputPtr+1] != '!'
+                        || _inputBuffer[_inputPtr+2] != '[') {
+                    // can't be CDATA, we are done here
+                    return false;
+                }
+                // but let's verify it still:
+                _inputPtr += 3;
+                for (int i = 0; i < 6; ++i) {
+                    if (_inputPtr >= _inputEnd) {
+                        loadMoreGuaranteed();
+                    }
+                    char c = _inputBuffer[_inputPtr++];
+                    if (c != CDATA_STR.charAt(i)) {
+                        reportTreeUnexpChar(c, " (expected '"+CDATA_STR.charAt(i)+"' for CDATA section)");
+                    }
+                }
+                skipCData();
+            } else { // textual (or entity, error etc)
+                if (skipCharacters()) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* 2nd level parsing for skipping content
+    /**********************************************************************
+     */
+
+    @Override
+    protected final void skipComment()
+            throws XMLStreamException
+    {
+        final int[] TYPES = sCharTypes.OTHER_CHARS;
+        final char[] inputBuffer = _inputBuffer;
+
+        while (true) {
+            char c;
+
+            // Then the tight ascii non-funny-char loop:
+            ascii_loop:
+            while (true) {
+                int ptr = _inputPtr;
+                int max = _inputEnd;
+                if (ptr >= max) {
+                    loadMoreGuaranteed();
+                    ptr = _inputPtr;
+                    max = _inputEnd;
+                }
+                while (ptr < max) {
+                    c = inputBuffer[ptr++];
+                    if (c <= 0xFF) {
+                        if (TYPES[c] != 0) {
+                            _inputPtr = ptr;
+                            break ascii_loop;
+                        }
+                    } else if (c >= 0xD800) { // surrogates and 0xFFFE/0xFFFF
+                        _inputPtr = ptr;
+                        break ascii_loop;
+                    }
+                }
+                _inputPtr = ptr;
+            }
+
+            if (c <= 0xFF) {
+                switch (TYPES[c]) {
+                    case XmlCharTypes.CT_INVALID:
+                        c = handleInvalidXmlChar(c);
+                    case XmlCharTypes.CT_WS_CR:
+                    {
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (inputBuffer[_inputPtr] == '\n') {
+                            ++_inputPtr;
+                        }
+                        markLF();
+                    }
+                    break;
+                    case XmlCharTypes.CT_WS_LF:
+                        markLF();
+                        break;
+                    case XmlCharTypes.CT_HYPHEN: // '-->'?
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (_inputBuffer[_inputPtr] == '-') { // ok, must be end then
+                            ++_inputPtr;
+                            if (_inputPtr >= _inputEnd) {
+                                loadMoreGuaranteed();
+                            }
+                            if (_inputBuffer[_inputPtr++] != '>') {
+                                reportDoubleHyphenInComments();
+                            }
+                            return;
+                        }
+                        break;
+                }
+
+                // default:
+                // Other types are not important here...
+            }
+        }
+    }
+
+    @Override
+    protected final void skipPI() throws XMLStreamException
+    {
+        final int[] TYPES = sCharTypes.OTHER_CHARS;
+        final char[] inputBuffer = _inputBuffer;
+
+        while (true) {
+            char c;
+
+            // Then the tight ascii non-funny-char loop:
+            ascii_loop:
+            while (true) {
+                int ptr = _inputPtr;
+                int max = _inputEnd;
+                if (ptr >= max) {
+                    loadMoreGuaranteed();
+                    ptr = _inputPtr;
+                    max = _inputEnd;
+                }
+                while (ptr < max) {
+                    c = inputBuffer[ptr++];
+                    if (c <= 0xFF) {
+                        if (TYPES[c] != 0) {
+                            _inputPtr = ptr;
+                            break ascii_loop;
+                        }
+                    } else if (c >= 0xD800) { // surrogates and 0xFFFE/0xFFFF
+                        _inputPtr = ptr;
+                        break ascii_loop;
+                    }
+                }
+                _inputPtr = ptr;
+            }
+
+            if (c <= 0xFF) {
+                switch (TYPES[c]) {
+                    case XmlCharTypes.CT_WS_CR:
+                    {
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (inputBuffer[_inputPtr] == CHAR_LF) {
+                            ++_inputPtr;
+                        }
+                        markLF();
+                    }
+                    break;
+                    case XmlCharTypes.CT_WS_LF:
+                        markLF();
+                        break;
+                    case XmlCharTypes.CT_QMARK: // '?>'?
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (_inputBuffer[_inputPtr] == '>') {
+                            ++_inputPtr;
+                            return;
+                        }
+                        break;
+                    // default:
+                    // Other types are not important here...
+                }
+            } else if (c >= 0xD800) {  // high-range, surrogates etc
+                if (c < 0xE000) {
+                    // if ok, returns second surrogate; otherwise exception
+                    /*char d =*/ checkSurrogate(c);
+                } else if (c >= 0xFFFE) {
+                    c = handleInvalidXmlChar(c);
+                }
+            }
+            // skipping, no need to output
+        }
+    }
+
+    @Override
+    protected final boolean skipCharacters() throws XMLStreamException
+    {
+        final int[] TYPES = sCharTypes.TEXT_CHARS;
+        final char[] inputBuffer = _inputBuffer;
+
+        while (true) {
+            char c;
+
+            // Then the tight ascii non-funny-char loop:
+            ascii_loop:
+            while (true) {
+                int ptr = _inputPtr;
+                int max = _inputEnd;
+                if (ptr >= max) {
+                    loadMoreGuaranteed();
+                    ptr = _inputPtr;
+                    max = _inputEnd;
+                }
+                while (ptr < max) {
+                    c = inputBuffer[ptr++];
+                    if (c <= 0xFF) {
+                        if (TYPES[c] != 0) {
+                            _inputPtr = ptr;
+                            break ascii_loop;
+                        }
+                    } else if (c >= 0xD800) { // surrogates and 0xFFFE/0xFFFF
+                        _inputPtr = ptr;
+                        break ascii_loop;
+                    }
+                }
+                _inputPtr = ptr;
+            }
+
+            if (c <= 0xFF) {
+                switch (TYPES[c]) {
+                    case XmlCharTypes.CT_INVALID:
+                        c = handleInvalidXmlChar(c);
+                    case XmlCharTypes.CT_WS_CR:
+                    {
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (inputBuffer[_inputPtr] == CHAR_LF) {
+                            ++_inputPtr;
+                        }
+                        markLF();
+                    }
+                    break;
+                    case XmlCharTypes.CT_WS_LF:
+                        markLF();
+                        break;
+                    case XmlCharTypes.CT_LT:
+                        --_inputPtr;
+                        return false;
+                    case XmlCharTypes.CT_AMP:
+                    {
+                        int d = handleEntityInText(false);
+                        if (d == 0) { // unexpandable general parsed entity
+                            return true;
+                        }
+                    }
+                    break;
+                    case XmlCharTypes.CT_RBRACKET: // ']]>'?
+                    {
+                        // Let's then just count number of brackets --
+                        // in case they are not followed by '>'
+                        int count = 1;
+                        while (true) {
+                            if (_inputPtr >= _inputEnd) {
+                                loadMoreGuaranteed();
+                            }
+                            c = inputBuffer[_inputPtr];
+                            if (c != ']') {
+                                break;
+                            }
+                            ++_inputPtr; // to skip past bracket
+                            ++count;
+                        }
+                        if (c == '>' && count > 1) {
+                            reportIllegalCDataEnd();
+                        }
+                    }
+                    // Can just output the first ']' along normal output
+                    break;
+
+                    // default:
+                    // Other types are not important here...
+                }
+            } else if (c >= 0xD800) {  // high-range, surrogates etc
+                if (c < 0xE000) {
+                    // if ok, returns second surrogate; otherwise exception
+                    /*char d =*/ checkSurrogate(c);
+                } else if (c >= 0xFFFE) {
+                    c = handleInvalidXmlChar(c);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected final void skipCData() throws XMLStreamException
+    {
+        final int[] TYPES = sCharTypes.OTHER_CHARS;
+        final char[] inputBuffer = _inputBuffer;
+
+        while (true) {
+            char c;
+
+            // Then the tight ascii non-funny-char loop:
+            ascii_loop:
+            while (true) {
+                int ptr = _inputPtr;
+                int max = _inputEnd;
+                if (ptr >= max) {
+                    loadMoreGuaranteed();
+                    ptr = _inputPtr;
+                    max = _inputEnd;
+                }
+                while (ptr < max) {
+                    c = inputBuffer[ptr++];
+                    if (c <= 0xFF) {
+                        if (TYPES[c] != 0) {
+                            _inputPtr = ptr;
+                            break ascii_loop;
+                        }
+                    } else if (c >= 0xD800) { // surrogates and 0xFFFE/0xFFFF
+                        _inputPtr = ptr;
+                        break ascii_loop;
+                    }
+                }
+                _inputPtr = ptr;
+            }
+
+            if (c <= 0xFF) {
+                switch (TYPES[c]) {
+                    case XmlCharTypes.CT_INVALID:
+                        c = handleInvalidXmlChar(c);
+                    case XmlCharTypes.CT_WS_CR:
+                    {
+                        int ptr = _inputPtr;
+                        if (ptr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                            ptr = _inputPtr;
+                        }
+                        if (inputBuffer[ptr] == CHAR_LF) {
+                            ++ptr;
+                            ++_inputPtr;
+                        }
+                        markLF(ptr);
+                    }
+                    break;
+                    case XmlCharTypes.CT_WS_LF:
+                        markLF();
+                        break;
+                    case XmlCharTypes.CT_RBRACKET: // ']]>'?
+                    {
+                        // end is nigh?
+                        int count = 0;
+
+                        do {
+                            if (_inputPtr >= _inputEnd) {
+                                loadMoreGuaranteed();
+                            }
+                            ++count;
+                            c = _inputBuffer[_inputPtr++];
+                        } while (c == ']');
+
+                        if (c == '>') {
+                            if (count > 1) { // gotcha
+                                return;
+                            }
+                            // can still skip plain ']>'...
+                        } else {
+                            --_inputPtr; // need to push back last char
+                        }
+                    }
+                    break;
+
+                    // default:
+                    // Other types are not important here...
+                }
+            } else if (c >= 0xD800) {  // high-range, surrogates etc
+                if (c < 0xE000) {
+                    // if ok, returns second surrogate; otherwise exception
+                    /*char d =*/ checkSurrogate(c);
+                } else if (c >= 0xFFFE) {
+                    c = handleInvalidXmlChar(c);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected final void skipSpace() throws XMLStreamException
+    {
+        // mTmpChar has a space, but it's been checked, can ignore
+        int ptr = _inputPtr;
+
+        while (true) {
+            if (ptr >= _inputEnd) {
+                if (!loadMore()) {
+                    break;
+                }
+                ptr = _inputPtr;
+            }
+            char c = _inputBuffer[ptr];
+            if (c > ' ') { // !!! TODO: xml 1.1 ws
+                break;
+            }
+            ++ptr;
+
+            if (c == '\n') {
+                markLF(ptr);
+            } else if (c == '\r') {
+                if (ptr >= _inputEnd) {
+                    if (!loadMore()) {
+                        break;
+                    }
+                    ptr = _inputPtr;
+                }
+                if (_inputBuffer[ptr] == '\n') {
+                    ++ptr;
+                }
+                markLF(ptr);
+            } else if (c != ' ' && c != '\t') {
+                _inputPtr = ptr;
+                throwInvalidSpace(c);
+            }
+        }
+        _inputPtr = ptr;
+    }
+
+    /*
+    /**********************************************************************
+    /* Entity/name handling
+    /**********************************************************************
+     */
+
+    /**
+     * @return First byte following skipped white space
+     */
+    protected char skipInternalWs(boolean reqd, String msg)
+            throws XMLStreamException
+    {
+        if (_inputPtr >= _inputEnd) {
+            loadMoreGuaranteed();
+        }
+        char c = _inputBuffer[_inputPtr++];
+        if (c > INT_SPACE) {
+            if (!reqd) {
+                return c;
+            }
+            reportTreeUnexpChar(c, " (expected white space "+msg+")");
+        }
+        do {
+            // But let's first handle the space we already got:
+            if (c == '\n') {
+                markLF();
+            } else if (c == '\r') {
+                if (_inputPtr >= _inputEnd) {
+                    loadMoreGuaranteed();
+                }
+                if (_inputBuffer[_inputPtr] == '\n') {
+                    ++_inputPtr;
+                }
+                markLF();
+            } else if (c != ' ' && c != '\t') {
+                throwInvalidSpace(c);
+            }
+
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            c = _inputBuffer[_inputPtr++];
+        } while (c <= INT_SPACE);
+
+        return c;
+    }
+
+    private final void matchAsciiKeyword(String keyw)
+            throws XMLStreamException
+    {
+        for (int i = 1, len = keyw.length(); i < len; ++i) {
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            char c = _inputBuffer[_inputPtr++];
+            if (c != keyw.charAt(i)) {
+                reportTreeUnexpChar(c, " (expected '"+keyw.charAt(i)+"' for "+keyw+" keyword)");
+            }
+        }
+    }
+
+    /**
+     *<p>
+     * Note: consequtive white space is only considered indentation,
+     * if the following token seems like a tag (start/end). This so
+     * that if a CDATA section follows, it can be coalesced in
+     * coalescing mode. Although we could check if coalescing mode is
+     * enabled, this should seldom have significant effect either way,
+     * so it removes one possible source of problems in coalescing mode.
+     *
+     * @return -1, if indentation was handled; offset in the output
+     *    buffer, if not
+     */
+    protected final int checkInTreeIndentation(char c)
+            throws XMLStreamException
+    {
+        if (c == '\r') {
+            // First a degenerate case, a lone \r:
+            if (_inputPtr >= _inputEnd && !loadMore()) {
+                _textBuilder.resetWithIndentation(0, CHAR_SPACE);
+                return -1;
+            }
+            if (_inputBuffer[_inputPtr] == '\n') {
+                ++_inputPtr;
+            }
+        }
+        markLF();
+        // Then need an indentation char (or start/end tag):
+        if (_inputPtr >= _inputEnd) {
+            loadMoreGuaranteed();
+        }
+        c = _inputBuffer[_inputPtr];
+        if (c != ' ' && c != '\t') {
+            // May still be indentation, if it's lt + non-exclamation mark
+            if (c == '<') {
+                if ((_inputPtr+1) < _inputEnd && _inputBuffer[_inputPtr+1] != '!') {
+                    _textBuilder.resetWithIndentation(0, ' ');
+                    return -1;
+                }
+            }
+            char[] outputBuffer = _textBuilder.resetWithEmpty();
+            outputBuffer[0] = '\n';
+            _textBuilder.setCurrentLength(1);
+            return 1;
+        }
+        // So how many do we get?
+        ++_inputPtr;
+        int count = 1;
+        int max = (c == ' ') ? TextBuilder.MAX_INDENT_SPACES : TextBuilder.MAX_INDENT_TABS;
+        while (count <= max) {
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            char c2 = _inputBuffer[_inputPtr];
+            if (c2 != c) {
+                // Has to be followed by a start/end tag...
+                if (c2 == '<' && (_inputPtr+1) < _inputEnd
+                        && _inputBuffer[_inputPtr+1] != '!') {
+                    _textBuilder.resetWithIndentation(count, c);
+                    return -1;
+                }
+                break;
+            }
+            ++_inputPtr;
+            ++count;
+        }
+        // Nope, hit something else, or too long: need to just copy the stuff
+        // we know buffer has enough room either way
+        char[] outputBuffer = _textBuilder.resetWithEmpty();
+        outputBuffer[0] = '\n';
+        for (int i = 1; i <= count; ++i) {
+            outputBuffer[i] = c;
+        }
+        count += 1; // to account for leading lf
+        _textBuilder.setCurrentLength(count);
+        return count;
+    }
+
+    /**
+     * @return -1, if indentation was handled; offset in the output
+     *    buffer, if not
+     */
+    protected final int checkPrologIndentation(char c)
+            throws XMLStreamException
+    {
+        if (c == '\r') {
+            // First a degenerate case, a lone \r:
+            if (_inputPtr >= _inputEnd && !loadMore()) {
+                _textBuilder.resetWithIndentation(0, CHAR_SPACE);
+                return -1;
+            }
+            if (_inputBuffer[_inputPtr] == '\n') {
+                ++_inputPtr;
+            }
+        }
+        markLF();
+        // Ok, indentation char?
+        if (_inputPtr >= _inputEnd && !loadMore()) {
+            _textBuilder.resetWithIndentation(0, CHAR_SPACE);
+            return -1;
+        }
+        c = _inputBuffer[_inputPtr]; // won't advance past the char yet
+        if (c != ' ' && c != '\t') {
+            // If lt, it's still indentation ok:
+            if (c == '<') { // need
+                _textBuilder.resetWithIndentation(0, CHAR_SPACE);
+                return -1;
+            }
+            // Nope... something else
+            char[] outputBuffer = _textBuilder.resetWithEmpty();
+            outputBuffer[0] = '\n';
+            _textBuilder.setCurrentLength(1);
+            return 1;
+        }
+        // So how many do we get?
+        ++_inputPtr;
+        int count = 1;
+        int max = (c == ' ') ? TextBuilder.MAX_INDENT_SPACES : TextBuilder.MAX_INDENT_TABS;
+        while (true) {
+            if (_inputPtr >= _inputEnd && !loadMore()) {
+                break;
+            }
+            if (_inputBuffer[_inputPtr] != c) {
+                break;
+            }
+            ++_inputPtr;
+            ++count;
+            if (count >= max) { // ok, can't share... but can build it still
+                // we know buffer has enough room
+                char[] outputBuffer = _textBuilder.resetWithEmpty();
+                outputBuffer[0] = '\n';
+                for (int i = 1; i <= count; ++i) {
+                    outputBuffer[i] = c;
+                }
+                count += 1; // to account for leading lf
+                _textBuilder.setCurrentLength(count);
+                return count;
+            }
+        }
+        // Ok, gotcha?
+        _textBuilder.resetWithIndentation(count, c);
+        return -1;
+    }
+
+    protected PName parsePName(char c)
+            throws XMLStreamException
+    {
+        char[] nameBuffer = _nameBuffer;
+
+        /* Let's do just quick sanity check first; a thorough check will be
+         * done later on if necessary, now we'll just do the very cheap
+         * check to catch extra spaces etc.
+         */
+        if (c < INT_A) { // lowest acceptable start char, except for ':' that would be allowed in non-ns mode
+            throwUnexpectedChar(c, "; expected a name start character");
+        }
+        nameBuffer[0] = c;
+        int hash = (int) c;
+        int ptr = 1;
+
+        while (true) {
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            c = _inputBuffer[_inputPtr];
+            int d = (int) c;
+            if (d < 65) {
+                // Ok; "_" (45), "." (46) and "0"-"9"/":" (48 - 57/58) still name chars
+                if (d < 45 || d > 58 || d == 47) {
+                    // End of name, a single ascii char?
+                    PName n = _symbols.findSymbol(nameBuffer, 0, ptr, hash);
+                    if (n == null) {
+                        n = addPName(nameBuffer, ptr, hash);
+                    }
+                    return n;
+                }
+            }
+            ++_inputPtr;
+            if (ptr >= nameBuffer.length) {
+                _nameBuffer = nameBuffer = DataUtil.growArrayBy(nameBuffer, nameBuffer.length);
+            }
+            nameBuffer[ptr++] = c;
+            hash = (hash * 31) + d;
+        }
+    }
+
+    protected final PName addPName(char[] nameBuffer, int nameLen, int hash)
+            throws XMLStreamException
+    {
+        // Let's validate completely, now:
+        char c = nameBuffer[0];
+        int namePtr = 1;
+        int last_colon = -1; // where the colon is
+
+        if (c < 0xD800 || c >= 0xE000) {
+            if (!XmlChars.is10NameStartChar(c)) {
+                reportInvalidNameChar(c, 0);
+            }
+        } else {
+            if (nameLen == 1) {
+                reportInvalidFirstSurrogate(c);
+            }
+            // Only returns if ok; throws exception otherwise
+            checkSurrogateNameChar(c, nameBuffer[1], 0);
+            ++namePtr;
+        }
+
+        for (; namePtr < nameLen; ++namePtr) {
+            c = nameBuffer[namePtr];
+
+            if (c < 0xD800 || c >= 0xE000) {
+                if (c == ':') {
+                    if (last_colon >= 0) {
+                        reportMultipleColonsInName();
+                    }
+                    last_colon = namePtr;
+                } else {
+                    if (!XmlChars.is10NameChar(c)) {
+                        reportInvalidNameChar(c, namePtr);
+                    }
+                }
+            } else {
+                if ((namePtr+1) >= nameLen) { // unpaired surrogate
+                    reportInvalidFirstSurrogate(c);
+                }
+                checkSurrogateNameChar(c, nameBuffer[namePtr+1], namePtr);
+            }
+        }
+        return _symbols.addSymbol(nameBuffer, 0, nameLen, hash);
+    }
+
+    protected String parsePublicId(char quoteChar)
+            throws XMLStreamException
+    {
+        char[] outputBuffer = _nameBuffer;
+        int outPtr = 0;
+        final int[] TYPES = XmlCharTypes.PUBID_CHARS;
+        boolean addSpace = false;
+
+        main_loop:
+        while (true) {
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            // Easier to check without char type table, first:
+            char c = _inputBuffer[_inputPtr++];
+            if (c == quoteChar) {
+                break main_loop;
+            }
+            if ((c > 0xFF) || TYPES[c] != XmlCharTypes.PUBID_OK) {
+                throwUnexpectedChar(c, " in public identifier");
+            }
+
+            // White space? Needs to be coalecsed
+            if (c <= INT_SPACE) {
+                addSpace = true;
+                continue;
+            }
+            if (addSpace) {
+                if (outPtr >= outputBuffer.length) {
+                    outputBuffer = _textBuilder.finishCurrentSegment();
+                    outPtr = 0;
+                }
+                outputBuffer[outPtr++] = ' ';
+                addSpace = false;
+            }
+            if (outPtr >= outputBuffer.length) {
+                _nameBuffer = outputBuffer = DataUtil.growArrayBy(outputBuffer, outputBuffer.length);
+                outPtr = 0;
+            }
+            outputBuffer[outPtr++] = c;
+        }
+        return new String(outputBuffer, 0, outPtr);
+    }
+
+    protected String parseSystemId(char quoteChar)
+            throws XMLStreamException
+    {
+        char[] outputBuffer = _nameBuffer;
+        int outPtr = 0;
+        // attribute types are closest matches, so let's use them
+        final int[] TYPES = sCharTypes.ATTR_CHARS;
+        //boolean spaceToAdd = false;
+
+        main_loop:
+        while (true) {
+            if (_inputPtr >= _inputEnd) {
+                loadMoreGuaranteed();
+            }
+            char c = _inputBuffer[_inputPtr++];
+            if (TYPES[c] != 0) {
+                switch (TYPES[c]) {
+                    case XmlCharTypes.CT_INVALID:
+                        c = handleInvalidXmlChar(c);
+                    case XmlCharTypes.CT_WS_CR:
+                    {
+                        if (_inputPtr >= _inputEnd) {
+                            loadMoreGuaranteed();
+                        }
+                        if (_inputBuffer[_inputPtr] == '\n') {
+                            ++_inputPtr;
+                        }
+                        markLF();
+                    }
+                    c = '\n';
+                    break;
+                    case XmlCharTypes.CT_WS_LF:
+                        markLF();
+                        break;
+
+                    case XmlCharTypes.CT_ATTR_QUOTE:
+                        if (c == quoteChar) {
+                            break main_loop;
+                        }
+                }
+            }
+            if (outPtr >= outputBuffer.length) {
+                _nameBuffer = outputBuffer = DataUtil.growArrayBy(outputBuffer, outputBuffer.length);
+                outPtr = 0;
+            }
+            outputBuffer[outPtr++] = c;
+        }
+        return new String(outputBuffer, 0, outPtr);
+    }
+
+    /*
+    /**********************************************************************
+    /* Other parsing helper methods
+    /**********************************************************************
+     */
+
+    /**
+     * This method is called to verify that a surrogate
+     * pair found describes a legal surrogate pair (ie. expands
+     * to a legal XML char)
+     */
+    private char checkSurrogate(char firstChar)
+            throws XMLStreamException
+    {
+        if (firstChar >= 0xDC00) {
+            reportInvalidFirstSurrogate(firstChar);
+        }
+        if (_inputPtr >= _inputEnd) {
+            loadMoreGuaranteed();
+        }
+        char sec = _inputBuffer[_inputPtr++];
+        if (sec < 0xDC00 || sec >= 0xE000) {
+            reportInvalidSecondSurrogate(sec);
+        }
+        // And the composite, is it ok?
+        int val = ((firstChar - 0xD800) << 10) + 0x10000;
+        if (val > XmlConsts.MAX_UNICODE_CHAR) {
+            reportInvalidXmlChar(val);
+        }
+        return sec;
+    }
+
+    private int checkSurrogateNameChar(char firstChar, char sec, int index)
+            throws XMLStreamException
+    {
+        if (firstChar >= 0xDC00) {
+            reportInvalidFirstSurrogate(firstChar);
+        }
+        if (sec < 0xDC00 || sec >= 0xE000) {
+            reportInvalidSecondSurrogate(sec);
+        }
+        // And the composite, is it ok?
+        int val = ((firstChar - 0xD800) << 10) + 0x10000;
+        if (val > XmlConsts.MAX_UNICODE_CHAR) {
+            reportInvalidXmlChar(val);
+        }
+        // !!! TODO: xml 1.1 vs 1.0 rules: none valid for 1.0, many for 1.1
+        if (true) {
+            reportInvalidNameChar(val, index);
+        }
+        return val;
+    }
+
+    /**
+     * This method is similar to <code>checkSurrogate</code>, but
+     * returns the actual character code encoded by the surrogate
+     * pair. This is needed if further validation rules (such as name
+     * charactert checks) are to be done.
+     */
+    private int decodeSurrogate(char firstChar)
+            throws XMLStreamException
+    {
+        if (firstChar >= 0xDC00) {
+            reportInvalidFirstSurrogate(firstChar);
+        }
+        if (_inputPtr >= _inputEnd) {
+            loadMoreGuaranteed();
+        }
+        char sec = _inputBuffer[_inputPtr++];
+        if (sec < 0xDC00 || sec >= 0xE000) {
+            reportInvalidSecondSurrogate(sec);
+        }
+        // And the composite, is it ok?
+        int val = ((firstChar - 0xD800) << 10) + 0x10000;
+        if (val > XmlConsts.MAX_UNICODE_CHAR) {
+            reportInvalidXmlChar(val);
+        }
+        return val;
+    }
+
+    private void reportInvalidFirstSurrogate(char ch)
+            throws XMLStreamException
+    {
+        reportInputProblem("Invalid surrogate character (code 0x"+Integer.toHexString((int) ch)+"): can not start a surrogate pair");
+    }
+
+    private void reportInvalidSecondSurrogate(char ch)
+            throws XMLStreamException
+    {
+        reportInputProblem("Invalid surrogate character (code "+Integer.toHexString((int) ch)+"): is not legal as the second part of a surrogate pair");
+    }
+
+    /*
+    /**********************************************************************
+    /* Location handling
+    /**********************************************************************
+     */
+
+    @Override
+    public XMLStreamLocation2 getCurrentLocation()
+    {
+        return LocationImpl.fromZeroBased
+                (_config.getPublicId(), _config.getSystemId(),
+                        _pastBytesOrChars + _inputPtr, _currRow, _inputPtr - _rowStartOffset);
+    }
+
+    @Override
+    public int getCurrentColumnNr() {
+        return _inputPtr - _rowStartOffset;
+    }
+
+    @Override
+    public long getStartingByteOffset() {
+        // N/A for this type
+        return -1L;
+    }
+
+    @Override
+    public long getStartingCharOffset() {
+        return _startRawOffset;
+    }
+
+    @Override
+    public long getEndingByteOffset() throws XMLStreamException {
+        // N/A for this type
+        return -1L;
+    }
+
+    @Override
+    public long getEndingCharOffset() throws XMLStreamException {
+        // Have to complete the token to know the ending location...
+        if (_tokenIncomplete) {
+            finishToken();
+        }
+        return _pastBytesOrChars + _inputPtr;
+    }
+
+    protected final void markLF(int offset)
+    {
+        _rowStartOffset = offset;
+        ++_currRow;
+    }
+
+    protected final void markLF()
+    {
+        _rowStartOffset = _inputPtr;
+        ++_currRow;
+    }
+
+    protected final void setStartLocation() {
+        _startRawOffset = _pastBytesOrChars + _inputPtr;
+        _startRow = _currRow;
+        _startColumn = _inputPtr - _rowStartOffset;
+    }
+    
+    /*
+    /**********************************************************************
+    /* Input loading
+    /**********************************************************************
+     */
+
+    @Override
+    protected final boolean loadMore() throws XMLStreamException
+    {
+        // If it's a block source, there's no Reader, or any more data:
+        if (_in == null) {
+            _inputEnd = 0;
+            return false;
+        }
+
+        // Otherwise let's update offsets:
+        _pastBytesOrChars += _inputEnd;
+        _rowStartOffset -= _inputEnd;
+        _inputPtr = 0;
+
+        try {
+            int count = _in.read(_inputBuffer, 0, _inputBuffer.length);
+            if (count < 1) {
+                _inputEnd = 0;
+                if (count == 0) {
+                    /* Sanity check; should never happen with correctly written
+                     * InputStreams...
+                     */
+                    reportInputProblem("Reader returned 0 bytes, even when asked to read up to "+_inputBuffer.length);
+                }
+                return false;
+            }
+            _inputEnd = count;
+            return true;
+        } catch (IOException ioe) {
+            throw new IoStreamException(ioe);
+        }
+    }
+
+    protected final char loadOne() throws XMLStreamException
+    {
+        if (!loadMore()) {
+            reportInputProblem("Unexpected end-of-input when trying to parse "+ErrorConsts.tokenTypeDesc(_currToken));
+        }
+        return _inputBuffer[_inputPtr++];
+    }
+
+    protected final char loadOne(int type)
+            throws XMLStreamException
+    {
+        if (!loadMore()) {
+            reportInputProblem("Unexpected end-of-input when trying to parse "+ErrorConsts.tokenTypeDesc(type));
+        }
+        return _inputBuffer[_inputPtr++];
+    }
+
+    protected final boolean loadAndRetain(int nrOfChars)
+            throws XMLStreamException
+    {
+        /* first: can't move, if we were handed an immutable block
+         * (alternative to handing Reader as _in)
+         */
+        if (_in == null) {
+            return false;
+        }
+
+        // otherwise, need to use cut'n pasted code from loadMore()...
+
+        _pastBytesOrChars += _inputPtr;
+        _rowStartOffset -= _inputPtr;
+
+        int remaining = (_inputEnd - _inputPtr); // must be > 0
+        System.arraycopy(_inputBuffer, _inputPtr, _inputBuffer, 0, remaining);
+        _inputPtr = 0;
+        _inputEnd = remaining; // temporarily set to cover copied stuff
+
+        try {
+            do {
+                int max = _inputBuffer.length - _inputEnd;
+                int count = _in.read(_inputBuffer, _inputEnd, max);
+                if (count < 1) {
+                    if (count == 0) {
+                        // Sanity check, should never happen with non-buggy readers/stream
+                        reportInputProblem("Reader returned 0 bytes, even when asked to read up to "+max);
+                    }
+                    return false;
+                }
+                _inputEnd += count;
+            } while (_inputEnd < nrOfChars);
+            return true;
+        } catch (IOException ioe) {
+            throw new IoStreamException(ioe);
+        }
+    }
+}

--- a/benchmark/src/main/java/com/fasterxml/aalto/sax/BenchmarkAaltoXMLReader.java
+++ b/benchmark/src/main/java/com/fasterxml/aalto/sax/BenchmarkAaltoXMLReader.java
@@ -1,0 +1,923 @@
+/* Woodstox Lite ("wool") XML processor
+ *
+ * Copyright (c) 2006- Tatu Saloranta, tatu.saloranta@iki.fi
+ *
+ * Licensed under the License specified in the file LICENSE which is
+ * included with the source code.
+ * You may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fasterxml.aalto.sax;
+
+import java.io.*;
+import java.net.URL;
+
+import javax.xml.parsers.SAXParser;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.xml.sax.*;
+import org.xml.sax.ext.Attributes2;
+import org.xml.sax.ext.DeclHandler;
+import org.xml.sax.ext.LexicalHandler;
+import org.xml.sax.ext.Locator2;
+import org.xml.sax.helpers.DefaultHandler;
+
+import com.fasterxml.aalto.in.*;
+import com.fasterxml.aalto.stax.InputFactoryImpl;
+import com.fasterxml.aalto.util.URLUtil;
+
+@SuppressWarnings("deprecation")
+public class BenchmarkAaltoXMLReader
+        extends SAXParser
+        implements Parser // SAX1
+        ,XMLReader // SAX2
+        ,Attributes2 // SAX2
+        ,Locator2 // SAX2
+{
+    final InputFactoryImpl _staxFactory;
+
+    /**
+     * Since the stream reader would mostly be just a wrapper around
+     * the underlying scanner (its main job is to implement Stax
+     * interface), we can and should just use the scanner. In effect,
+     * this class is then a replacement of StreamReaderImpl, when
+     * using SAX interfaces.
+     */
+    protected XmlScanner _scanner;
+
+    protected AttributeCollector _attrCollector;
+
+    // // // Listeners attached:
+
+    protected ContentHandler _contentHandler;
+    protected DTDHandler _dtdHandler;
+    private EntityResolver _entityResolver;
+    private ErrorHandler _errorHandler;
+
+    private LexicalHandler _lexicalHandler;
+    private DeclHandler _declHandler;
+
+    // // // State:
+
+    private int _attrCount;
+
+    /*
+    /**********************************************************************
+    /* Life-cycle
+    /**********************************************************************
+     */
+
+    public BenchmarkAaltoXMLReader()
+    {
+        InputFactoryImpl inputFactory = new InputFactoryImpl();
+        inputFactory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+
+        _staxFactory = inputFactory;
+    }
+
+    @Override
+    public final Parser getParser()
+    {
+        return this;
+    }
+
+    @Override
+    public final XMLReader getXMLReader()
+    {
+        return this;
+    }
+
+    /*
+    /**********************************************************************
+    /* Configuration, SAXParser
+    /**********************************************************************
+     */
+
+    @Override
+    public boolean isNamespaceAware() {
+        return true;
+    }
+
+    @Override
+    public boolean isValidating() {
+        return false;
+    }
+
+    @Override
+    public Object getProperty(String name)
+            throws SAXNotRecognizedException, SAXNotSupportedException
+    {
+        SAXProperty stdProp = SAXUtil.findStdProperty(name);
+        if (stdProp != null) {
+            switch (stdProp) {
+                case DECLARATION_HANDLER:
+                    return _declHandler;
+                case DOCUMENT_XML_VERSION:
+                    // as per [Issue 9], provide version info (is it ok to return potentially null?)
+                    return _scanner.getConfig().getXmlDeclVersion();
+                case DOM_NODE: // not implemented, won't be
+                    return null;
+                case LEXICAL_HANDLER:
+                    return _lexicalHandler;
+                case XML_STRING: // not implemented, won't be
+                    return null;
+            }
+        }
+        SAXUtil.reportUnknownProperty(name);
+        return null;
+    }
+
+    @Override
+    public void setProperty(String name, Object value)
+            throws SAXNotRecognizedException, SAXNotSupportedException
+    {
+        SAXProperty stdProp = SAXUtil.findStdProperty(name);
+
+        if (stdProp != null) {
+            switch (stdProp) {
+                case DECLARATION_HANDLER:
+                    _declHandler = (DeclHandler) value;
+                    return;
+                case DOCUMENT_XML_VERSION:
+                    // as per [Issue 9]:
+                    _scanner.getConfig().setXmlVersion((value == null) ? null : String.valueOf(value));
+                    return;
+                case DOM_NODE: // not implemented, won't be
+                    return;
+                case LEXICAL_HANDLER:
+                    _lexicalHandler = (LexicalHandler) value;
+                    return;
+                case XML_STRING: // not implemented, won't be
+                    return;
+            }
+        }
+        SAXUtil.reportUnknownFeature(name);
+    }
+
+    /*
+    /**********************************************************************
+    /* Overrides, SAXParser
+    /**********************************************************************
+     */
+
+    /* Have to override some methods from SAXParser; JDK
+     * implementation is sucky, as it tries to override
+     * many things it really should not...
+     */
+
+    @Override
+    public void parse(InputSource is, HandlerBase hb)
+            throws SAXException, IOException
+    {
+        if (hb != null) {
+            /* Ok: let's ONLY set if there are no explicit sets... not
+             * extremely clear, but JDK tries to set them always so
+             * let's at least do damage control.
+             */
+            if (_contentHandler == null) {
+                setDocumentHandler(hb);
+            }
+            if (_entityResolver == null) {
+                setEntityResolver(hb);
+            }
+            if (_errorHandler == null) {
+                setErrorHandler(hb);
+            }
+            if (_dtdHandler == null) {
+                setDTDHandler(hb);
+            }
+        }
+        parse(is);
+    }
+
+    @Override
+    public void parse(InputSource is, DefaultHandler dh)
+            throws SAXException, IOException
+    {
+        if (dh != null) {
+            /* Ok: let's ONLY set if there are no explicit sets... not
+             * extremely clear, but JDK tries to set them always so
+             * let's at least do damage control.
+             */
+            if (_contentHandler == null) {
+                setContentHandler(dh);
+            }
+            if (_entityResolver == null) {
+                setEntityResolver(dh);
+            }
+            if (_errorHandler == null) {
+                setErrorHandler(dh);
+            }
+            if (_dtdHandler == null) {
+                setDTDHandler(dh);
+            }
+        }
+        parse(is);
+    }
+
+    /*
+    /**********************************************************************
+    /* XLMReader (SAX2) implementation: cfg access
+    /**********************************************************************
+     */
+
+    @Override
+    public ContentHandler getContentHandler() {
+        return _contentHandler;
+    }
+
+    @Override
+    public DTDHandler getDTDHandler() {
+        return _dtdHandler;
+    }
+
+    @Override
+    public EntityResolver getEntityResolver() {
+        return _entityResolver;
+    }
+
+    @Override
+    public ErrorHandler getErrorHandler() {
+        return _errorHandler;
+    }
+
+    @Override
+    public boolean getFeature(String name)
+            throws SAXNotRecognizedException
+    {
+        // Standard feature?
+        SAXFeature stdFeat = SAXUtil.findStdFeature(name);
+        if (stdFeat != null) {
+            // fixed?
+            Boolean b = SAXUtil.getFixedStdFeatureValue(stdFeat);
+            if (b != null) {
+                return b.booleanValue();
+            }
+            // ok, may change:
+            switch (stdFeat) {
+                case IS_STANDALONE: // read-only, but only during parsing
+                    // !!! TBI
+                    return true;
+                default:
+            }
+        } else {
+            // any non-standard one we may support?
+        }
+
+        // nope, not recognized:
+        SAXUtil.reportUnknownFeature(name);
+        return false; // never gets here
+    }
+
+    // Already implemented for SAXParser
+    //public Object getProperty(String name)
+
+    /*
+    /**********************************************************************
+    /* XLMReader (SAX2) implementation: cfg changing
+    /**********************************************************************
+     */
+
+    @Override
+    public void setContentHandler(ContentHandler handler) {
+        _contentHandler = handler;
+    }
+
+    @Override
+    public void setDTDHandler(DTDHandler handler) {
+        _dtdHandler = handler;
+    }
+
+    @Override
+    public void setEntityResolver(EntityResolver resolver) {
+        _entityResolver = resolver;
+    }
+
+    @Override
+    public void setErrorHandler(ErrorHandler handler) {
+        _errorHandler = handler;
+    }
+
+    @Override
+    public void setFeature(String name, boolean value)
+            throws SAXNotRecognizedException
+    {
+        // Standard feature?
+        SAXFeature stdFeat = SAXUtil.findStdFeature(name);
+        if (stdFeat != null) {
+            //boolean ok;
+
+            // !!! TBI
+            /*
+            switch (stdFeat) {
+            }
+            */
+        } else {
+            SAXUtil.reportUnknownFeature(name);
+        }
+
+    }
+
+    // Already implemented for SAXParser
+    //public void setProperty(String name, Object value) 
+
+    /*
+    /**********************************************************************
+    /* XLMReader (SAX2) implementation: parsing
+    /**********************************************************************
+     */
+
+    @Override
+    public void parse(InputSource input) throws SAXException
+    {
+        String enc = input.getEncoding();
+        String systemId = input.getSystemId();
+        /* Let's ask for default (non-event-reader-bound) reader
+         * first. One open question: whether auto-closing needs to be
+         * forced? For now, let's assume not (second false, first is for
+         * 'isForEventReader')
+         */
+        ReaderConfig cfg = _staxFactory.getNonSharedConfig
+                (systemId, input.getPublicId(), enc, false, false);
+        /* But let's disable lazy parsing: with SAX there's no good
+         * way to make use of it (similar to why it's disabled for
+         * event readers)
+         */
+        cfg.doParseLazily(false);
+
+        // Let's figure out input, first, before sending start-doc event
+        InputStream is = null;
+        Reader r = input.getCharacterStream();
+        if (r == null) {
+            is = input.getByteStream();
+            if (is == null) {
+                if (systemId == null) {
+                    throw new SAXException("Invalid InputSource passed: neither character or byte stream passed, nor system id specified");
+                }
+                try {
+                    URL url = URLUtil.urlFromSystemId(systemId);
+                    is = URLUtil.inputStreamFromURL(url);
+                } catch (IOException ioe) {
+                    SAXException saxe = new SAXException(ioe);
+                    if (saxe.getCause() == null) {
+                        saxe.initCause(ioe);
+                    }
+                    throw saxe;
+                }
+            }
+        }
+
+        if (_contentHandler != null) {
+            _contentHandler.setDocumentLocator(this);
+            _contentHandler.startDocument();
+        }
+
+        try {
+            if (r != null) {
+                _scanner = BenchmarkCharSourceBootstrapper.construct(cfg, r).bootstrap();
+            } else {
+                _scanner = ByteSourceBootstrapper.construct(cfg, is).bootstrap();
+            }
+            _attrCollector = _scanner.getAttrCollector();
+            fireEvents();
+        } catch (XMLStreamException strex) {
+            throwSaxException(strex);
+        } finally {
+            if (_contentHandler != null) {
+                _contentHandler.endDocument();
+            }
+            /* Could try holding onto the buffers, too... but
+             * maybe it's better to allow them to be reclaimed, if
+             * needed by GC
+             */
+            if (_scanner != null) {
+                try {
+                    _scanner.close(false); // false -> no forced closing of source
+                } catch (XMLStreamException strex) {
+                    /* Hmmh. Should we bother trying to throw it? Should
+                     * never really happen as it can only occur from
+                     * stream.close() failing... which is a useless exception
+                     * if it can occur. So, for once, let's just supress it.
+                     */
+                    ; // intentional no-action
+                }
+                _scanner = null;
+            }
+            if (r != null) {
+                try {
+                    r.close();
+                } catch (IOException ioe) { /* whatever */ }
+            }
+            if (is != null) {
+                try {
+                    is.close();
+                } catch (IOException ioe) { /* whatever */ }
+            }
+        }
+    }
+
+    @Override
+    public void parse(String systemId) throws SAXException
+    {
+        InputSource src = new InputSource(systemId);
+        parse(src);
+    }
+
+    /*
+    /**********************************************************************
+    /* Parsing loop, helper methods
+    /**********************************************************************
+     */
+
+    /**
+     * This is the actual "tight event loop" that will send all events
+     * between start and end document events. Although we could
+     * use the stream reader here, there's not much as it mostly
+     * just forwards requests to the scanner: and so we can as well
+     * just copy the little code stream reader's next() method has.
+     */
+    private final void fireEvents()
+            throws SAXException, XMLStreamException
+    {
+        // First we are in prolog:
+        int type;
+
+        while ((type = _scanner.nextFromProlog(true)) != XMLStreamConstants.START_ELEMENT) {
+            fireAuxEvent(type, false);
+        }
+
+        // Now just starting the tree, need to process the START_ELEMENT
+        fireStartTag();
+
+        int depth = 1;
+        while (true) {
+            type = _scanner.nextFromTree();
+            if (type == XMLStreamConstants.START_ELEMENT) {
+                fireStartTag();
+                ++depth;
+            } else if (type == XMLStreamConstants.END_ELEMENT) {
+                fireEndTag();
+                if (--depth < 1) {
+                    break;
+                }
+            } else if (type == XMLStreamConstants.CHARACTERS) {
+                _scanner.fireSaxCharacterEvents(_contentHandler);
+            } else {
+                fireAuxEvent(type, true);
+            }
+        }
+
+        // And then epilog:
+        while (true) {
+            type = _scanner.nextFromProlog(false);
+            if (type == XmlScanner.TOKEN_EOI) {
+                break;
+            }
+            if (type == XmlScanner.SPACE) {
+                /* Not to be reported via SAX interface (which may or may not
+                 * be different from Stax)
+                 */
+                continue;
+            }
+            fireAuxEvent(type, false);
+        }
+    }
+
+    private final void fireAuxEvent(int type, boolean inTree)
+            throws SAXException, XMLStreamException
+    {
+        switch (type) {
+            case XMLStreamConstants.COMMENT:
+                _scanner.fireSaxCommentEvent(_lexicalHandler);
+                break;
+            case XMLStreamConstants.CDATA:
+                if (_lexicalHandler != null) {
+                    _lexicalHandler.startCDATA();
+                    _scanner.fireSaxCharacterEvents(_contentHandler);
+                    _lexicalHandler.endCDATA();
+                } else {
+                    _scanner.fireSaxCharacterEvents(_contentHandler);
+                }
+                break;
+            case XMLStreamConstants.DTD:
+                if (_lexicalHandler != null) {
+                    PName n = _scanner.getName();
+                    _lexicalHandler.startDTD(n.getPrefixedName(), _scanner.getDTDPublicId(),
+                            _scanner.getDTDSystemId());
+                    _lexicalHandler.endDTD();
+                }
+                break;
+            case XMLStreamConstants.PROCESSING_INSTRUCTION:
+                _scanner.fireSaxPIEvent(_contentHandler);
+                break;
+            case XMLStreamConstants.SPACE:
+                /* With SAX, only to be sent as an event if inside the
+                 * tree, not from within prolog/epilog
+                 */
+                if (inTree) {
+                    _scanner.fireSaxSpaceEvents(_contentHandler);
+                }
+                break;
+            case XMLStreamConstants.ENTITY_REFERENCE:
+                break;
+            default:
+                if (type == XmlScanner.TOKEN_EOI) {
+                    throwSaxException("Unexpected end-of-input in "+(inTree ? "tree" : "prolog"));
+                }
+                throw new RuntimeException("Internal error: unexpected type, "+type);
+        }
+    }
+
+    private final void fireStartTag()
+            throws SAXException
+    {
+        _attrCount = _scanner.getAttrCount();
+        _scanner.fireSaxStartElement(_contentHandler, this);
+    }
+
+    private final void fireEndTag()
+            throws SAXException
+    {
+        _scanner.fireSaxEndElement(_contentHandler);
+    }
+
+    /*
+    /**********************************************************************
+    /* Parser (SAX1) implementation
+    /**********************************************************************
+     */
+
+    // Already implemented for XMLReader:
+    //public void parse(InputSource source)
+    //public void parse(String systemId)
+    //public void setEntityResolver(EntityResolver resolver)
+    //public void setErrorHandler(ErrorHandler handler)
+
+    @Override
+    public void setDocumentHandler(DocumentHandler handler)
+    {
+        setContentHandler(new DocHandlerWrapper(handler));
+    }
+
+    @Override
+    public void setLocale(java.util.Locale locale)
+    {
+        // Not supported, let's just ignore
+    }
+
+    /*
+    /**********************************************************************
+    /* Attributes (SAX2) implementation
+    /**********************************************************************
+     */
+
+    @Override
+    public int getIndex(String qName)
+    {
+        return (_attrCollector == null) ? -1 :
+                _attrCollector.findIndex(null, qName);
+    }
+
+    @Override
+    public int getIndex(String uri, String localName)
+    {
+        return (_attrCollector == null) ? -1 :
+                _attrCollector.findIndex(uri, localName);
+    }
+
+    @Override
+    public int getLength()
+    {
+        return _attrCount;
+    }
+
+    @Override
+    public String getLocalName(int index)
+    {
+        return (index < 0 || index >= _attrCount) ? null :
+                _attrCollector.getName(index).getLocalName();
+    }
+
+    @Override
+    public String getQName(int index)
+    {
+        return (index < 0 || index >= _attrCount) ? null :
+                _attrCollector.getName(index).getPrefixedName();
+    }
+
+    @Override
+    public String getType(int index)
+    {
+        /* 13-Sep-2006, tatus: Note: not yet really implemented, will
+         *   just return "CDATA".
+         */
+        return (index < 0 || index >= _attrCount) ? null :
+                _scanner.getAttrType(index);
+    }
+
+    @Override
+    public String getType(String qName)
+    {
+        int ix = getIndex(qName);
+        return (ix < 0) ? null : _scanner.getAttrType(ix);
+    }
+
+    @Override
+    public String getType(String uri, String localName)
+    {
+        int ix = getIndex(uri, localName);
+        return (ix < 0) ? null : _scanner.getAttrType(ix);
+    }
+
+    @Override
+    public String getURI(int index)
+    {
+        if (index < 0 || index >= _attrCount) {
+            return null;
+        }
+        String uri = _attrCollector.getName(index).getNsUri();
+        return (uri == null) ? "" : uri;
+    }
+
+    @Override
+    public String getValue(int index)
+    {
+        return (index < 0 || index >= _attrCount) ? null :
+                _attrCollector.getValue(index);
+    }
+
+    @Override
+    public String getValue(String qName)
+    {
+        int ix = getIndex(qName);
+        return (ix < 0) ? null :  _attrCollector.getValue(ix);
+    }
+
+    @Override
+    public String getValue(String uri, String localName)
+    {
+        int ix = getIndex(uri, localName);
+        return (ix < 0) ? null :  _attrCollector.getValue(ix);
+    }
+
+    /*
+    /**********************************************************************
+    /* Attributes2 (SAX2) implementation
+    /**********************************************************************
+     */
+
+    /* Note: for now (in absence of DTD processing), none of attributes
+     * are declared, and all are specified (can not default without
+     * a DTD)
+     */
+
+    @Override
+    public boolean isDeclared(int index) {
+        return false;
+    }
+
+    @Override
+    public boolean isDeclared(String qName) {
+        return false;
+    }
+
+    @Override
+    public boolean isDeclared(String uri, String localName) {
+        return false;
+    }
+
+    @Override
+    public boolean isSpecified(int index) {
+        return true;
+    }
+
+    @Override
+    public boolean isSpecified(String qName) {
+        return true;
+    }
+
+    @Override
+    public boolean isSpecified(String uri, String localName) {
+        return true;
+    }
+
+    /*
+    /**********************************************************************
+    /* Locator (SAX1) implementation
+    /**********************************************************************
+     */
+
+    @Override
+    public int getColumnNumber() {
+        return (_scanner != null) ? _scanner.getCurrentColumnNr() : -1;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return (_scanner != null) ? _scanner.getCurrentLineNr() : -1;
+    }
+
+    @Override
+    public String getPublicId() {
+        return (_scanner != null) ? _scanner.getInputPublicId() : null;
+    }
+
+    @Override
+    public String getSystemId() {
+        return (_scanner != null) ? _scanner.getInputSystemId() : null;
+    }
+
+    /*
+    /**********************************************************************
+    /* Locator2 (SAX2) implementation
+    /**********************************************************************
+     */
+
+    @Override
+    public String getEncoding()
+    {
+        ReaderConfig cfg = _scanner.getConfig();
+        String enc = cfg.getActualEncoding();
+        if (enc == null) {
+            enc = cfg.getXmlDeclEncoding();
+            if (enc == null) {
+                enc = cfg.getExternalEncoding();
+            }
+        }
+        return enc;
+    }
+
+    @Override
+    public String getXMLVersion() {
+        return _scanner.getConfig().getXmlDeclVersion();
+    }
+
+    /*
+    /**********************************************************************
+    /* Internal methods
+    /**********************************************************************
+     */
+
+    private void throwSaxException(Exception e)
+            throws SAXException
+    {
+        SAXParseException se = new SAXParseException(e.getMessage(), (Locator) this, e);
+        if (se.getCause() == null) {
+            se.initCause(e);
+        }
+        if (_errorHandler != null) {
+            _errorHandler.fatalError(se);
+        }
+        throw se;
+    }
+
+    private void throwSaxException(String msg)
+            throws SAXException
+    {
+        SAXParseException se = new SAXParseException(msg, (Locator) this);
+        if (_errorHandler != null) {
+            _errorHandler.fatalError(se);
+        }
+        throw se;
+    }
+
+    /*
+    /**********************************************************************
+    /* Helper classes for SAX1 support
+    /**********************************************************************
+     */
+
+    final static class DocHandlerWrapper
+            implements ContentHandler
+    {
+        final DocumentHandler mDocHandler;
+
+        final AttributesWrapper mAttrWrapper = new AttributesWrapper();
+
+        DocHandlerWrapper(DocumentHandler h)
+        {
+            mDocHandler = h;
+        }
+
+        @Override
+        public void characters(char[] ch, int start, int length) throws SAXException {
+            mDocHandler.characters(ch, start, length);
+        }
+
+        @Override
+        public void endDocument() throws SAXException {
+            mDocHandler.endDocument();
+        }
+
+        @Override
+        public void endElement(String uri, String localName, String qName) throws SAXException
+        {
+            if (qName == null) {
+                qName = localName;
+            }
+            mDocHandler.endElement(qName);
+        }
+
+        @Override
+        public void endPrefixMapping(String prefix) {
+            // no equivalent in SAX1, ignore
+        }
+
+        @Override
+        public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException
+        {
+            mDocHandler.ignorableWhitespace(ch, start, length);
+        }
+
+        @Override
+        public void processingInstruction(String target, String data)
+                throws SAXException {
+            mDocHandler.processingInstruction(target, data);
+        }
+
+        @Override
+        public void setDocumentLocator(Locator locator) {
+            mDocHandler.setDocumentLocator(locator);
+        }
+
+        @Override
+        public void skippedEntity(String name) {
+            // no equivalent in SAX1, ignore
+        }
+
+        @Override
+        public void startDocument() throws SAXException
+        {
+            mDocHandler.startDocument();
+        }
+
+        @Override
+        public void startElement(String uri, String localName, String qName,
+                                 Attributes attrs)
+                throws SAXException
+        {
+            if (qName == null) {
+                qName = localName;
+            }
+            // Also, need to wrap Attributes to look like AttributeLost
+            mAttrWrapper.setAttributes(attrs);
+            mDocHandler.startElement(qName, mAttrWrapper);
+        }
+
+        @Override
+        public void startPrefixMapping(String prefix, String uri) {
+            // no equivalent in SAX1, ignore
+        }
+    }
+
+    final static class AttributesWrapper
+            implements AttributeList
+    {
+        Attributes mAttrs;
+
+        public AttributesWrapper() { }
+
+        public void setAttributes(Attributes a) {
+            mAttrs = a;
+        }
+
+        @Override
+        public int getLength() {
+            return mAttrs.getLength();
+        }
+
+        @Override
+        public String getName(int i) {
+            String n = mAttrs.getQName(i);
+            return (n == null) ? mAttrs.getLocalName(i) : n;
+        }
+
+        @Override
+        public String getType(int i) {
+            return mAttrs.getType(i);
+        }
+
+        @Override
+        public String getType(String name) {
+            return mAttrs.getType(name);
+        }
+
+        @Override
+        public String getValue(int i) {
+            return mAttrs.getValue(i);
+        }
+
+        @Override
+        public String getValue(String name) {
+            return mAttrs.getValue(name);
+        }
+    }
+}

--- a/benchmark/src/main/java/org/smooks/benchmark/BenchmarkApp.java
+++ b/benchmark/src/main/java/org/smooks/benchmark/BenchmarkApp.java
@@ -1,0 +1,166 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Benchmark
+ * %%
+ * Copyright (C) 2020 - 2021 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.benchmark;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.smooks.Smooks;
+import org.smooks.engine.DefaultApplicationContextBuilder;
+import org.xml.sax.SAXException;
+
+import javax.xml.transform.stream.StreamSource;
+import java.io.*;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.zip.GZIPInputStream;
+
+public class BenchmarkApp {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BenchmarkApp.class);
+
+    private static class CountingInputStream extends InputStream {
+        private final InputStream inputStream;
+        private long byteCount;
+        
+        public CountingInputStream(InputStream inputStream) {
+            this.inputStream = inputStream;
+        }
+        
+        @Override
+        public int read(byte[] b) throws IOException {
+            int bytesRead = inputStream.read(b);
+            if (bytesRead != -1) {
+                byteCount += bytesRead;
+            }
+            return bytesRead;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            int bytesRead = inputStream.read(b, off, len);
+            if (bytesRead != -1) {
+                byteCount += bytesRead;
+            }
+            return bytesRead;
+        }
+
+        @Override
+        public long skip(long n) throws IOException {
+            long bytesRead = inputStream.skip(n);
+            byteCount += bytesRead;
+            return bytesRead;
+        }
+
+        @Override
+        public int available() throws IOException {
+            return inputStream.available();
+        }
+
+        @Override
+        public void close() throws IOException {
+            inputStream.close();
+        }
+
+        @Override
+        public synchronized void mark(int readlimit) {
+            inputStream.mark(readlimit);
+        }
+
+        @Override
+        public synchronized void reset() throws IOException {
+            inputStream.reset();
+        }
+
+        @Override
+        public boolean markSupported() {
+            return inputStream.markSupported();
+        }
+
+        @Override
+        public int read() throws IOException {
+            int bytesRead = inputStream.read();
+            if (bytesRead != -1) {
+                byteCount++;
+            }
+            return bytesRead;
+        }
+
+        public long getByteCount() {
+            return byteCount;
+        }
+    }
+    
+    public static void main(String... args) throws IOException, SAXException {
+        final URL url = new URL("https://dblp.org/xml/release/dblp-2015-03-02.xml.gz");
+        final URLConnection connection = url.openConnection();
+        connection.setDoOutput(true);
+
+        final File testDatasetFile = File.createTempFile("dblp-2015-03-02", ".xml.gz");
+        final FileOutputStream fileOutputStream = new FileOutputStream(testDatasetFile);
+
+        LOGGER.info("Downloading test dataset...");
+        byte[] buf = new byte[8192];
+        int length;
+        while ((length = connection.getInputStream().read(buf)) > 0) {
+            fileOutputStream.write(buf, 0, length);
+        }
+
+        final Smooks smooks = new Smooks(new DefaultApplicationContextBuilder().setRegisterSystemResources(true).build());
+        smooks.addConfigurations(BenchmarkApp.class.getResourceAsStream("/smooks-config.xml"));
+        IntStream.range(0, Math.min(2, Runtime.getRuntime().availableProcessors())).parallel().forEach(value -> {
+            try {
+                final CountingInputStream inputStream = new CountingInputStream(new GZIPInputStream(new FileInputStream(testDatasetFile)));
+                LOGGER.info("Filtering...");
+                final long startTime = System.currentTimeMillis();
+                smooks.filterSource(new StreamSource(inputStream));
+                final long duration = System.currentTimeMillis() - startTime;
+                LOGGER.info("Filtered {} MBs in {} minutes", (inputStream.getByteCount() / 1024) / 1024, TimeUnit.MILLISECONDS.toMinutes(duration));
+            } catch (IOException e) {
+                LOGGER.error(e.getMessage(), e);
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/benchmark/src/main/java/org/smooks/benchmark/BenchmarkVisitor.java
+++ b/benchmark/src/main/java/org/smooks/benchmark/BenchmarkVisitor.java
@@ -1,0 +1,68 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Benchmark
+ * %%
+ * Copyright (C) 2020 - 2021 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.benchmark;
+
+import org.smooks.api.ExecutionContext;
+import org.smooks.api.resource.visitor.sax.ng.ElementVisitor;
+import org.w3c.dom.CharacterData;
+import org.w3c.dom.Element;
+
+public class BenchmarkVisitor implements ElementVisitor {
+    @Override
+    public void visitAfter(Element element, ExecutionContext executionContext) {
+
+    }
+
+    @Override
+    public void visitBefore(Element element, ExecutionContext executionContext) {
+    }
+
+    @Override
+    public void visitChildText(CharacterData characterData, ExecutionContext executionContext) {
+
+    }
+
+    @Override
+    public void visitChildElement(Element childElement, ExecutionContext executionContext) {
+    }
+}

--- a/benchmark/src/main/java/org/smooks/benchmark/BibliographyVisitor.java
+++ b/benchmark/src/main/java/org/smooks/benchmark/BibliographyVisitor.java
@@ -1,0 +1,82 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Benchmark
+ * %%
+ * Copyright (C) 2020 - 2021 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.benchmark;
+
+import org.jaxen.JaxenException;
+import org.jaxen.dom.DOMXPath;
+import org.smooks.api.ExecutionContext;
+import org.smooks.api.SmooksException;
+import org.smooks.api.resource.visitor.sax.ng.AfterVisitor;
+import org.smooks.io.Stream;
+import org.w3c.dom.Element;
+
+import javax.annotation.PostConstruct;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.IOException;
+import java.util.List;
+
+public class BibliographyVisitor implements AfterVisitor {
+    private final static String TEMPLATE = "<entry><author>%s</author><title>%s</title></entry>";
+    private DOMXPath domXPath;
+    private DOMXPath titleXPath;
+
+    @PostConstruct
+    public void postConstruct() throws JaxenException {
+        this.domXPath = new DOMXPath("//author");
+        this.titleXPath = new DOMXPath("//title");
+    }
+    
+    @Override
+    public void visitAfter(Element element, ExecutionContext executionContext) {
+        try {
+            List<Element> authors = ((List<Element>)domXPath.evaluate(element));
+            List<Element> titles = ((List<Element>)titleXPath.evaluate(element));
+            Stream.out(executionContext).write(String.format(TEMPLATE, authors.isEmpty() ? "N/A" : authors.get(0).getTextContent(), "<![CDATA[" + (titles.isEmpty() ? "N/A" : titles.get(0).getTextContent())) + "]]>");
+        } catch (IOException | JaxenException e) {
+            throw new SmooksException(e);
+        }
+    }
+}

--- a/benchmark/src/main/java/org/smooks/benchmark/CounterVisitor.java
+++ b/benchmark/src/main/java/org/smooks/benchmark/CounterVisitor.java
@@ -40,32 +40,25 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks;
+package org.smooks.benchmark;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.smooks.api.ExecutionContext;
+import org.smooks.api.TypedKey;
+import org.smooks.api.lifecycle.ExecutionLifecycleInitializable;
+import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
+import org.w3c.dom.Element;
 
-import javax.xml.transform.stream.StreamSource;
-import java.io.IOException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.util.concurrent.TimeUnit;
-import java.util.zip.GZIPInputStream;
+public class CounterVisitor implements BeforeVisitor, ExecutionLifecycleInitializable {
+    
+    private final TypedKey<Long> counterTypedKey = new TypedKey<>();
+    
+    @Override
+    public void visitBefore(Element element, ExecutionContext executionContext) {
+        executionContext.put(counterTypedKey, executionContext.get(counterTypedKey) + 1);
+    }
 
-public class BenchmarkApp {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(BenchmarkApp.class);
-
-    public static void main(String... args) throws IOException {
-        final URL url = new URL("https://dblp.org/xml/release/dblp-2015-03-02.xml.gz");
-        final URLConnection connection = url.openConnection();
-        connection.setDoOutput(true);
-
-        final Smooks smooks = new Smooks();
-        final long startTime = System.currentTimeMillis();
-        LOGGER.info("Filtering...");
-        smooks.filterSource(new StreamSource(new GZIPInputStream(connection.getInputStream())));
-        final long duration = System.currentTimeMillis() - startTime;
-        LOGGER.info("Filtering completed in {} minutes", TimeUnit.MILLISECONDS.toMinutes(duration));
+    @Override
+    public void executeExecutionLifecycleInitialize(ExecutionContext executionContext) {
+        executionContext.put(counterTypedKey, 0L);
     }
 }

--- a/benchmark/src/main/resources/smooks-config.xml
+++ b/benchmark/src/main/resources/smooks-config.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <!--
   ========================LICENSE_START=================================
-  Core
+  Benchmark
   %%
-  Copyright (C) 2020 Smooks
+  Copyright (C) 2020 - 2021 Smooks
   %%
   Licensed under the terms of the Apache License Version 2.0, or
   the GNU Lesser General Public License version 3.0 or later.
@@ -45,10 +45,35 @@
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
                       xmlns:core="https://www.smooks.org/xsd/smooks/smooks-core-1.6.xsd">
 
-    <core:node-reader>
-        <resource-config selector="#document">
-            <resource>org.smooks.engine.resource.reader.NodeReaderFunctionalTestCase$NodeReaderResource</resource>
-        </resource-config>
-    </core:node-reader>
+    <resource-config selector="org.xml.sax.driver">
+        <resource>com.fasterxml.aalto.sax.BenchmarkAaltoXMLReader</resource>
+    </resource-config>
+
+    <resource-config selector="global-parameters">
+        <param name="entities.rewrite">false</param>
+        <param name="default.serialization.on">false</param>
+    </resource-config>
+    
+    <resource-config selector="author">
+        <resource>org.smooks.benchmark.CounterVisitor</resource>
+    </resource-config>
+    
+    <core:smooks filterSourceOn="article,inproceedings,proceedings,book,incollection,phdthesis,mastersthesis,www" maxNodeDepth="0">
+        <core:config>
+            <smooks-resource-list>
+                <core:delegate-reader>
+                    <resource-config selector="#document">
+                        <resource>org.smooks.benchmark.BibliographyVisitor</resource>
+                    </resource-config>
+                </core:delegate-reader>
+                <resource-config selector="author">
+                    <resource>org.smooks.benchmark.BenchmarkVisitor</resource>
+                </resource-config>
+                <resource-config selector="title">
+                    <resource>org.smooks.benchmark.BenchmarkVisitor</resource>
+                </resource-config>
+            </smooks-resource-list>
+        </core:config>
+    </core:smooks>
 
 </smooks-resource-list>

--- a/commons/src/test/java/org/smooks/support/XmlUtilTestCase.java
+++ b/commons/src/test/java/org/smooks/support/XmlUtilTestCase.java
@@ -55,7 +55,6 @@ import java.io.StringReader;
 import java.io.StringWriter;
 
 import org.smooks.io.StreamUtils;
-import org.smooks.support.XmlUtil;
 import org.smooks.xml.LocalDTDEntityResolver;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -91,6 +91,17 @@
             <groupId>com.fasterxml</groupId>
             <artifactId>aalto-xml</artifactId>
             <version>1.2.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.woodstox</groupId>
+                    <artifactId>stax2-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>6.2.3</version>
         </dependency>
         <dependency>
             <groupId>xml-apis</groupId>

--- a/core/src/main/java/org/smooks/Smooks.java
+++ b/core/src/main/java/org/smooks/Smooks.java
@@ -569,8 +569,12 @@ public class Smooks {
                 executionContext.setTerminationError(t);
                 throw new SmooksException("Smooks Filtering operation failed.", t);
             } finally {
-                filter.cleanup();
                 AbstractFilter.removeCurrentFilter();
+                try {
+                    filter.close();
+                } catch (IOException e) {
+                    throw new SmooksException(e);
+                }
             }
         } finally {
             for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {

--- a/core/src/main/java/org/smooks/engine/DefaultExecutionContext.java
+++ b/core/src/main/java/org/smooks/engine/DefaultExecutionContext.java
@@ -60,10 +60,7 @@ import org.smooks.engine.bean.context.StandaloneBeanContextFactory;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
-import java.util.Collections;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Standalone Container Request implementation.
@@ -72,7 +69,7 @@ import java.util.Map;
 public class DefaultExecutionContext implements ExecutionContext {
 
     private final ProfileSet targetProfileSet;
-	private final Map<TypedKey<Object>, Object> attributes = new Hashtable<>();
+	private final Map<TypedKey<Object>, Object> attributes = new HashMap<>();
     private final ContentDeliveryRuntime contentDeliveryRuntime;
 	private final MementoCaretaker mementoCaretaker;
 	private final ApplicationContext applicationContext;

--- a/core/src/main/java/org/smooks/engine/bean/context/DefaultBeanIdStore.java
+++ b/core/src/main/java/org/smooks/engine/bean/context/DefaultBeanIdStore.java
@@ -52,7 +52,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class DefaultBeanIdStore implements BeanIdStore {
-    private volatile HashMap<String, BeanId> beanIdMap = new  HashMap<String, BeanId>();
+    private volatile HashMap<String, BeanId> beanIdMap = new HashMap<>();
 
     /**
      * registers a beanId name and returns the {@link BeanId} object.
@@ -116,7 +116,7 @@ public class DefaultBeanIdStore implements BeanIdStore {
      *
      */
     @Override
-    public synchronized Map<String, BeanId> getBeanIdMap() {
+    public Map<String, BeanId> getBeanIdMap() {
         return Collections.unmodifiableMap(beanIdMap);
     }
 

--- a/core/src/main/java/org/smooks/engine/delivery/DOMReader.java
+++ b/core/src/main/java/org/smooks/engine/delivery/DOMReader.java
@@ -1,0 +1,943 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Core
+ * %%
+ * Copyright (C) 2020 - 2021 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+/*
+ * Copyright 2001-2005 (C) MetaStuff, Ltd. All Rights Reserved.
+ *
+ * This software is open source.
+ * See the bottom of this file for the licence.
+ */
+
+package org.smooks.engine.delivery;
+
+import org.smooks.api.ExecutionContext;
+import org.smooks.api.resource.reader.SmooksXMLReader;
+import org.smooks.io.DocumentInputSource;
+import org.w3c.dom.*;
+import org.xml.sax.*;
+import org.xml.sax.ext.LexicalHandler;
+import org.xml.sax.helpers.AttributesImpl;
+import org.xml.sax.helpers.LocatorImpl;
+
+import javax.xml.XMLConstants;
+import javax.xml.namespace.QName;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * <p>
+ * <code>SAXWriter</code> writes a DOM tree to a SAX ContentHandler.
+ * </p>
+ * 
+ * @author <a href="mailto:james.strachan@metastuff.com">James Strachan </a>
+ * @version $Revision: 1.24 $
+ */
+public class DOMReader implements SmooksXMLReader {
+    protected static final String[] LEXICAL_HANDLER_NAMES = {
+            "http://xml.org/sax/properties/lexical-handler",
+            "http://xml.org/sax/handlers/LexicalHandler" };
+
+    protected static final String FEATURE_NAMESPACE_PREFIXES 
+            = "http://xml.org/sax/features/namespace-prefixes";
+
+    protected static final String FEATURE_NAMESPACES 
+            = "http://xml.org/sax/features/namespaces";
+
+    /** <code>ContentHandler</code> to which SAX events are raised */
+    private ContentHandler contentHandler;
+
+    /** <code>DTDHandler</code> fired when a document has a DTD */
+    private DTDHandler dtdHandler;
+
+    /** <code>EntityResolver</code> fired when a document has a DTD */
+    private EntityResolver entityResolver;
+
+    private ErrorHandler errorHandler;
+
+    /** <code>LexicalHandler</code> fired on Entity and CDATA sections */
+    private LexicalHandler lexicalHandler;
+
+    /** <code>AttributesImpl</code> used when generating the Attributes */
+    private AttributesImpl attributes = new AttributesImpl();
+
+    /** Stores the features */
+    private Map<String, Boolean> features = new HashMap();
+
+    /** Stores the properties */
+    private Map<String, Object> properties = new HashMap();
+
+    /** Whether namespace declarations are exported as attributes or not */
+    private boolean declareNamespaceAttributes;
+    private ExecutionContext executionContext;
+
+    public DOMReader() {
+        properties.put(FEATURE_NAMESPACE_PREFIXES, Boolean.FALSE);
+        properties.put(FEATURE_NAMESPACE_PREFIXES, Boolean.TRUE);
+    }
+
+    public DOMReader(ContentHandler contentHandler) {
+        this();
+        this.contentHandler = contentHandler;
+    }
+
+    public DOMReader(ContentHandler contentHandler,
+                     LexicalHandler lexicalHandler) {
+        this();
+        this.contentHandler = contentHandler;
+        this.lexicalHandler = lexicalHandler;
+    }
+
+    public DOMReader(ContentHandler contentHandler,
+                     LexicalHandler lexicalHandler, EntityResolver entityResolver) {
+        this();
+        this.contentHandler = contentHandler;
+        this.lexicalHandler = lexicalHandler;
+        this.entityResolver = entityResolver;
+    }
+
+    /**
+     * A polymorphic method to write any Node to this SAX stream
+     * 
+     * @param node
+     *            DOCUMENT ME!
+     * 
+     * @throws SAXException
+     *             DOCUMENT ME!
+     */
+    public void write(Node node) throws SAXException {
+        int nodeType = node.getNodeType();
+
+        switch (nodeType) {
+            case Node.ELEMENT_NODE:
+                write((Element) node);
+                break;
+
+            case Node.TEXT_NODE:
+                write(node.getTextContent());
+                break;
+
+            case Node.CDATA_SECTION_NODE:
+                write((CDATASection) node);
+                break;
+
+            case Node.ENTITY_REFERENCE_NODE:
+                write((Entity) node);
+                break;
+
+            case Node.PROCESSING_INSTRUCTION_NODE:
+                write((ProcessingInstruction) node);
+                break;
+
+            case Node.COMMENT_NODE:
+                write((Comment) node);
+                break;
+
+            case Node.DOCUMENT_NODE:
+                write((Document) node);
+                break;
+
+            case Node.DOCUMENT_TYPE_NODE:
+                write(node);
+                break;
+
+            default:
+                throw new SAXException("Invalid node type: " + node);
+        }
+    }
+
+    /**
+     * Generates SAX events for the given Document and all its content
+     * 
+     * @param document
+     *            is the Document to parse
+     * 
+     * @throws SAXException
+     *             if there is a SAX error processing the events
+     */
+    public void write(Document document) throws SAXException {
+        if (document != null) {
+            checkForNullHandlers();
+
+            documentLocator(document);
+            startDocument();
+            entityResolver(document);
+            dtdHandler(document);
+
+            writeContent(document, new Stack<>());
+            endDocument();
+        }
+    }
+
+    /**
+     * Generates SAX events for the given Element and all its content
+     * 
+     * @param element
+     *            is the Element to parse
+     * 
+     * @throws SAXException
+     *             if there is a SAX error processing the events
+     */
+    public void write(Element element) throws SAXException {
+        write(element, new Stack<>());
+    }
+
+    /**
+     * <p>
+     * Writes the opening tag of an {@link Element}, including its {@link
+     * Attribute}s but without its content.
+     * </p>
+     * 
+     * @param element
+     *            <code>Element</code> to output.
+     * 
+     * @throws SAXException
+     *             DOCUMENT ME!
+     */
+    public void writeOpen(Element element) throws SAXException {
+        startElement(element, null);
+    }
+
+    /**
+     * <p>
+     * Writes the closing tag of an {@link Element}
+     * </p>
+     * 
+     * @param element
+     *            <code>Element</code> to output.
+     * 
+     * @throws SAXException
+     *             DOCUMENT ME!
+     */
+    public void writeClose(Element element) throws SAXException {
+        endElement(element);
+    }
+
+    /**
+     * Generates SAX events for the given text
+     * 
+     * @param text
+     *            is the text to send to the SAX ContentHandler
+     * 
+     * @throws SAXException
+     *             if there is a SAX error processing the events
+     */
+    public void write(String text) throws SAXException {
+        if (text != null) {
+            char[] chars = text.toCharArray();
+            contentHandler.characters(chars, 0, chars.length);
+        }
+    }
+
+    /**
+     * Generates SAX events for the given CDATA
+     * 
+     * @param cdata
+     *            is the CDATA to parse
+     * 
+     * @throws SAXException
+     *             if there is a SAX error processing the events
+     */
+    public void write(CDATASection cdata) throws SAXException {
+        String text = cdata.getData();
+
+        if (lexicalHandler != null) {
+            lexicalHandler.startCDATA();
+            write(text);
+            lexicalHandler.endCDATA();
+        } else {
+            write(text);
+        }
+    }
+
+    /**
+     * Generates SAX events for the given Comment
+     * 
+     * @param comment
+     *            is the Comment to parse
+     * 
+     * @throws SAXException
+     *             if there is a SAX error processing the events
+     */
+    public void write(Comment comment) throws SAXException {
+        if (lexicalHandler != null) {
+            String text = comment.getData();
+            char[] chars = text.toCharArray();
+            lexicalHandler.comment(chars, 0, chars.length);
+        }
+    }
+
+    /**
+     * Generates SAX events for the given Entity
+     * 
+     * @param entity
+     *            is the Entity to parse
+     * 
+     * @throws SAXException
+     *             if there is a SAX error processing the events
+     */
+    public void write(Entity entity) throws SAXException {
+        String text = entity.getTextContent();
+
+        if (lexicalHandler != null) {
+            String name = entity.getNodeName();
+            lexicalHandler.startEntity(name);
+            write(text);
+            lexicalHandler.endEntity(name);
+        } else {
+            write(text);
+        }
+    }
+
+    /**
+     * Generates SAX events for the given ProcessingInstruction
+     * 
+     * @param pi
+     *            is the ProcessingInstruction to parse
+     * 
+     * @throws SAXException
+     *             if there is a SAX error processing the events
+     */
+    public void write(ProcessingInstruction pi) throws SAXException {
+        String target = pi.getTarget();
+        String text = pi.getData();
+        contentHandler.processingInstruction(target, text);
+    }
+
+    /**
+     * Should namespace declarations be converted to "xmlns" attributes. This
+     * property defaults to <code>false</code> as per the SAX specification.
+     * This property is set via the SAX feature
+     * "http://xml.org/sax/features/namespace-prefixes"
+     * 
+     * @return DOCUMENT ME!
+     */
+    public boolean isDeclareNamespaceAttributes() {
+        return declareNamespaceAttributes;
+    }
+
+    /**
+     * Sets whether namespace declarations should be exported as "xmlns"
+     * attributes or not. This property is set from the SAX feature
+     * "http://xml.org/sax/features/namespace-prefixes"
+     * 
+     * @param declareNamespaceAttrs
+     *            DOCUMENT ME!
+     */
+    public void setDeclareNamespaceAttributes(boolean declareNamespaceAttrs) {
+        this.declareNamespaceAttributes = declareNamespaceAttrs;
+    }
+
+    // XMLReader methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * DOCUMENT ME!
+     * 
+     * @return the <code>ContentHandler</code> called when SAX events are
+     *         raised
+     */
+    public ContentHandler getContentHandler() {
+        return contentHandler;
+    }
+
+    /**
+     * Sets the <code>ContentHandler</code> called when SAX events are raised
+     * 
+     * @param contentHandler
+     *            is the <code>ContentHandler</code> called when SAX events
+     *            are raised
+     */
+    public void setContentHandler(ContentHandler contentHandler) {
+        this.contentHandler = contentHandler;
+    }
+
+    /**
+     * DOCUMENT ME!
+     * 
+     * @return the <code>DTDHandler</code>
+     */
+    public DTDHandler getDTDHandler() {
+        return dtdHandler;
+    }
+
+    /**
+     * Sets the <code>DTDHandler</code>.
+     * 
+     * @param handler
+     *            DOCUMENT ME!
+     */
+    public void setDTDHandler(DTDHandler handler) {
+        this.dtdHandler = handler;
+    }
+
+    /**
+     * DOCUMENT ME!
+     * 
+     * @return the <code>ErrorHandler</code>
+     */
+    public ErrorHandler getErrorHandler() {
+        return errorHandler;
+    }
+
+    /**
+     * Sets the <code>ErrorHandler</code>.
+     * 
+     * @param errorHandler
+     *            DOCUMENT ME!
+     */
+    public void setErrorHandler(ErrorHandler errorHandler) {
+        this.errorHandler = errorHandler;
+    }
+
+    /**
+     * DOCUMENT ME!
+     * 
+     * @return the <code>EntityResolver</code> used when a Document contains a
+     *         DTD
+     */
+    public EntityResolver getEntityResolver() {
+        return entityResolver;
+    }
+
+    /**
+     * Sets the <code>EntityResolver</code>.
+     * 
+     * @param entityResolver
+     *            is the <code>EntityResolver</code>
+     */
+    public void setEntityResolver(EntityResolver entityResolver) {
+        this.entityResolver = entityResolver;
+    }
+
+    /**
+     * DOCUMENT ME!
+     * 
+     * @return the <code>LexicalHandler</code> used when a Document contains a
+     *         DTD
+     */
+    public LexicalHandler getLexicalHandler() {
+        return lexicalHandler;
+    }
+
+    /**
+     * Sets the <code>LexicalHandler</code>.
+     * 
+     * @param lexicalHandler
+     *            is the <code>LexicalHandler</code>
+     */
+    public void setLexicalHandler(LexicalHandler lexicalHandler) {
+        this.lexicalHandler = lexicalHandler;
+    }
+
+    /**
+     * Sets the <code>XMLReader</code> used to write SAX events to
+     * 
+     * @param xmlReader
+     *            is the <code>XMLReader</code>
+     */
+    public void setXMLReader(XMLReader xmlReader) {
+        setContentHandler(xmlReader.getContentHandler());
+        setDTDHandler(xmlReader.getDTDHandler());
+        setEntityResolver(xmlReader.getEntityResolver());
+        setErrorHandler(xmlReader.getErrorHandler());
+    }
+
+    /**
+     * Looks up the value of a feature.
+     * 
+     * @param name
+     *            DOCUMENT ME!
+     * 
+     * @return DOCUMENT ME!
+     * 
+     * @throws SAXNotRecognizedException
+     *             DOCUMENT ME!
+     * @throws SAXNotSupportedException
+     *             DOCUMENT ME!
+     */
+    public boolean getFeature(String name) throws SAXNotRecognizedException, SAXNotSupportedException {
+        Boolean answer = features.get(name);
+
+        return (answer != null) && answer;
+    }
+
+    /**
+     * This implementation does actually use any features but just stores them
+     * for later retrieval
+     * 
+     * @param name
+     *            DOCUMENT ME!
+     * @param value
+     *            DOCUMENT ME!
+     * 
+     * @throws SAXNotRecognizedException
+     *             DOCUMENT ME!
+     * @throws SAXNotSupportedException
+     *             DOCUMENT ME!
+     */
+    public void setFeature(String name, boolean value)
+            throws SAXNotRecognizedException, SAXNotSupportedException {
+        if (FEATURE_NAMESPACE_PREFIXES.equals(name)) {
+            setDeclareNamespaceAttributes(value);
+        } else if (FEATURE_NAMESPACE_PREFIXES.equals(name)) {
+            if (!value) {
+                String msg = "Namespace feature is always supported in dom4j";
+                throw new SAXNotSupportedException(msg);
+            }
+        }
+
+        features.put(name, (value) ? Boolean.TRUE : Boolean.FALSE);
+    }
+
+    /**
+     * Sets the given SAX property
+     * 
+     * @param name
+     *            DOCUMENT ME!
+     * @param value
+     *            DOCUMENT ME!
+     */
+    public void setProperty(String name, Object value) {
+        for (String lexicalHandlerName : LEXICAL_HANDLER_NAMES) {
+            if (lexicalHandlerName.equals(name)) {
+                setLexicalHandler((LexicalHandler) value);
+
+                return;
+            }
+        }
+
+        properties.put(name, value);
+    }
+
+    /**
+     * Gets the given SAX property
+     * 
+     * @param name
+     *            DOCUMENT ME!
+     * 
+     * @return DOCUMENT ME!
+     * 
+     * @throws SAXNotRecognizedException
+     *             DOCUMENT ME!
+     * @throws SAXNotSupportedException
+     *             DOCUMENT ME!
+     */
+    public Object getProperty(String name) throws SAXNotRecognizedException,
+            SAXNotSupportedException {
+        for (String lexicalHandlerName : LEXICAL_HANDLER_NAMES) {
+            if (lexicalHandlerName.equals(name)) {
+                return getLexicalHandler();
+            }
+        }
+
+        return properties.get(name);
+    }
+
+    /**
+     * This method is not supported.
+     * 
+     * @param systemId
+     *            DOCUMENT ME!
+     * 
+     * @throws SAXNotSupportedException
+     *             DOCUMENT ME!
+     */
+    public void parse(String systemId) throws SAXNotSupportedException {
+        throw new SAXNotSupportedException("This XMLReader can only accept"
+                + " <dom4j> InputSource objects");
+    }
+
+    /**
+     * Parses an XML document. This method can only accept DocumentInputSource
+     * inputs otherwise a {@link SAXNotSupportedException}exception is thrown.
+     * 
+     * @param input
+     *            DOCUMENT ME!
+     * 
+     * @throws SAXException
+     *             DOCUMENT ME!
+     * @throws SAXNotSupportedException
+     *             if the input source is not wrapping a dom4j document
+     */
+    public void parse(InputSource input) throws SAXException {
+        if (input instanceof DocumentInputSource) {
+            Document document = ((DocumentInputSource) input).getDocument();
+            write(document);
+        } else {
+            throw new SAXNotSupportedException("This XMLReader can only accept " + "<dom4j> InputSource objects");
+        }
+    }
+
+    // Implementation methods
+    // -------------------------------------------------------------------------
+    protected void writeContent(Node branch, Stack<QName> namespaceStack) throws SAXException {
+        NodeList childNodes = branch.getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node childNode = childNodes.item(i);
+
+            if (childNode instanceof Element) {
+                write((Element) childNode, namespaceStack);
+            } else if (childNode instanceof CharacterData) {
+                if (childNode instanceof CDATASection) {
+                    write((CDATASection) childNode);
+                } else if (childNode instanceof Text) {
+                    Text text = (Text) childNode;
+                    write(text.getData());
+                } else if (childNode instanceof Comment) {
+                    write((Comment) childNode);
+                } else {
+                    throw new SAXException("Invalid node in DOM content: " + childNode + " of type: " + childNode.getClass());
+                }
+            } else if (childNode instanceof Entity) {
+                write((Entity) childNode);
+            } else if (childNode instanceof ProcessingInstruction) {
+                write((ProcessingInstruction) childNode);
+            } else {
+                throw new SAXException("Invalid node in DOM content: " + childNode);
+            }
+        }
+    }
+
+    /**
+     * The {@link org.xml.sax.Locator}is only really useful when parsing a
+     * textual document as its main purpose is to identify the line and column
+     * number. Since we are processing an in memory tree which will probably
+     * have its line number information removed, we'll just use -1 for the line
+     * and column numbers.
+     * 
+     * @param document
+     *            DOCUMENT ME!
+     * 
+     * @throws SAXException
+     *             DOCUMENT ME!
+     */
+    protected void documentLocator(Document document) throws SAXException {
+        LocatorImpl locator = new LocatorImpl();
+
+        String publicID = null;
+        String systemID = null;
+        DocumentType docType = document.getDoctype();
+
+        if (docType != null) {
+            publicID = docType.getPublicId();
+            systemID = docType.getSystemId();
+        }
+
+        if (publicID != null) {
+            locator.setPublicId(publicID);
+        }
+
+        if (systemID != null) {
+            locator.setSystemId(systemID);
+        }
+
+        locator.setLineNumber(-1);
+        locator.setColumnNumber(-1);
+
+        contentHandler.setDocumentLocator(locator);
+    }
+
+    protected void entityResolver(Document document) throws SAXException {
+        if (entityResolver != null) {
+            DocumentType docType = document.getDoctype();
+
+            if (docType != null) {
+                String publicID = docType.getPublicId();
+                String systemID = docType.getSystemId();
+
+                if ((publicID != null) || (systemID != null)) {
+                    try {
+                        entityResolver.resolveEntity(publicID, systemID);
+                    } catch (IOException e) {
+                        throw new SAXException("Could not resolve publicID: "
+                                + publicID + " systemID: " + systemID, e);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * We do not yet support DTD or XML Schemas so this method does nothing
+     * right now.
+     * 
+     * @param document
+     *            DOCUMENT ME!
+     * 
+     * @throws SAXException
+     *             DOCUMENT ME!
+     */
+    protected void dtdHandler(Document document) throws SAXException {
+    }
+
+    protected void startDocument() throws SAXException {
+        contentHandler.startDocument();
+    }
+
+    protected void endDocument() throws SAXException {
+        contentHandler.endDocument();
+    }
+
+    protected void write(Element element, Stack<QName> namespaceStack)
+            throws SAXException {
+        int stackSize = namespaceStack.size();
+        AttributesImpl namespaceAttributes = startPrefixMapping(element, namespaceStack);
+        startElement(element, namespaceAttributes);
+        writeContent(element, namespaceStack);
+        endElement(element);
+        endPrefixMapping(namespaceStack, stackSize);
+    }
+
+    /**
+     * Fires a SAX startPrefixMapping event for all the namespaceStack which
+     * have just come into scope
+     * 
+     * @param element
+     *            DOCUMENT ME!
+     * @param namespaceStack
+     *            DOCUMENT ME!
+     * 
+     * @return DOCUMENT ME!
+     * 
+     * @throws SAXException
+     *             DOCUMENT ME!
+     */
+    protected AttributesImpl startPrefixMapping(Element element, Stack<QName> namespaceStack) throws SAXException {
+        AttributesImpl namespaceAttributes = null;
+
+        // start with the namespace of the element
+        String elementNamespace = element.getNamespaceURI();
+        final QName elementQName;
+        String elementLocalName = element.getLocalName() == null ? element.getNodeName() : element.getLocalName();
+        if (element.getPrefix() == null) {
+            elementQName = new QName(elementNamespace, elementLocalName);
+        } else {
+            elementQName = new QName(elementNamespace, elementLocalName, element.getPrefix());
+        }
+        
+        if ((elementNamespace != null) && !isIgnoreableNamespace(elementQName, namespaceStack)) {
+            namespaceStack.push(elementQName);
+            contentHandler.startPrefixMapping(element.getPrefix(), elementNamespace);
+            namespaceAttributes = addNamespaceAttribute(namespaceAttributes, elementQName);
+        }
+
+        NamedNodeMap attributes = element.getAttributes();
+        for (int i = 0; i < attributes.getLength(); i++) {
+            Node attribute = attributes.item(i);
+            String attrLocalName = attribute.getLocalName() == null ? attribute.getNodeName() : attribute.getLocalName();
+            if (attribute.getNamespaceURI() != null && attribute.getNamespaceURI().equals(XMLConstants.XML_NS_URI) && isIgnoreableNamespace(new QName(attribute.getNodeValue(), attrLocalName), namespaceStack)) {
+                QName attrQName = new QName(attribute.getNodeValue(), attrLocalName);
+                namespaceStack.push(attrQName);
+                contentHandler.startPrefixMapping(attrLocalName, attribute.getNodeValue());
+                namespaceAttributes = addNamespaceAttribute(namespaceAttributes, attrQName);
+            }
+        }
+
+        return namespaceAttributes;
+    }
+
+    /**
+     * Fires a SAX endPrefixMapping event for all the namespaceStack which have
+     * gone out of scope
+     * 
+     * @param stack
+     *            DOCUMENT ME!
+     * @param stackSize
+     *            DOCUMENT ME!
+     * 
+     * @throws SAXException
+     *             DOCUMENT ME!
+     */
+    protected void endPrefixMapping(Stack<QName> stack, int stackSize) throws SAXException {
+        while (stack.size() > stackSize) {
+            QName namespace = stack.pop();
+
+            if (namespace != null) {
+                contentHandler.endPrefixMapping(namespace.getPrefix());
+            }
+        }
+    }
+
+    protected void startElement(Element element, AttributesImpl namespaceAttributes) throws SAXException {
+        String localName = element.getLocalName() == null ? element.getNodeName() : element.getLocalName();
+        contentHandler.startElement(element.getNamespaceURI(), localName, getQName(element.getPrefix(), localName), createAttributes(element, namespaceAttributes));
+    }
+
+    protected void endElement(Element element) throws SAXException {
+        String localName = element.getLocalName() == null ? element.getNodeName() : element.getLocalName();
+        contentHandler.endElement(element.getNamespaceURI(), localName, getQName(element.getPrefix(), localName));
+    }
+
+    protected Attributes createAttributes(Element element, Attributes namespaceAttributes) throws SAXException {
+        attributes.clear();
+
+        if (namespaceAttributes != null) {
+            attributes.setAttributes(namespaceAttributes);
+        }
+        
+        NamedNodeMap attributes = element.getAttributes();
+        for (int i = 0; i < attributes.getLength(); i++) {
+            Node attribute = attributes.item(i);
+            String localName = attribute.getLocalName() == null ? attribute.getNodeName() : attribute.getLocalName();
+            this.attributes.addAttribute(attribute.getNamespaceURI(), localName, getQName(attribute.getPrefix(), localName), "CDATA", attribute.getNodeValue()); 
+        }
+        
+        return this.attributes;
+    }
+
+    /**
+     * If isDelcareNamespaceAttributes() is enabled then this method will add
+     * the given namespace declaration to the supplied attributes object,
+     * creating one if it does not exist.
+     * 
+     * @param attrs
+     *            DOCUMENT ME!
+     * @param namespace
+     *            DOCUMENT ME!
+     * 
+     * @return DOCUMENT ME!
+     */
+    protected AttributesImpl addNamespaceAttribute(AttributesImpl attrs, QName namespace) {
+        if (declareNamespaceAttributes) {
+            if (attrs == null) {
+                attrs = new AttributesImpl();
+            }
+
+            String prefix = namespace.getPrefix();
+            String qualifiedName = "xmlns";
+
+            String localName;
+            if ((prefix != null) && (prefix.length() > 0)) {
+                qualifiedName = "xmlns:" + prefix;
+                localName = prefix;
+            } else {
+                localName = qualifiedName;
+            }
+
+            String uri = "";
+            String type = "CDATA";
+            String value = namespace.getNamespaceURI();
+
+            attrs.addAttribute(uri, localName, qualifiedName, type, value);
+        }
+
+        return attrs;
+    }
+
+    /**
+     * DOCUMENT ME!
+     * 
+     * @param namespace
+     *            DOCUMENT ME!
+     * @param namespaceStack
+     *            DOCUMENT ME!
+     * 
+     * @return true if the given namespace is an ignorable namespace (such as
+     *         Namespace.NO_NAMESPACE or Namespace.XML_NAMESPACE) or if the
+     *         namespace has already been declared in the current scope
+     */
+    protected boolean isIgnoreableNamespace(QName namespace, Stack<QName> namespaceStack) {
+        if ((namespace.getPrefix().equals(XMLConstants.DEFAULT_NS_PREFIX) && namespace.getNamespaceURI().equals(XMLConstants.NULL_NS_URI)) || (namespace.getPrefix().equals(XMLConstants.XML_NS_PREFIX) && namespace.getNamespaceURI().equals(XMLConstants.XML_NS_URI))) {
+            return true;
+        }
+
+        for (QName qName : namespaceStack) {
+            if (qName.getPrefix().equals(namespace.getPrefix()) && qName.getNamespaceURI().equals(namespace.getNamespaceURI())) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+
+    /**
+     * Ensures non-null content handlers?
+     */
+    protected void checkForNullHandlers() {
+    }
+
+    protected String getQName(String prefix, String localName) {
+        return (prefix != null && prefix.length() > 0) ? prefix + ":" + localName : localName;
+    }
+
+    @Override
+    public void setExecutionContext(ExecutionContext executionContext) {
+        this.executionContext = executionContext;
+    }
+}
+
+/*
+ * Redistribution and use of this software and associated documentation
+ * ("Software"), with or without modification, are permitted provided that the
+ * following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain copyright statements and
+ * notices. Redistributions must also contain a copy of this document.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 
+ * 3. The name "DOM4J" must not be used to endorse or promote products derived
+ * from this Software without prior written permission of MetaStuff, Ltd. For
+ * written permission, please contact dom4j-info@metastuff.com.
+ * 
+ * 4. Products derived from this Software may not be called "DOM4J" nor may
+ * "DOM4J" appear in their names without prior written permission of MetaStuff,
+ * Ltd. DOM4J is a registered trademark of MetaStuff, Ltd.
+ * 
+ * 5. Due credit should be given to the DOM4J Project - http://www.dom4j.org
+ * 
+ * THIS SOFTWARE IS PROVIDED BY METASTUFF, LTD. AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL METASTUFF, LTD. OR ITS CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * 
+ * Copyright 2001-2005 (C) MetaStuff, Ltd. All Rights Reserved.
+ */

--- a/core/src/main/java/org/smooks/engine/delivery/DefaultContentDeliveryConfigBuilder.java
+++ b/core/src/main/java/org/smooks/engine/delivery/DefaultContentDeliveryConfigBuilder.java
@@ -304,7 +304,7 @@ public class DefaultContentDeliveryConfigBuilder implements ContentDeliveryConfi
         }
 
         // Add it to the sorted resourceConfigTable...
-        final List<ResourceConfig> resourceConfigs = resourceConfigTable.computeIfAbsent(element, k -> new Vector<>());
+        final List<ResourceConfig> resourceConfigs = resourceConfigTable.computeIfAbsent(element, k -> new ArrayList<>());
         if(!resourceConfigs.contains(resourceConfig)) {
             resourceConfigs.add(resourceConfig);
         }
@@ -324,7 +324,7 @@ public class DefaultContentDeliveryConfigBuilder implements ContentDeliveryConfi
                 ResourceConfigSortComparator sortComparator = new DefaultResourceConfigSortComparator(profileSet);
 
                 Arrays.sort(resourceConfigs, sortComparator);
-                entry.setValue(new Vector<>(Arrays.asList(resourceConfigs)));
+                entry.setValue(new ArrayList<>(Arrays.asList(resourceConfigs)));
             }
         }
     }

--- a/core/src/main/java/org/smooks/engine/delivery/DefaultContentHandlerBinding.java
+++ b/core/src/main/java/org/smooks/engine/delivery/DefaultContentHandlerBinding.java
@@ -57,6 +57,7 @@ import java.util.Objects;
 public class DefaultContentHandlerBinding<T extends ContentHandler> implements ContentHandlerBinding<T> {
     private final T contentHandler;
     private final ResourceConfig resourceConfig;
+    private int hash;
 
     /**
      * Public constructor.
@@ -112,6 +113,10 @@ public class DefaultContentHandlerBinding<T extends ContentHandler> implements C
 
     @Override
     public int hashCode() {
-        return Objects.hash(contentHandler, resourceConfig);
+        if (hash == 0) {
+            hash = Objects.hash(contentHandler, resourceConfig);
+        }
+
+        return hash;
     }
 }

--- a/core/src/main/java/org/smooks/engine/delivery/DynamicReaderPool.java
+++ b/core/src/main/java/org/smooks/engine/delivery/DynamicReaderPool.java
@@ -1,0 +1,82 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Core
+ * %%
+ * Copyright (C) 2020 - 2021 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.engine.delivery;
+
+import org.smooks.api.delivery.ReaderPool;
+import org.xml.sax.XMLReader;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+public class DynamicReaderPool implements ReaderPool {
+    private final AtomicReference<AtomicReferenceArray<XMLReader>> xmlReaderPoolReference = new AtomicReference<>();
+
+    public DynamicReaderPool() {
+        xmlReaderPoolReference.set(new AtomicReferenceArray<>(16));
+    }
+    
+    @Override
+    public XMLReader borrowXMLReader() {
+        final AtomicReferenceArray<XMLReader> readerPool = xmlReaderPoolReference.get();
+        for (int i = 0; i < readerPool.length(); i++) {
+            final XMLReader xmlReader = readerPool.getAndSet(i, null);
+            if (xmlReader != null) {
+                return xmlReader;
+            }
+        }
+
+        return null;
+    }
+    
+    @Override
+    public void returnXMLReader(final XMLReader xmlReader) {
+        final AtomicReferenceArray<XMLReader> xmlReaderPool = xmlReaderPoolReference.get();
+        for (int i = 0; i < xmlReaderPool.length(); i++) {
+            if (xmlReaderPool.compareAndSet(i, null, xmlReader)) {
+                return;
+            }
+        }
+        
+        xmlReaderPoolReference.compareAndSet(xmlReaderPool, new AtomicReferenceArray<>(xmlReaderPool.length() * 2));
+    }
+}

--- a/core/src/main/java/org/smooks/engine/delivery/SelectorTable.java
+++ b/core/src/main/java/org/smooks/engine/delivery/SelectorTable.java
@@ -47,6 +47,7 @@ import org.smooks.api.delivery.ContentHandler;
 import org.smooks.api.delivery.ContentHandlerBinding;
 import org.smooks.engine.delivery.ordering.Sorter;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import java.util.*;
 
 /**
@@ -54,6 +55,7 @@ import java.util.*;
  * 
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
+@NotThreadSafe
 public class SelectorTable<T extends ContentHandler> implements Map<String, List<ContentHandlerBinding<T>>> {
 
     private final Map<String, List<ContentHandlerBinding<T>>> contentHandlerBindingsBySelector = new LinkedHashMap<>();
@@ -76,7 +78,7 @@ public class SelectorTable<T extends ContentHandler> implements Map<String, List
      * @param contentHandlerBinding The mapping instance to be added.
      */
     public void put(String selector, ContentHandlerBinding<T> contentHandlerBinding) {
-        List<ContentHandlerBinding<T>> contentHandlerBindings = contentHandlerBindingsBySelector.computeIfAbsent(selector, k -> new Vector<>());
+        List<ContentHandlerBinding<T>> contentHandlerBindings = contentHandlerBindingsBySelector.computeIfAbsent(selector, k -> new ArrayList<>());
         contentHandlerBindings.add(contentHandlerBinding);
     }
     
@@ -86,7 +88,7 @@ public class SelectorTable<T extends ContentHandler> implements Map<String, List
      * @return The combined {@link ContentHandlerBinding} list for the supplied list of selector strings,
      * or an empty list if there are none.
      */
-    public List<ContentHandlerBinding<T>> get(String[] selectors) {
+    public List<ContentHandlerBinding<T>> get(String... selectors) {
         List<ContentHandlerBinding<T>> collectedContentHandlerBindings = new ArrayList<>();
 
         for (String selector : selectors) {

--- a/core/src/main/java/org/smooks/engine/delivery/SmooksContentHandler.java
+++ b/core/src/main/java/org/smooks/engine/delivery/SmooksContentHandler.java
@@ -178,5 +178,5 @@ public abstract class SmooksContentHandler extends DefaultHandler2 implements SA
         nestedContentHandler = null;
     }
 
-    public abstract void cleanup();
+    public abstract void close();
 }

--- a/core/src/main/java/org/smooks/engine/delivery/dom/DOMBuilder.java
+++ b/core/src/main/java/org/smooks/engine/delivery/dom/DOMBuilder.java
@@ -211,7 +211,7 @@ public class DOMBuilder extends SmooksContentHandler {
     }
 
     @Override
-    public void cleanup() {
+    public void close() {
     }
 
     private String getCurPath() {

--- a/core/src/main/java/org/smooks/engine/delivery/dom/SmooksDOMFilter.java
+++ b/core/src/main/java/org/smooks/engine/delivery/dom/SmooksDOMFilter.java
@@ -320,7 +320,7 @@ public class SmooksDOMFilter extends AbstractFilter {
     }
 
     @Override
-    public void cleanup() {
+    public void close() {
     }
 
     /**

--- a/core/src/main/java/org/smooks/engine/delivery/interceptor/ExceptionInterceptor.java
+++ b/core/src/main/java/org/smooks/engine/delivery/interceptor/ExceptionInterceptor.java
@@ -44,47 +44,60 @@ package org.smooks.engine.delivery.interceptor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.smooks.api.SmooksException;
-import org.smooks.api.ApplicationContext;
 import org.smooks.api.ExecutionContext;
-import org.smooks.api.delivery.Filter;
+import org.smooks.api.SmooksException;
 import org.smooks.api.delivery.ContentHandlerBinding;
+import org.smooks.api.delivery.Filter;
+import org.smooks.api.delivery.event.ExecutionEventListener;
+import org.smooks.api.delivery.fragment.Fragment;
 import org.smooks.api.delivery.sax.SAXElement;
 import org.smooks.api.delivery.sax.SAXText;
+import org.smooks.api.resource.visitor.Visitor;
+import org.smooks.api.resource.visitor.dom.DOMElementVisitor;
 import org.smooks.api.resource.visitor.sax.SAXElementVisitor;
 import org.smooks.api.resource.visitor.sax.SAXVisitAfter;
 import org.smooks.api.resource.visitor.sax.SAXVisitBefore;
 import org.smooks.api.resource.visitor.sax.SAXVisitChildren;
-import org.smooks.engine.delivery.event.VisitSequence;
-import org.smooks.api.resource.visitor.Visitor;
-import org.smooks.api.resource.visitor.dom.DOMElementVisitor;
-import org.smooks.api.delivery.fragment.Fragment;
-import org.smooks.engine.delivery.fragment.NodeFragment;
-import org.smooks.engine.delivery.fragment.SAXElementFragment;
 import org.smooks.api.resource.visitor.sax.ng.AfterVisitor;
 import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
 import org.smooks.api.resource.visitor.sax.ng.ChildrenVisitor;
 import org.smooks.api.resource.visitor.sax.ng.ElementVisitor;
-import org.smooks.engine.delivery.sax.ng.terminate.TerminateException;
-import org.smooks.api.delivery.event.ExecutionEventListener;
 import org.smooks.engine.delivery.event.VisitEvent;
+import org.smooks.engine.delivery.event.VisitSequence;
+import org.smooks.engine.delivery.fragment.NodeFragment;
+import org.smooks.engine.delivery.fragment.SAXElementFragment;
+import org.smooks.engine.delivery.sax.ng.terminate.TerminateException;
 import org.smooks.engine.lookup.GlobalParamsLookup;
 import org.w3c.dom.CharacterData;
 import org.w3c.dom.Element;
 
+import javax.annotation.PostConstruct;
 import java.io.IOException;
+import java.util.function.Supplier;
 
 public class ExceptionInterceptor extends AbstractInterceptorVisitor implements ElementVisitor, DOMElementVisitor, SAXElementVisitor {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionInterceptor.class);
+    
+    protected boolean terminateOnVisitorException;
+    protected String visitBeforeExceptionMessage;
+    protected String visitAfterExceptionMessage;
+    protected String visitChildTextExceptionMessage;
+    private String visitChildElementExceptionMessage;
 
-    private boolean terminateOnVisitorException;
-
+    @PostConstruct
+    public void postConstructor() {
+        terminateOnVisitorException = Boolean.parseBoolean(applicationContext.getRegistry().lookup(new GlobalParamsLookup(applicationContext.getRegistry())).getParameterValue(Filter.TERMINATE_ON_VISITOR_EXCEPTION, String.class, "true"));
+        visitBeforeExceptionMessage = String.format("Error in %s while processing visitBefore SAX NG event", visitorBinding.getContentHandler().getClass().getName());
+        visitAfterExceptionMessage = String.format("Error in %s while processing visitAfter SAX NG event", visitorBinding.getContentHandler().getClass().getName());
+        visitChildTextExceptionMessage = String.format("Error in %s while processing visitChildText SAX NG event", visitorBinding.getContentHandler().getClass().getName());
+        visitChildElementExceptionMessage = String.format("Error in %s while processing visitChildElement SAX NG event", visitorBinding.getContentHandler().getClass().getName());
+    }
+    
     @Override
     public void visitBefore(SAXElement element, ExecutionContext executionContext) throws SmooksException, IOException {
         intercept(new Invocation<SAXVisitBefore>() {
             @Override
-            public Object invoke(SAXVisitBefore visitor) {
+            public Object invoke(SAXVisitBefore visitor, Object... args) {
                 try {
                     visitor.visitBefore(element, executionContext);
                 } catch (IOException e) {
@@ -104,7 +117,7 @@ public class ExceptionInterceptor extends AbstractInterceptorVisitor implements 
     public void visitAfter(SAXElement element, ExecutionContext executionContext) throws SmooksException, IOException {
         intercept(new Invocation<SAXVisitAfter>() {
             @Override
-            public Object invoke(SAXVisitAfter visitor) {
+            public Object invoke(SAXVisitAfter visitor, Object... args) {
                 try {
                     visitor.visitAfter(element, executionContext);
                 } catch (IOException e) {
@@ -124,7 +137,7 @@ public class ExceptionInterceptor extends AbstractInterceptorVisitor implements 
     public void onChildText(SAXElement element, SAXText childText, ExecutionContext executionContext) throws SmooksException {
         intercept(new Invocation<SAXVisitChildren>() {
             @Override
-            public Object invoke(SAXVisitChildren visitor) {
+            public Object invoke(SAXVisitChildren visitor, Object... args) {
                 try {
                     visitor.onChildText(element, childText, executionContext);
                 } catch (IOException e) {
@@ -144,7 +157,7 @@ public class ExceptionInterceptor extends AbstractInterceptorVisitor implements 
     public void onChildElement(SAXElement element, SAXElement childElement, ExecutionContext executionContext) throws SmooksException, IOException {
         intercept(new Invocation<SAXVisitChildren>() {
             @Override
-            public Object invoke(SAXVisitChildren visitor) {
+            public Object invoke(SAXVisitChildren visitor, Object... args) {
                 try {
                     visitor.onChildElement(element, childElement, executionContext);
                 } catch (IOException e) {
@@ -162,77 +175,27 @@ public class ExceptionInterceptor extends AbstractInterceptorVisitor implements 
 
     @Override
     public void visitBefore(Element element, ExecutionContext executionContext) {
-        intercept(new Invocation<BeforeVisitor>() {
-            @Override
-            public Object invoke(BeforeVisitor visitor) {
-                visitor.visitBefore(element, executionContext);
-                return null;
-            }
-
-            @Override
-            public Class<BeforeVisitor> getTarget() {
-                return BeforeVisitor.class;
-            }
-        }, executionContext, String.format("Error in %s while processing visitBefore SAX NG event", visitorBinding.getContentHandler().getClass().getName()), new NodeFragment(element), VisitSequence.BEFORE);
+        intercept(visitBeforeInvocation, executionContext, visitBeforeExceptionMessage, new NodeFragment(element), VisitSequence.BEFORE, element, executionContext);
     }
 
     @Override
     public void visitAfter(Element element, ExecutionContext executionContext) {
-        intercept(new Invocation<AfterVisitor>() {
-            @Override
-            public Object invoke(AfterVisitor visitor) {
-                visitor.visitAfter(element, executionContext);
-                return null;
-            }
-
-            @Override
-            public Class<AfterVisitor> getTarget() {
-                return AfterVisitor.class;
-            }
-        }, executionContext, String.format("Error in %s while processing visitAfter SAX NG event", visitorBinding.getContentHandler().getClass().getName()), new NodeFragment(element), VisitSequence.AFTER);
+        intercept(visitAfterInvocation, executionContext, visitAfterExceptionMessage, new NodeFragment(element), VisitSequence.AFTER, element, executionContext);
     }
 
     @Override
     public void visitChildText(CharacterData characterData, ExecutionContext executionContext) {
-        intercept(new Invocation<ChildrenVisitor>() {
-            @Override
-            public Object invoke(ChildrenVisitor visitor) {
-                visitor.visitChildText(characterData, executionContext);
-                return null;
-            }
-
-            @Override
-            public Class<ChildrenVisitor> getTarget() {
-                return ChildrenVisitor.class;
-            }
-        }, executionContext, String.format("Error in %s while processing visitChildText SAX NG event", visitorBinding.getContentHandler().getClass().getName()), new NodeFragment(characterData), VisitSequence.AFTER);
+        intercept(visitChildTextInvocation, executionContext, visitChildTextExceptionMessage, new NodeFragment(characterData), VisitSequence.AFTER, characterData, executionContext);
     }
 
     @Override
     public void visitChildElement(Element childElement, ExecutionContext executionContext) {
-        intercept(new Invocation<ChildrenVisitor>() {
-            @Override
-            public Object invoke(ChildrenVisitor visitor) {
-                visitor.visitChildElement(childElement, executionContext);
-                return null;
-            }
-
-            @Override
-            public Class<ChildrenVisitor> getTarget() {
-                return ChildrenVisitor.class;
-            }
-        }, executionContext, String.format("Error in %s while processing visitChildElement SAX NG event", visitorBinding.getContentHandler().getClass().getName()), new NodeFragment(childElement.getParentNode()), VisitSequence.AFTER);
-    }
-
-    @Override
-    public void setApplicationContext(final ApplicationContext applicationContext) {
-        super.setApplicationContext(applicationContext);
-        terminateOnVisitorException = Boolean.parseBoolean(applicationContext.getRegistry().lookup(new GlobalParamsLookup(applicationContext.getRegistry())).getParameterValue(Filter.TERMINATE_ON_VISITOR_EXCEPTION, String.class, "true"));
+        intercept(visitChildElementInvocation, executionContext, visitChildElementExceptionMessage, new NodeFragment(childElement.getParentNode()), VisitSequence.AFTER, childElement, executionContext);
     }
     
-    private <T extends Visitor> void intercept(final Invocation<T> invocation, final ExecutionContext executionContext, final String exceptionMessage, final Fragment<?> fragment, final VisitSequence visitSequence) {
+    private <T extends Visitor> void intercept(final Invocation<T> invocation, final ExecutionContext executionContext, final String exceptionMessage, final Fragment<?> fragment, final VisitSequence visitSequence, final Object... invocationArgs) {
         try {
-            intercept(invocation);
+            intercept(invocation, invocationArgs);
         } catch (Throwable t) {
             processVisitorException(t, exceptionMessage, executionContext, fragment, visitSequence, visitorBinding);
         }

--- a/core/src/main/java/org/smooks/engine/delivery/sax/SAXContentDeliveryConfig.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/SAXContentDeliveryConfig.java
@@ -126,7 +126,7 @@ public class SAXContentDeliveryConfig extends AbstractContentDeliveryConfig {
 
     @Override
     public Filter newFilter(ExecutionContext executionContext) {
-        return new SmooksSAXFilter(executionContext);
+        return new SmooksSAXFilter(executionContext, getCloseSource(), getCloseResult());
     }
 
     @Override
@@ -226,7 +226,7 @@ public class SAXContentDeliveryConfig extends AbstractContentDeliveryConfig {
         reverseVisitOrderOnVisitAfter = Boolean.parseBoolean(ParameterAccessor.getParameterValue(Filter.REVERSE_VISIT_ORDER_ON_VISIT_AFTER, String.class, "true", this));
         terminateOnVisitorException = Boolean.parseBoolean(ParameterAccessor.getParameterValue(Filter.TERMINATE_ON_VISITOR_EXCEPTION, String.class, "true", this));
 
-		filterBypass = getFilterBypass(visitBeforeSelectorTable, visitAfterSelectorTable);
+        filterBypass = getFilterBypass(visitBeforeSelectorTable, visitAfterSelectorTable);
     }
 
     public void assertSelectorsNotAccessingText() {

--- a/core/src/main/java/org/smooks/engine/delivery/sax/SAXHandler.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/SAXHandler.java
@@ -176,7 +176,7 @@ public class SAXHandler extends SmooksContentHandler {
     }
 
     @Override
-    public void cleanup() {
+    public void close() {
     }
 
     @Override

--- a/core/src/main/java/org/smooks/engine/delivery/sax/SAXParser.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/SAXParser.java
@@ -53,6 +53,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 
 import javax.xml.transform.Source;
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
@@ -62,7 +63,7 @@ import java.nio.charset.Charset;
  *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class SAXParser extends AbstractParser {
+public class SAXParser extends AbstractParser implements Closeable {
 
     private SAXHandler saxHandler;
 
@@ -120,9 +121,10 @@ public class SAXParser extends AbstractParser {
         }
     }
 
-    public void cleanup() {
-        if(saxHandler != null) {
-            saxHandler.cleanup();
+    @Override
+    public void close() {
+        if (saxHandler != null) {
+            saxHandler.close();
         }
     }
 }

--- a/core/src/main/java/org/smooks/engine/delivery/sax/SmooksSAXFilter.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/SmooksSAXFilter.java
@@ -79,10 +79,10 @@ public class SmooksSAXFilter extends AbstractFilter {
     protected final boolean closeSource;
     protected final boolean closeResult;
 
-    public SmooksSAXFilter(ExecutionContext executionContext) {
+    public SmooksSAXFilter(ExecutionContext executionContext, boolean closeSource, boolean closeResult) {
         this.executionContext = executionContext;
-        closeSource = Boolean.parseBoolean(ParameterAccessor.getParameterValue(Filter.CLOSE_SOURCE, String.class, "true", executionContext.getContentDeliveryRuntime().getContentDeliveryConfig()));
-        closeResult = Boolean.parseBoolean(ParameterAccessor.getParameterValue(Filter.CLOSE_RESULT, String.class, "true", executionContext.getContentDeliveryRuntime().getContentDeliveryConfig()));
+        this.closeSource = closeSource;
+        this.closeResult = closeResult;
         parser = new SAXParser(executionContext);
     }
 
@@ -95,10 +95,10 @@ public class SmooksSAXFilter extends AbstractFilter {
     }
 
     protected void doFilter(Source source, Result result) {
-        if(source instanceof DOMSource) {
-            String serializedDOM = XmlUtil.serialize(((DOMSource)source).getNode(), false, true);
+        if (source instanceof DOMSource) {
+            String serializedDOM = XmlUtil.serialize(((DOMSource) source).getNode(), false, true);
             source = new StringSource(serializedDOM);
-            if(LOGGER.isDebugEnabled()) {
+            if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("DOMSource converted to a StringSource.");
             }
         }
@@ -118,27 +118,27 @@ public class SmooksSAXFilter extends AbstractFilter {
             parser.parse(source, executionContext);
             writer.flush();
         } catch (TerminateException e) {
-            if(LOGGER.isDebugEnabled()) {
-            	if(e.isTerminateBefore()) {
-            		LOGGER.debug("Terminated filtering on visitBefore of element '" + SAXUtil.getXPath(e.getElement()) + "'.");
-            	} else {
-            		LOGGER.debug("Terminated filtering on visitAfter of element '" + SAXUtil.getXPath(e.getElement()) + "'.");            		
-            	}
+            if (LOGGER.isDebugEnabled()) {
+                if (e.isTerminateBefore()) {
+                    LOGGER.debug("Terminated filtering on visitBefore of element '" + SAXUtil.getXPath(e.getElement()) + "'.");
+                } else {
+                    LOGGER.debug("Terminated filtering on visitAfter of element '" + SAXUtil.getXPath(e.getElement()) + "'.");
+                }
             }
         } catch (Exception e) {
             throw new SmooksException("Failed to filter source.", e);
         } finally {
-            if(closeSource) {
+            if (closeSource) {
                 close(source);
             }
-            if(closeResult) {
+            if (closeResult) {
                 close(result);
             }
         }
     }
 
     @Override
-    public void cleanup() {
-        parser.cleanup();
+    public void close() {
+        parser.close();
     }
 }

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgFilter.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgFilter.java
@@ -55,6 +55,7 @@ import org.smooks.io.payload.JavaSource;
 import org.smooks.support.DomUtils;
 import org.smooks.support.XmlUtil;
 
+import javax.xml.parsers.DocumentBuilder;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMResult;
@@ -70,9 +71,9 @@ public class SaxNgFilter extends SmooksSAXFilter {
 
     private final SaxNgParser parser;
 
-    public SaxNgFilter(ExecutionContext executionContext) {
-        super(executionContext);
-        parser = new SaxNgParser(executionContext);
+    public SaxNgFilter(final ExecutionContext executionContext, final DocumentBuilder documentBuilder, boolean closeSource, boolean closeResult) {
+        super(executionContext, closeSource, closeResult);
+        parser = new SaxNgParser(executionContext, documentBuilder);
     }
 
     @Override

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgVisitorBindings.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgVisitorBindings.java
@@ -52,11 +52,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class SaxNgVisitorBindings {
+class SaxNgVisitorBindings {
 
     private List<ContentHandlerBinding<BeforeVisitor>> beforeVisitors;
     private List<ContentHandlerBinding<ChildrenVisitor>> childVisitors;
     private List<ContentHandlerBinding<AfterVisitor>> afterVisitors;
+    public List<ContentHandlerBinding<? extends Visitor>> visitors;
 
     public List<ContentHandlerBinding<BeforeVisitor>> getBeforeVisitors() {
         return beforeVisitors;
@@ -82,19 +83,26 @@ public class SaxNgVisitorBindings {
         this.afterVisitors = afterVisitors;
     }
 
-    public List<ContentHandlerBinding<? extends Visitor>> getVisitorBindings() {
-        List<ContentHandlerBinding<? extends Visitor>> visitors = new ArrayList<>();
-        if (beforeVisitors != null) {
-            visitors.addAll(beforeVisitors);
-        }
-        if (afterVisitors != null) {
-            visitors.addAll(afterVisitors);
-        }
-        if (childVisitors != null) {
-            visitors.addAll(childVisitors);
+    public List<ContentHandlerBinding<? extends Visitor>> getAll() {
+        if (visitors == null) {
+            synchronized (this) {
+                if (visitors == null) {
+                    List<ContentHandlerBinding<? extends Visitor>> distinctVisitors = new ArrayList<>();
+                    if (beforeVisitors != null) {
+                        distinctVisitors.addAll(beforeVisitors);
+                    }
+                    if (afterVisitors != null) {
+                        distinctVisitors.addAll(afterVisitors);
+                    }
+                    if (childVisitors != null) {
+                        distinctVisitors.addAll(childVisitors);
+                    }
+                    visitors = distinctVisitors.stream().distinct().collect(Collectors.toList());
+                }
+            }
         }
         
-        return visitors.stream().distinct().collect(Collectors.toList());
+        return visitors;
     }
     
     public SaxNgVisitorBindings merge(SaxNgVisitorBindings map) {

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/org/apache/xerces/dom/CoreDocumentImpl.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/org/apache/xerces/dom/CoreDocumentImpl.java
@@ -1531,7 +1531,7 @@ extends org.smooks.engine.delivery.sax.ng.org.apache.xerces.dom.ParentNode imple
     HashMap reversedIdentifiers)
     throws DOMException {
         Node newnode=null;
-		Hashtable userData = null;
+		Map userData = null;
 
         // Sigh. This doesn't work; too many nodes have private data that
         // would have to be manually tweaked. May be able to add local
@@ -1777,7 +1777,7 @@ extends org.smooks.engine.delivery.sax.ng.org.apache.xerces.dom.ParentNode imple
      **/
     public Node adoptNode(Node source) {
         org.smooks.engine.delivery.sax.ng.org.apache.xerces.dom.NodeImpl node;
-		Hashtable userData = null;
+		Map userData = null;
         try {
             node = (org.smooks.engine.delivery.sax.ng.org.apache.xerces.dom.NodeImpl) source;
         } catch (ClassCastException e) {
@@ -2436,7 +2436,7 @@ extends org.smooks.engine.delivery.sax.ng.org.apache.xerces.dom.ParentNode imple
      * @param n The node this operation applies to.
      * @param data The user data table.
      */
-    void setUserDataTable(Node n, Hashtable data) {
+    void setUserDataTable(Node n, Map data) {
         if (userData == null) {
             userData = new WeakHashMap();
         }

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/org/apache/xerces/dom/DocumentTypeImpl.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/org/apache/xerces/dom/DocumentTypeImpl.java
@@ -18,11 +18,8 @@
 package org.smooks.engine.delivery.sax.ng.org.apache.xerces.dom;
 
 import java.util.Hashtable;
+import java.util.Map;
 
-import org.smooks.engine.delivery.sax.ng.org.apache.xerces.dom.*;
-import org.smooks.engine.delivery.sax.ng.org.apache.xerces.dom.CoreDocumentImpl;
-import org.smooks.engine.delivery.sax.ng.org.apache.xerces.dom.NodeImpl;
-import org.smooks.engine.delivery.sax.ng.org.apache.xerces.dom.ParentNode;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.DocumentType;
 import org.w3c.dom.NamedNodeMap;
@@ -481,7 +478,7 @@ public class DocumentTypeImpl
         return null;
     }
     
-    protected Hashtable getUserDataRecord(){
+    protected Map getUserDataRecord(){
         return userData;
     }
     

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/org/apache/xerces/dom/NodeImpl.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/org/apache/xerces/dom/NodeImpl.java
@@ -20,13 +20,8 @@ package org.smooks.engine.delivery.sax.ng.org.apache.xerces.dom;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.util.Hashtable;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.WeakHashMap;
+import java.util.*;
 
-import org.smooks.engine.delivery.sax.ng.org.apache.xerces.dom.*;
-import org.smooks.engine.delivery.sax.ng.org.apache.xerces.dom.AttrImpl;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.DocumentType;
@@ -168,7 +163,7 @@ public abstract class NodeImpl
     protected final static short ID           = 0x1<<9;
 
     /** Table for user data attached to this document nodes. */
-    protected Hashtable userData;  // serialized as Hashtable
+    protected Map userData;  // serialized as Hashtable
     //
     // Constructors
     //
@@ -310,7 +305,7 @@ public abstract class NodeImpl
         }
         //Hashtable t = (Hashtable) userData.get(n);
         if(n instanceof NodeImpl){
-            Hashtable t = ((NodeImpl)n).getUserDataRecord();
+            Map t = ((NodeImpl)n).getUserDataRecord();
             if (t == null || t.isEmpty()) {
                 return;
             }
@@ -325,7 +320,7 @@ public abstract class NodeImpl
      * @param operation The operation - import, clone, or delete.
      * @param handlers Data associated with n.
      */
-    void callUserDataHandlers(Node n, Node c, short operation, Hashtable userData) {
+    void callUserDataHandlers(Node n, Node c, short operation, Map userData) {
         if (userData == null || userData.isEmpty()) {
             return;
         }
@@ -1840,7 +1835,7 @@ public abstract class NodeImpl
             }
         } else {
             if (userData == null) {
-                userData = new Hashtable<>();
+                userData = new HashMap();
             }
             Object o = userData.put(key, new ParentNode.UserDataRecord(data, handler));
             if (o != null) {
@@ -1872,7 +1867,7 @@ public abstract class NodeImpl
         return null;
     }
 
-	protected Hashtable getUserDataRecord(){
+	protected Map getUserDataRecord(){
         return userData;
 	}
 

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/session/SessionInterceptor.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/session/SessionInterceptor.java
@@ -72,33 +72,11 @@ public class SessionInterceptor extends AbstractInterceptorVisitor implements El
         if (Session.isSession(element)) {
             if (doVisit(element, "visitBefore", executionContext)) {
                 Object source = executionContext.get(new TypedKey<>(element.getAttribute("source")));
-                intercept(new Invocation<BeforeVisitor>() {
-                    @Override
-                    public Object invoke(final BeforeVisitor visitor) {
-                        visitor.visitBefore((Element) source, executionContext);
-                        return null;
-                    }
-
-                    @Override
-                    public Class<BeforeVisitor> getTarget() {
-                        return BeforeVisitor.class;
-                    }
-                });
+                intercept(visitBeforeInvocation, source, executionContext);
             }
         } else {
             if (new NodeFragment(element).isMatch(getTarget().getResourceConfig().getSelectorPath(), executionContext)) {
-                intercept(new Invocation<BeforeVisitor>() {
-                    @Override
-                    public Object invoke(final BeforeVisitor visitor) {
-                        visitor.visitBefore(element, executionContext);
-                        return null;
-                    }
-
-                    @Override
-                    public Class<BeforeVisitor> getTarget() {
-                        return BeforeVisitor.class;
-                    }
-                });
+                intercept(visitBeforeInvocation, element, executionContext);
             }
         }
     }
@@ -106,35 +84,13 @@ public class SessionInterceptor extends AbstractInterceptorVisitor implements El
     @Override
     public void visitChildText(final CharacterData characterData, final ExecutionContext executionContext) {
         if (new NodeFragment(characterData.getParentNode()).isMatch(getTarget().getResourceConfig().getSelectorPath(), executionContext)) {
-            intercept(new Invocation<ChildrenVisitor>() {
-                @Override
-                public Object invoke(ChildrenVisitor visitor) {
-                    visitor.visitChildText(characterData, executionContext);
-                    return null;
-                }
-
-                @Override
-                public Class<ChildrenVisitor> getTarget() {
-                    return ChildrenVisitor.class;
-                }
-            });
+            intercept(visitChildTextInvocation, characterData, executionContext);
         }
     }
 
     @Override
     public void visitChildElement(Element childElement, ExecutionContext executionContext) {
-        intercept(new Invocation<ChildrenVisitor>() {
-            @Override
-            public Object invoke(ChildrenVisitor visitor) {
-                visitor.visitChildElement(childElement, executionContext);
-                return null;
-            }
-
-            @Override
-            public Class<ChildrenVisitor> getTarget() {
-                return ChildrenVisitor.class;
-            }
-        });
+        intercept(visitChildElementInvocation, childElement, executionContext);
     }
 
     @Override
@@ -145,34 +101,12 @@ public class SessionInterceptor extends AbstractInterceptorVisitor implements El
                 if (element.getAttribute("visit").equals("visitChildText")) {
                     visitChildText((CharacterData) source, executionContext);
                 } else {
-                    intercept(new Invocation<AfterVisitor>() {
-                        @Override
-                        public Object invoke(final AfterVisitor visitor) {
-                            visitor.visitAfter((Element) source, executionContext);
-                            return null;
-                        }
-
-                        @Override
-                        public Class<AfterVisitor> getTarget() {
-                            return AfterVisitor.class;
-                        }
-                    });
+                    intercept(visitAfterInvocation, source, executionContext);
                 }
             }
         } else {
             if (new NodeFragment(element).isMatch(getTarget().getResourceConfig().getSelectorPath(), executionContext)) {
-                intercept(new Invocation<AfterVisitor>() {
-                    @Override
-                    public Object invoke(final AfterVisitor visitor) {
-                        visitor.visitAfter(element, executionContext);
-                        return null;
-                    }
-
-                    @Override
-                    public Class<AfterVisitor> getTarget() {
-                        return AfterVisitor.class;
-                    }
-                });
+                intercept(visitAfterInvocation, element, executionContext);
             }
         }
     }

--- a/core/src/main/java/org/smooks/engine/memento/DefaultMementoCaretaker.java
+++ b/core/src/main/java/org/smooks/engine/memento/DefaultMementoCaretaker.java
@@ -48,12 +48,14 @@ import org.smooks.api.TypedMap;
 import org.smooks.api.delivery.fragment.Fragment;
 import org.smooks.api.memento.Memento;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+@NotThreadSafe
 public class DefaultMementoCaretaker implements MementoCaretaker {
 
     private final Map<Fragment<?>, Set<String>> mementoAnchors = new HashMap<>();

--- a/core/src/main/java/org/smooks/engine/memento/VisitorMemento.java
+++ b/core/src/main/java/org/smooks/engine/memento/VisitorMemento.java
@@ -51,7 +51,11 @@ public class VisitorMemento<T> extends AbstractVisitorMemento {
 
     protected TypedKey<?> typedKey;
     protected T state;
-    
+
+    public VisitorMemento(final Fragment<?> fragment, final Visitor visitor, final TypedKey<?> typedKey) {
+        this(fragment, visitor, typedKey, null);
+    }
+        
     public VisitorMemento(final Fragment<?> fragment, final Visitor visitor, final TypedKey<?> typedKey, final T state) {
         super(fragment, visitor);
         this.state = state;

--- a/core/src/main/java/org/smooks/engine/resource/config/DefaultResourceConfig.java
+++ b/core/src/main/java/org/smooks/engine/resource/config/DefaultResourceConfig.java
@@ -709,11 +709,11 @@ public class DefaultResourceConfig implements ResourceConfig {
         Object parameter = parameters.get(name);
 
         if (parameter instanceof List) {
-            return (List) parameter;
+            return (List<Parameter<?>>) parameter;
         } else if (parameter instanceof Parameter) {
-            Vector paramList = new Vector();
-            paramList.add(parameter);
-            //parameters.put(name, paramList);
+            List<Parameter<?>> paramList = new ArrayList<>();
+            paramList.add((Parameter<?>) parameter);
+
             return paramList;
         }
 

--- a/core/src/main/java/org/smooks/engine/resource/reader/XStreamXMLReader.java
+++ b/core/src/main/java/org/smooks/engine/resource/reader/XStreamXMLReader.java
@@ -77,9 +77,7 @@ public class XStreamXMLReader implements JavaXMLReader {
     public void setSourceObjects(List<Object> sourceObjects) throws SmooksConfigException {
         try {
             xstreamReader.setProperty(SaxWriter.SOURCE_OBJECT_LIST_PROPERTY, sourceObjects);
-        } catch (SAXNotRecognizedException e) {
-            throw new SmooksConfigException("Unable to set source Java Objects on the underlying XStream SaxWriter.", e);
-        } catch (SAXNotSupportedException e) {
+        } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
             throw new SmooksConfigException("Unable to set source Java Objects on the underlying XStream SaxWriter.", e);
         }
     }

--- a/core/src/main/java/org/smooks/engine/resource/visitor/dom/DomModelCreator.java
+++ b/core/src/main/java/org/smooks/engine/resource/visitor/dom/DomModelCreator.java
@@ -218,6 +218,7 @@ public class DomModelCreator implements BeforeVisitor, AfterVisitor, Producer {
 
         private DOMCreator(ExecutionContext executionContext) {
             document = documentBuilder.newDocument();
+            document.setStrictErrorChecking(false);
             currentNode = document;
             this.executionContext = executionContext;
         }

--- a/core/src/main/java/org/smooks/io/DocumentInputSource.java
+++ b/core/src/main/java/org/smooks/io/DocumentInputSource.java
@@ -42,39 +42,33 @@
  */
 package org.smooks.io;
 
-import org.smooks.support.XmlUtil;
-import org.w3c.dom.Node;
+import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.Reader;
-import java.io.StringReader;
 
-public class DOMInputSource extends InputSource {
+public class DocumentInputSource extends InputSource {
 
-    private final Node node;
-    private final boolean closeEmptyElements;
-    private String serializedNode;
-
-    public DOMInputSource(Node node, boolean closeEmptyElements) {
-        this.node = node;
-        this.closeEmptyElements = closeEmptyElements;
+    private final Document document;
+    
+    public DocumentInputSource(Document document) {
+        this.document = document;
     }
     
-    public DOMInputSource() {
+    public DocumentInputSource() {
         throw new UnsupportedOperationException();
     }
 
-    public DOMInputSource(String systemId) {
+    public DocumentInputSource(String systemId) {
         throw new UnsupportedOperationException();
     }
 
-    public DOMInputSource(InputStream byteStream) {
+    public DocumentInputSource(InputStream byteStream) {
         throw new UnsupportedOperationException();
     }
 
-    public DOMInputSource(Reader characterStream) {
+    public DocumentInputSource(Reader characterStream) {
         throw new UnsupportedOperationException();
     }
 
@@ -95,7 +89,7 @@ public class DOMInputSource extends InputSource {
 
     @Override
     public InputStream getByteStream() {
-        return new ByteArrayInputStream(serialize(node, closeEmptyElements).getBytes());
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -110,18 +104,10 @@ public class DOMInputSource extends InputSource {
 
     @Override
     public Reader getCharacterStream() {
-        return new StringReader(serialize(node, closeEmptyElements));
-    }
-    
-    protected String serialize(final Node node, final boolean closeEmptyElements) {
-        if (serializedNode == null) {
-            this.serializedNode = XmlUtil.serialize(node, false, closeEmptyElements);
-        }
-        
-        return serializedNode;
+        throw new UnsupportedOperationException();
     }
 
-    public Node getNode() {
-        return node;
+    public Document getDocument() {
+        return document;
     }
 }

--- a/core/src/main/resources/META-INF/LICENSE.dom4j
+++ b/core/src/main/resources/META-INF/LICENSE.dom4j
@@ -1,0 +1,39 @@
+Copyright 2001-2016 (C) MetaStuff, Ltd. and DOM4J contributors. All Rights Reserved.
+
+Redistribution and use of this software and associated documentation
+("Software"), with or without modification, are permitted provided
+that the following conditions are met:
+
+1. Redistributions of source code must retain copyright
+   statements and notices.  Redistributions must also contain a
+   copy of this document.
+ 
+2. Redistributions in binary form must reproduce the
+   above copyright notice, this list of conditions and the
+   following disclaimer in the documentation and/or other
+   materials provided with the distribution.
+ 
+3. The name "DOM4J" must not be used to endorse or promote
+   products derived from this Software without prior written
+   permission of MetaStuff, Ltd.  For written permission,
+   please contact dom4j-info@metastuff.com.
+ 
+4. Products derived from this Software may not be called "DOM4J"
+   nor may "DOM4J" appear in their names without prior written
+   permission of MetaStuff, Ltd. DOM4J is a registered
+   trademark of MetaStuff, Ltd.
+ 
+5. Due credit should be given to the DOM4J Project - https://dom4j.github.io/
+ 
+THIS SOFTWARE IS PROVIDED BY METASTUFF, LTD. AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+METASTUFF, LTD. OR ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/core/src/main/resources/META-INF/services/javax.xml.parsers.SAXParserFactory
+++ b/core/src/main/resources/META-INF/services/javax.xml.parsers.SAXParserFactory
@@ -1,1 +1,0 @@
-org.smooks.engine.delivery.sax.ng.org.apache.xerces.jaxp.SAXParserFactoryImpl

--- a/core/src/main/resources/META-INF/services/org.xml.sax.driver
+++ b/core/src/main/resources/META-INF/services/org.xml.sax.driver
@@ -1,2 +1,1 @@
-org.smooks.engine.delivery.sax.ng.org.apache.xerces.parsers.SAXParser
-
+com.ctc.wstx.sax.WstxSAXParser

--- a/core/src/main/resources/META-INF/xsd/smooks/smooks-core-1.6.xsd
+++ b/core/src/main/resources/META-INF/xsd/smooks/smooks-core-1.6.xsd
@@ -418,7 +418,7 @@
         </xs:complexContent>
     </xs:complexType>
 
-    <xs:element name="node-reader" substitutionGroup="smooks:abstract-reader">
+    <xs:element name="delegate-reader" substitutionGroup="smooks:abstract-reader">
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="smooks:abstract-reader">

--- a/core/src/main/resources/META-INF/xsd/smooks/smooks-core-1.6.xsd-smooks.xml
+++ b/core/src/main/resources/META-INF/xsd/smooks/smooks-core-1.6.xsd-smooks.xml
@@ -283,16 +283,16 @@
     </resource-config>
 
     
-    <resource-config selector="/smooks:smooks-resource-list/smooks-core:node-reader">
+    <resource-config selector="/smooks:smooks-resource-list/smooks-core:delegate-reader">
         <resource>org.smooks.engine.resource.extension.NewResourceConfig</resource>
-        <param name="resource">org.smooks.engine.resource.reader.NodeReader</param>
+        <param name="resource">org.smooks.engine.resource.reader.DelegateReader</param>
     </resource-config>
-    <resource-config selector="/smooks:smooks-resource-list/smooks-core:node-reader">
+    <resource-config selector="/smooks:smooks-resource-list/smooks-core:delegate-reader">
         <resource>org.smooks.engine.resource.extension.SetOnResourceConfig</resource>
         <param name="setOn">selector</param>
         <param name="value">org.xml.sax.driver</param>
     </resource-config>
-    <resource-config selector="/smooks:smooks-resource-list/smooks-core:node-reader">
+    <resource-config selector="/smooks:smooks-resource-list/smooks-core:delegate-reader">
         <resource>org.smooks.engine.resource.extension.MapToResourceConfigFromXml</resource>
         <param name="mapTo">resourceConfigs</param>
     </resource-config>

--- a/core/src/test/java/org/smooks/engine/delivery/AbstractParserTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/AbstractParserTestCase.java
@@ -110,7 +110,7 @@ public class AbstractParserTestCase {
     	assertEquals(3, UnpooledSAXParser.numSetHandlerCalls);
     }
 
-    private class TestParser extends AbstractParser {
+    private static class TestParser extends AbstractParser {
         public TestParser(ExecutionContext execContext) {
             super(execContext);
         }
@@ -128,10 +128,10 @@ public class AbstractParserTestCase {
 				lastParserInstance = this;
 			}
 			if(this != lastParserInstance) {
-				fail("Should only be 1 parser instanse (pooled).");
+				fail("Should only be 1 parser instance (pooled).");
 			}
 			if(handler == lastHandlerInstance) {
-				fail("Shouldn't be just 1 handler instanse (pooled or unpooled).");
+				fail("Shouldn't be just 1 handler instance (pooled or unpooled).");
 			}
 			numSetHandlerCalls++;
 			lastParserInstance = this;
@@ -149,10 +149,10 @@ public class AbstractParserTestCase {
 		@Override
 		public void setContentHandler(ContentHandler handler) {
 			if(this == lastParserInstance) {
-				fail("Shouldn't be just 1 parser instanse (unpooled).");
+				fail("Shouldn't be just 1 parser instance (unpooled).");
 			}
 			if(handler == lastHandlerInstance) {
-				fail("Shouldn't be just 1 handler instanse (pooled or unpooled).");
+				fail("Shouldn't be just 1 handler instance (pooled or unpooled).");
 			}
 			numSetHandlerCalls++;
 			lastParserInstance = this;

--- a/core/src/test/java/org/smooks/engine/delivery/dom/MILYN_247_TestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/dom/MILYN_247_TestCase.java
@@ -72,11 +72,11 @@ public class MILYN_247_TestCase {
     public void test_MILYN_247_02() {
         Smooks smooks = new Smooks();
 
-        smooks.setFilterSettings(new FilterSettings().setFilterType(StreamFilterType.DOM).setRewriteEntities(false));
+        smooks.setFilterSettings(new FilterSettings().setFilterType(StreamFilterType.DOM).setRewriteEntities(true));
 
         StringResult stringResult = new StringResult();
         smooks.filterSource(new StringSource("<a attrib=\"an &amp; 'attribute\">Bigger &gt; is better!</a>"), stringResult);
-        assertEquals("<a attrib=\"an & 'attribute\">Bigger &#62; is better!</a>", stringResult.getResult());
+        assertEquals("<a attrib=\"an &amp; &apos;attribute\">Bigger &gt; is better!</a>", stringResult.getResult());
     }
 
 	@Test
@@ -98,6 +98,6 @@ public class MILYN_247_TestCase {
 
         StringResult stringResult = new StringResult();
         smooks.filterSource(new StringSource("<a attrib=\"an &amp; 'attribute\">Bigger &gt; is better!</a>"), stringResult);
-        assertEquals("<a attrib=\"an & 'attribute\">Bigger &#62; is better!</a>", stringResult.getResult());
+        assertEquals("<a attrib=\"an & 'attribute\">Bigger > is better!</a>", stringResult.getResult());
     }
 }

--- a/core/src/test/java/org/smooks/engine/delivery/sax/SAXFilterTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/sax/SAXFilterTestCase.java
@@ -151,7 +151,7 @@ public class SAXFilterTestCase {
         assertEquals("", SAXVisitor03.element.getName().getPrefix());
         assertEquals("http://x", SAXVisitor03.element.getName().getNamespaceURI());
         assertEquals(1, SAXVisitor03.children.size());
-        assertEquals(7, SAXVisitor03.childText.size());
+        assertEquals(2, SAXVisitor03.childText.size());
     }
 
 	@Test

--- a/core/src/test/java/org/smooks/engine/delivery/sax/SAXToXMLWriterTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/sax/SAXToXMLWriterTestCase.java
@@ -85,8 +85,8 @@ public class SAXToXMLWriterTestCase {
 		
 		smooks.filterSource(new StringSource("<a><b>some&amp;text</b></a>"), stringResult);
 		
-		assertEquals("<a><b>{{some&#38;text}}</b></a>", stringResult.getResult());
-		assertEquals("some&#38;text", VisitAfterWrittingVisitor.elementText);
+		assertEquals("<a><b>{{some&text}}</b></a>", stringResult.getResult());
+		assertEquals("some&text", VisitAfterWrittingVisitor.elementText);
 	}	
 	
 	private static class AllWrittingVisitor implements SAXElementVisitor {

--- a/core/src/test/java/org/smooks/engine/delivery/sax/SmooksSAXFilterTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/sax/SmooksSAXFilterTestCase.java
@@ -70,29 +70,27 @@ public class SmooksSAXFilterTestCase
 	private byte[] input;
 	private ExecutionContext context;
 	private SmooksSAXFilter saxFilter;
-	
+
 	@Test
-	public void doFilter_verify_that_flush_is_called() throws IOException
-	{
+	public void doFilter_verify_that_flush_is_called() throws IOException {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		StreamResult result = new StreamResult( baos );
-		
-		saxFilter.doFilter( new StreamSource( new ByteArrayInputStream( input ) ), result );
-		
+		StreamResult result = new StreamResult(baos);
+
+		saxFilter.doFilter(new StreamSource(new ByteArrayInputStream(input)), result);
+
 		OutputStream outputStream = result.getOutputStream();
-		assertTrue( outputStream instanceof ByteArrayOutputStream );
-		
-		byte[] byteArray = ((ByteArrayOutputStream)outputStream).toByteArray();
-		assertTrue ( byteArray.length > 0 );
+		assertTrue(outputStream instanceof ByteArrayOutputStream);
+
+		byte[] byteArray = ((ByteArrayOutputStream) outputStream).toByteArray();
+		assertTrue(byteArray.length > 0);
 	}
-	
+
 	@Before
-	public void setup() throws IOException, SAXException
-	{
-        Smooks smooks = new Smooks(getClass().getResourceAsStream("smooks-config-01.xml"));
-        context = smooks.createExecutionContext();
-		input = StreamUtils.readStream( getClass().getResourceAsStream( "test-01.xml") );
-		saxFilter = new SmooksSAXFilter( context );
+	public void setup() throws IOException, SAXException {
+		Smooks smooks = new Smooks(getClass().getResourceAsStream("smooks-config-01.xml"));
+		context = smooks.createExecutionContext();
+		input = StreamUtils.readStream(getClass().getResourceAsStream("test-01.xml"));
+		saxFilter = new SmooksSAXFilter(context, true, true);
 	}
 
 }

--- a/core/src/test/java/org/smooks/engine/delivery/sax/ng/SaxNgFilterTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/sax/ng/SaxNgFilterTestCase.java
@@ -144,7 +144,7 @@ public class SaxNgFilterTestCase {
         assertNull(Visitor03.element.getPrefix());
         assertEquals("http://x", Visitor03.element.getNamespaceURI());
         assertEquals(1, Visitor03.children.size());
-        assertEquals(7, Visitor03.childText.size());
+        assertEquals(2, Visitor03.childText.size());
     }
 
 	@Test

--- a/core/src/test/java/org/smooks/engine/resource/config/xpath/SelectorStepBuilderTestCase.java
+++ b/core/src/test/java/org/smooks/engine/resource/config/xpath/SelectorStepBuilderTestCase.java
@@ -50,9 +50,12 @@ import org.smooks.api.resource.config.xpath.SelectorPath;
 import org.smooks.engine.delivery.fragment.NodeFragment;
 import org.smooks.engine.delivery.fragment.SAXElementFragment;
 import org.smooks.engine.delivery.sax.DefaultSAXElement;
-import org.smooks.support.XmlUtil;
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import java.util.Properties;
 
 import static org.junit.Assert.*;
@@ -161,31 +164,31 @@ public class SelectorStepBuilderTestCase {
         SelectorPath selectorPath = SelectorStepBuilder.buildSteps("x/y[(@d = 23 or text() = 'ddd') and @h = 'rrr']", namespaces);
         assertEquals("x/y(((@d = 23.0) or (text() = 'ddd')) and (@h = 'rrr'))", selectorPath.toString());
 
-        Element y = XmlUtil.createElement("y");
+        Element y = createElement("y");
         y.setAttribute("d", "2");
         y.appendChild(y.getOwnerDocument().createTextNode("dd"));
         y.setAttribute("h", "rr");
         assertFalse(selectorPath.get(1).getPredicatesEvaluator().evaluate(new NodeFragment(y), null));
 
-        y = XmlUtil.createElement("y");
+        y = createElement("y");
         y.setAttribute("d", "23");
         y.appendChild(y.getOwnerDocument().createTextNode("dd"));
         y.setAttribute("h", "rr");
         assertFalse(selectorPath.get(1).getPredicatesEvaluator().evaluate(new NodeFragment(y), null));
 
-        y = XmlUtil.createElement("y");
+        y = createElement("y");
         y.setAttribute("d", "23");
         y.appendChild(y.getOwnerDocument().createTextNode("dd"));
         y.setAttribute("h", "rrr");
         assertTrue(selectorPath.get(1).getPredicatesEvaluator().evaluate(new NodeFragment(y), null));
 
-        y = XmlUtil.createElement("y");
+        y = createElement("y");
         y.setAttribute("d", "2");
         y.appendChild(y.getOwnerDocument().createTextNode("dd"));
         y.setAttribute("h", "rrr");
         assertFalse(selectorPath.get(1).getPredicatesEvaluator().evaluate(new NodeFragment(y), null));
 
-        y = XmlUtil.createElement("y");
+        y = createElement("y");
         y.setAttribute("d", "2");
         y.appendChild(y.getOwnerDocument().createTextNode("ddd"));
         y.setAttribute("h", "rrr");
@@ -494,5 +497,15 @@ public class SelectorStepBuilderTestCase {
         } catch(SmooksException e) {
             assertEquals("Unsupported XPath selector expression 'a[text() = 123]/b'.  XPath 'text()' tokens are only supported in the last step.", e.getMessage());
         }
+    }
+
+    protected Element createElement(String localPart) {
+        final Document document;
+        try {
+            document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        } catch (ParserConfigurationException e) {
+            throw new SmooksException(e);
+        }
+        return document.createElementNS(XMLConstants.NULL_NS_URI, localPart);
     }
 }

--- a/core/src/test/java/org/smooks/engine/resource/reader/DelegateReaderFunctionalTestCase.java
+++ b/core/src/test/java/org/smooks/engine/resource/reader/DelegateReaderFunctionalTestCase.java
@@ -61,9 +61,9 @@ import java.io.StringWriter;
 
 import static org.junit.Assert.assertEquals;
 
-public class NodeReaderFunctionalTestCase {
+public class DelegateReaderFunctionalTestCase {
 
-    public static class NodeReaderResource implements ElementVisitor {
+    public static class DelegateReaderResource implements ElementVisitor {
         private final TypedKey<FragmentWriter> fragmentWriterTypedKey = new TypedKey<>();
 
         @Override
@@ -103,7 +103,7 @@ public class NodeReaderFunctionalTestCase {
     
     @Test
     public void test() throws IOException, SAXException {
-        Smooks smooks = new Smooks(getClass().getResourceAsStream("smooks-config-node-reader.xml"));
+        Smooks smooks = new Smooks(getClass().getResourceAsStream("smooks-config-delegate-reader.xml"));
         ExecutionContext execContext = smooks.createExecutionContext();
         StringWriter result = new StringWriter();
 

--- a/core/src/test/java/org/smooks/engine/resource/visitor/smooks/NestedSmooksVisitorTestCase.java
+++ b/core/src/test/java/org/smooks/engine/resource/visitor/smooks/NestedSmooksVisitorTestCase.java
@@ -120,7 +120,7 @@ public class NestedSmooksVisitorTestCase {
         StringResult stringResult = new StringResult();
         smooks.filterSource(new DOMSource(new DOMWriter().write(DocumentHelper.createDocument().
                 addElement("a").addText("bar").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
     }
 
     @Test
@@ -146,7 +146,7 @@ public class NestedSmooksVisitorTestCase {
         StringResult stringResult = new StringResult();
         smooks.filterSource(new DOMSource(new DOMWriter().write(DocumentHelper.createDocument().
                 addElement("a").addElement("b").addElement("c").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
 
         assertEquals(0, countDownLatch.getCount());
     }
@@ -174,7 +174,7 @@ public class NestedSmooksVisitorTestCase {
         StringResult stringResult = new StringResult();
         smooks.filterSource(new DOMSource(new DOMWriter().write(DocumentHelper.createDocument().
                 addElement("a").addElement("b").addElement("c").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
 
         assertEquals(0, countDownLatch.getCount());
     }
@@ -221,7 +221,7 @@ public class NestedSmooksVisitorTestCase {
         StringResult stringResult = new StringResult();
         smooks.filterSource(new DOMSource(new DOMWriter().write(DocumentHelper.createDocument().
                 addElement("a").addElement("b").addElement("c").addText("Hello World!").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
 
         assertEquals(0, countDownLatch.getCount());
     }
@@ -264,7 +264,7 @@ public class NestedSmooksVisitorTestCase {
         smooks.filterSource(new DOMSource(new DOMWriter().write(DocumentHelper.createDocument().
                 addElement("a").
                 addText("foo").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
         
         assertEquals("bar<a>foo</a>", stringResult.toString());
     }
@@ -307,7 +307,7 @@ public class NestedSmooksVisitorTestCase {
         smooks.filterSource(new DOMSource(new DOMWriter().write(DocumentHelper.createDocument().
                 addElement("a").
                 addText("foo").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
 
         assertEquals("<a>barfoo</a>", stringResult.toString());
     }
@@ -351,7 +351,7 @@ public class NestedSmooksVisitorTestCase {
                 addElement("a").
                 addText("foo").
                 addElement("b").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
 
         assertEquals("<a>foobar</a>", stringResult.toString());
     }
@@ -395,7 +395,7 @@ public class NestedSmooksVisitorTestCase {
                 addElement("a").
                 addText("foo").
                 addElement("b").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
 
         assertEquals("<a>foobar</a>", stringResult.toString());
     }
@@ -422,7 +422,7 @@ public class NestedSmooksVisitorTestCase {
         smooks.filterSource(new DOMSource(new DOMWriter().write(DocumentHelper.createDocument().
                 addElement("a").
                 addText("foo").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
 
         assertEquals("bar<a>foo</a>", stringResult.toString());
     }
@@ -449,7 +449,7 @@ public class NestedSmooksVisitorTestCase {
         smooks.filterSource(new DOMSource(new DOMWriter().write(DocumentHelper.createDocument().
                 addElement("a").
                 addText("foo").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
 
         assertEquals("<a>barfoo</a>", stringResult.toString());
     }
@@ -476,7 +476,7 @@ public class NestedSmooksVisitorTestCase {
         smooks.filterSource(new DOMSource(new DOMWriter().write(DocumentHelper.createDocument().
                 addElement("a").
                 addText("foo").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
 
         assertEquals("bar<a>foo</a>", stringResult.toString());
     }
@@ -503,7 +503,7 @@ public class NestedSmooksVisitorTestCase {
         smooks.filterSource(new DOMSource(new DOMWriter().write(DocumentHelper.createDocument().
                 addElement("a").
                 addText("foo").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
 
         assertEquals("<a>barfoo</a>", stringResult.toString());
     }
@@ -530,7 +530,7 @@ public class NestedSmooksVisitorTestCase {
         smooks.filterSource(new DOMSource(new DOMWriter().write(DocumentHelper.createDocument().
                 addElement("a").
                 addText("foo").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
 
         assertEquals("<a>barfoo</a>", stringResult.toString());
     }
@@ -557,7 +557,7 @@ public class NestedSmooksVisitorTestCase {
         smooks.filterSource(new DOMSource(new DOMWriter().write(DocumentHelper.createDocument().
                 addElement("a").
                 addText("foo").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
 
         assertEquals("<a>barfoo</a>", stringResult.toString());
     }
@@ -584,7 +584,7 @@ public class NestedSmooksVisitorTestCase {
         smooks.filterSource(new DOMSource(new DOMWriter().write(DocumentHelper.createDocument().
                 addElement("a").
                 addText("foo").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
 
         assertEquals("<a>foobar</a>", stringResult.toString());
     }
@@ -611,7 +611,7 @@ public class NestedSmooksVisitorTestCase {
         smooks.filterSource(new DOMSource(new DOMWriter().write(DocumentHelper.createDocument().
                 addElement("a").
                 addText("foo").
-                getDocument()).getDocumentElement()), stringResult);
+                getDocument())), stringResult);
 
         assertEquals("<a>foo</a>bar", stringResult.toString());
     }

--- a/core/src/test/java/org/smooks/tck/MockExecutionContext.java
+++ b/core/src/test/java/org/smooks/tck/MockExecutionContext.java
@@ -45,6 +45,7 @@ package org.smooks.tck;
 import org.smooks.api.ApplicationContext;
 import org.smooks.api.ExecutionContext;
 import org.smooks.api.TypedKey;
+import org.smooks.api.delivery.Filter;
 import org.smooks.api.memento.MementoCaretaker;
 import org.smooks.api.delivery.ContentDeliveryConfig;
 import org.smooks.api.delivery.ContentDeliveryRuntime;
@@ -53,6 +54,7 @@ import org.smooks.api.profile.ProfileSet;
 import org.smooks.engine.DefaultExecutionContext;
 import org.smooks.engine.delivery.DefaultContentDeliveryRuntime;
 import org.smooks.engine.delivery.DefaultReaderPool;
+import org.smooks.engine.resource.config.ParameterAccessor;
 import org.smooks.tck.delivery.dom.MockContentDeliveryConfig;
 import org.smooks.api.bean.context.BeanContext;
 import org.smooks.engine.profile.DefaultProfileSet;
@@ -104,7 +106,7 @@ public class MockExecutionContext implements ExecutionContext {
 	 */
 	@Override
 	public ContentDeliveryRuntime getContentDeliveryRuntime() {
-		return new DefaultContentDeliveryRuntime(new DefaultReaderPool(deliveryConfig), deliveryConfig);
+		return new DefaultContentDeliveryRuntime(new DefaultReaderPool(Integer.parseInt(ParameterAccessor.getParameterValue(Filter.READER_POOL_SIZE, String.class, "0", deliveryConfig))), deliveryConfig);
 	}
 
     public void setContentEncoding(String contentEncoding) throws IllegalArgumentException {

--- a/core/src/test/resources/org/smooks/engine/delivery/JIRAs/MILYN_203/in-message.xml
+++ b/core/src/test/resources/org/smooks/engine/delivery/JIRAs/MILYN_203/in-message.xml
@@ -1,5 +1,5 @@
 <xml>
-    <lyrics><![CDATA[Party!/(Okay party people in the house) //Yo yo, in the place to be/My name is MC Ice-T/I got the Rhyme Syndicate with me/We
+    <lyrics>Party!/(Okay party people in the house) //Yo yo, in the place to be/My name is MC Ice-T/I got the Rhyme Syndicate with me/We
 about to tear stuff up, y'all feel good?/Yo, what the hell y'all wanna do, Syndicate, tonight, what you wanna do? /(Party!)/Randy Mac in the place to
 be, what you wanna do? (Party!)/Nat The Cat, you're in the house tonight, what you wanna do? (Party!)/Donald-D is in the place to be, what you wanna d
 o? (Party!)/Bronx Style Bob is in the house, what you wanna do? (Party!)/Hen-Gee is in the house, what you wanna do, homeboy? (Party!) /My man Shaquel
@@ -64,8 +64,8 @@ Everlast in full effect/Where's my gold record?/Where's my record?/Where's my re
 nald D the notorious, yeah//This is Bronx Style Bob...//Nat The Cat, boy//Randy Mac/One in a million on your back, boy//Yo/So we bout to get outta her
 e/Seems like the police is outside, man/(Yo Ice, man, they got King Tee, Aladdin and Islam)/What, the police, man?/I knew somethin had happened/I was
 wonderin why King Tee missed the party, man/Yo Randy Mac, you got some money?/(Aw, you know what time it is, man/I got...)/Yeah, for some bail, buddy/
-We got to go do some work, man.../]]></lyrics>
-    <lyrics><![CDATA[Party!/(Okay party people in the house) //Yo yo, in the place to be/My name is MC Ice-T/I got the Rhyme Syndicate with me/We
+We got to go do some work, man.../</lyrics>
+    <lyrics>Party!/(Okay party people in the house) //Yo yo, in the place to be/My name is MC Ice-T/I got the Rhyme Syndicate with me/We
 about to tear stuff up, y'all feel good?/Yo, what the hell y'all wanna do, Syndicate, tonight, what you wanna do? /(Party!)/Randy Mac in the place to
 be, what you wanna do? (Party!)/Nat The Cat, you're in the house tonight, what you wanna do? (Party!)/Donald-D is in the place to be, what you wanna d
 o? (Party!)/Bronx Style Bob is in the house, what you wanna do? (Party!)/Hen-Gee is in the house, what you wanna do, homeboy? (Party!) /My man Shaquel
@@ -130,5 +130,5 @@ Everlast in full effect/Where's my gold record?/Where's my record?/Where's my re
 nald D the notorious, yeah//This is Bronx Style Bob...//Nat The Cat, boy//Randy Mac/One in a million on your back, boy//Yo/So we bout to get outta her
 e/Seems like the police is outside, man/(Yo Ice, man, they got King Tee, Aladdin and Islam)/What, the police, man?/I knew somethin had happened/I was
 wonderin why King Tee missed the party, man/Yo Randy Mac, you got some money?/(Aw, you know what time it is, man/I got...)/Yeah, for some bail, buddy/
-We got to go do some work, man.../]]></lyrics>
+We got to go do some work, man.../</lyrics>
 </xml>

--- a/core/src/test/resources/org/smooks/engine/resource/reader/smooks-config-delegate-reader.xml
+++ b/core/src/test/resources/org/smooks/engine/resource/reader/smooks-config-delegate-reader.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<!--
+  ========================LICENSE_START=================================
+  Core
+  %%
+  Copyright (C) 2020 Smooks
+  %%
+  Licensed under the terms of the Apache License Version 2.0, or
+  the GNU Lesser General Public License version 3.0 or later.
+  
+  SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+  
+  ======================================================================
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  
+  ======================================================================
+  
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+  =========================LICENSE_END==================================
+  -->
+
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+                      xmlns:core="https://www.smooks.org/xsd/smooks/smooks-core-1.6.xsd">
+
+    <core:delegate-reader>
+        <resource-config selector="#document">
+            <resource>org.smooks.engine.resource.reader.DelegateReaderFunctionalTestCase$DelegateReaderResource</resource>
+        </resource-config>
+    </core:delegate-reader>
+
+</smooks-resource-list>


### PR DESCRIPTION
eliminate contention between threads

fix race conditions

replace default Xerces SAX parser implementation with Woodstox since tests show a notable improvement

use Aalto SAX parser for benchmarking given that it's faster than Woodstox though it supports less features

rename NodeReader to DelegateReader to convey better meaning

test concurrency during benchmark