### PR TITLE
build: replace log4j-slf4j-impl with log4j-slf4j2-impl to resolve dep…

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -53,7 +53,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <mockobjects-core.version>0.09</mockobjects-core.version>
         <mockobjects-j1.4-j2ee1.3.version>0.07</mockobjects-j1.4-j2ee1.3.version>
         <mvel.version>2.5.0.Final</mvel.version>
-        <slf4j-api.version>2.0.7</slf4j-api.version>
+        <slf4j-api.version>2.0.6</slf4j-api.version>
         <xmlunit.version>2.9.1</xmlunit.version>
         <xstream.version>1.4.20</xstream.version>
     </properties>


### PR DESCRIPTION
…endency convergence error

downgrade org.slf4j:slf4j-api dependency to 2.0.6 to prevent another dependency convergence error