### PR TITLE
refactor!: turn TypedKey into an interface

### DIFF
--- a/api/src/main/java/org/smooks/api/TypedKey.java
+++ b/api/src/main/java/org/smooks/api/TypedKey.java
@@ -51,54 +51,68 @@ import java.util.UUID;
  * @param <T> type of key
  * @see       org.smooks.api.TypedMap
  */
-public final class TypedKey<T> {
-    private final String name;
-    private int hash;
+public interface TypedKey<T> {
+
+    String getName();
 
     /**
      * Constructs a <code>TypedKey</code> with a random UUID for its name.
      */
-    public TypedKey() {
-        this(UUID.randomUUID().toString());
+    static <T> TypedKey<T> of() {
+        return new DefaultTypedKey<>(UUID.randomUUID().toString());
     }
-
 
     /**
      * Constructs a <code>TypedKey</code> with a custom name.
      *
      * @param name identifier to give to this <code>TypedKey</code>
      */
-    public TypedKey(String name) {
-        Objects.requireNonNull(name);
-        this.name = name;
+    static <T> TypedKey<T> of(String name) {
+        return new DefaultTypedKey<>(name);
     }
 
-    public String getName() {
-        return name;
-    }
+    final class DefaultTypedKey<T> implements TypedKey<T> {
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
+        private final String name;
+        private int hash;
+
+        /**
+         * Constructs a <code>TypedKey</code> with a custom name.
+         *
+         * @param name identifier to give to this <code>TypedKey</code>
+         */
+        public DefaultTypedKey(String name) {
+            Objects.requireNonNull(name);
+            this.name = name;
         }
-        if (!(o instanceof TypedKey)) {
-            return false;
-        }
-        TypedKey<?> typedKey = (TypedKey<?>) o;
-        return name.equals(typedKey.name);
-    }
 
-    @Override
-    public int hashCode() {
-        if (hash == 0) {
-            hash = Objects.hash(name);
+        public String getName() {
+            return name;
         }
-        return hash;
-    }
 
-    @Override
-    public String toString() {
-        return name;
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof TypedKey)) {
+                return false;
+            }
+            TypedKey<?> typedKey = (TypedKey<?>) o;
+            return name.equals(typedKey.getName());
+        }
+
+        @Override
+        public int hashCode() {
+            if (hash == 0) {
+                hash = Objects.hash(name);
+            }
+            return hash;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
     }
 }

--- a/benchmark/src/main/java/org/smooks/benchmark/CounterVisitor.java
+++ b/benchmark/src/main/java/org/smooks/benchmark/CounterVisitor.java
@@ -50,7 +50,7 @@ import org.w3c.dom.Element;
 
 public class CounterVisitor implements BeforeVisitor, ExecutionLifecycleInitializable {
     
-    private final TypedKey<Long> counterTypedKey = new TypedKey<>();
+    private final TypedKey<Long> counterTypedKey = TypedKey.of();
     
     @Override
     public void visitBefore(Element element, ExecutionContext executionContext) {

--- a/core/src/main/java/org/smooks/engine/delivery/AbstractParser.java
+++ b/core/src/main/java/org/smooks/engine/delivery/AbstractParser.java
@@ -94,7 +94,7 @@ public class AbstractParser {
     public static final String FEATURE_OFF = "feature-off";
     
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractParser.class);
-    private static final TypedKey<Stack<XMLReader>> XML_READER_STACK_TYPED_KEY = new TypedKey<>();
+    private static final TypedKey<Stack<XMLReader>> XML_READER_STACK_TYPED_KEY = TypedKey.of();
     
     private final ExecutionContext executionContext;
     private final ResourceConfig saxDriverConfig;

--- a/core/src/main/java/org/smooks/engine/delivery/SmooksContentHandler.java
+++ b/core/src/main/java/org/smooks/engine/delivery/SmooksContentHandler.java
@@ -62,7 +62,7 @@ import org.xml.sax.ext.DefaultHandler2;
  */
 public abstract class SmooksContentHandler extends DefaultHandler2 implements SAXEventReplay {
 
-    private static final TypedKey<SmooksContentHandler> SMOOKS_CONTENT_HANDLER_TYPED_KEY = new TypedKey<>();
+    private static final TypedKey<SmooksContentHandler> SMOOKS_CONTENT_HANDLER_TYPED_KEY = TypedKey.of();
 
     private final ExecutionContext executionContext;
     private final SmooksContentHandler parentContentHandler;

--- a/core/src/main/java/org/smooks/engine/delivery/dom/SmooksDOMFilter.java
+++ b/core/src/main/java/org/smooks/engine/delivery/dom/SmooksDOMFilter.java
@@ -197,7 +197,7 @@ public class SmooksDOMFilter extends AbstractFilter {
      * request.  This is needed because Xerces doesn't allow "overwriting" of
      * the document root node.
      */
-    private static final TypedKey<Node> DELIVERY_NODE_REQUEST_KEY = new TypedKey<>();
+    private static final TypedKey<Node> DELIVERY_NODE_REQUEST_KEY = TypedKey.of();
 
     private final Boolean closeSource;
     private final Boolean closeResult;

--- a/core/src/main/java/org/smooks/engine/delivery/dom/serialize/ContextObjectSerializerVisitor.java
+++ b/core/src/main/java/org/smooks/engine/delivery/dom/serialize/ContextObjectSerializerVisitor.java
@@ -72,10 +72,10 @@ public class ContextObjectSerializerVisitor implements DOMSerializerVisitor, Ele
     public void writeStartElement(Element element, Writer writer, ExecutionContext executionContext) throws IOException {
         String key = getContextKey(element);
 
-        if(key != null) {
-            Object object = executionContext.get(new TypedKey<>(key));
+        if (key != null) {
+            Object object = executionContext.get(TypedKey.of(key));
 
-            if(object != null) {
+            if (object != null) {
                 writer.write(object.toString());
             } else {
                 LOGGER.debug("Invalid <context-object> specification at '" + DomUtils.getXPath(element) + "'. No Object instance found on context at '" + key + "'.");
@@ -120,8 +120,9 @@ public class ContextObjectSerializerVisitor implements DOMSerializerVisitor, Ele
 
     /**
      * Utility method for creating a &lt;context-object/&gt; element.
+     *
      * @param ownerDocument The owner document.
-     * @param key The context key.
+     * @param key           The context key.
      * @return The &lt;context-object/&gt; element.
      */
     public static Element createElement(Document ownerDocument, String key) {
@@ -140,17 +141,17 @@ public class ContextObjectSerializerVisitor implements DOMSerializerVisitor, Ele
 
     @Override
     public void visitAfter(Element element, ExecutionContext executionContext) throws SmooksException {
-        
+
     }
 
     @Override
     public void visitBefore(Element element, ExecutionContext executionContext) throws SmooksException {
 
     }
-    
+
     @Override
     public void visitChildText(CharacterData characterData, ExecutionContext executionContext) {
-        
+
     }
 
     @Override

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/session/Session.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/session/Session.java
@@ -65,7 +65,7 @@ public class Session {
     }
 
     public TypedKey<Node> getSourceKey() {
-        return new TypedKey<>(node.getAttributes().getNamedItem("source").getNodeValue());
+        return TypedKey.of(node.getAttributes().getNamedItem("source").getNodeValue());
     }
 
     public String getVisit() {
@@ -73,6 +73,6 @@ public class Session {
     }
     
     public Node getSourceValue(ExecutionContext executionContext) {
-        return executionContext.get(new TypedKey<>(node.getAttributes().getNamedItem("source").getNodeValue()));
+        return executionContext.get(TypedKey.of(node.getAttributes().getNamedItem("source").getNodeValue()));
     }
 }

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/session/SessionInterceptor.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/session/SessionInterceptor.java
@@ -54,7 +54,7 @@ import org.w3c.dom.Node;
 public class SessionInterceptor extends AbstractInterceptorVisitor implements ElementVisitor {
     protected boolean doVisit(final Node node, final String currentVisit, final ExecutionContext executionContext) {
         if (((Element) node).getAttribute("visit").equals(currentVisit)) {
-            Node sourceNode = executionContext.get(new TypedKey<>(((Element) node).getAttribute("source")));
+            Node sourceNode = executionContext.get(TypedKey.of(((Element) node).getAttribute("source")));
             if (sourceNode instanceof CharacterData) {
                 return new NodeFragment(sourceNode.getParentNode()).isMatch(getTarget().getResourceConfig().getSelectorPath(), executionContext);
             } else {
@@ -68,7 +68,7 @@ public class SessionInterceptor extends AbstractInterceptorVisitor implements El
     public void visitBefore(final Element element, final ExecutionContext executionContext) {
         if (Session.isSession(element)) {
             if (doVisit(element, "visitBefore", executionContext)) {
-                Object source = executionContext.get(new TypedKey<>(element.getAttribute("source")));
+                Object source = executionContext.get(TypedKey.of(element.getAttribute("source")));
                 intercept(visitBeforeInvocation, source, executionContext);
             }
         } else {
@@ -94,7 +94,7 @@ public class SessionInterceptor extends AbstractInterceptorVisitor implements El
     public void visitAfter(final Element element, final ExecutionContext executionContext) {
         if (Session.isSession(element)) {
             if (doVisit(element, "visitChildText", executionContext) || doVisit(element, "visitAfter", executionContext)) {
-                Object source = executionContext.get(new TypedKey<>(element.getAttribute("source")));
+                Object source = executionContext.get(TypedKey.of(element.getAttribute("source")));
                 if (element.getAttribute("visit").equals("visitChildText")) {
                     visitChildText((CharacterData) source, executionContext);
                 } else {

--- a/core/src/main/java/org/smooks/engine/memento/DefaultMementoCaretaker.java
+++ b/core/src/main/java/org/smooks/engine/memento/DefaultMementoCaretaker.java
@@ -68,12 +68,12 @@ public class DefaultMementoCaretaker implements MementoCaretaker {
     @Override
     public void capture(Memento memento) {
         mementoAnchors.computeIfAbsent(memento.getFragment(), o -> new HashSet<>()).add(memento.getAnchor());
-        typedMap.put(new TypedKey<>(memento.getAnchor()), memento.copy());
+        typedMap.put(TypedKey.of(memento.getAnchor()), memento.copy());
     }
 
     @Override
     public void restore(Memento memento) {
-        final Memento restoredMemento = typedMap.get(new TypedKey<>(memento.getAnchor()));
+        final Memento restoredMemento = typedMap.get(TypedKey.of(memento.getAnchor()));
         if (restoredMemento != null) {
             memento.restore(restoredMemento);
         }
@@ -81,19 +81,19 @@ public class DefaultMementoCaretaker implements MementoCaretaker {
 
     @Override
     public boolean exists(Memento memento) {
-        return typedMap.get(new TypedKey<>(memento.getAnchor())) != null;
+        return typedMap.get(TypedKey.of(memento.getAnchor())) != null;
     }
 
     @Override
     public void forget(Memento visitorMemento) {
-        typedMap.remove(new TypedKey<>(visitorMemento.getAnchor()));
+        typedMap.remove(TypedKey.of(visitorMemento.getAnchor()));
         mementoAnchors.getOrDefault(visitorMemento.getFragment(), new HashSet<>()).remove(visitorMemento.getAnchor());
     }
 
     @Override
     public void forget(Fragment<?> fragment) {
         for (final String anchor : mementoAnchors.getOrDefault(fragment, new HashSet<>())) {
-            typedMap.remove(new TypedKey<>(anchor));
+            typedMap.remove(TypedKey.of(anchor));
         }
         mementoAnchors.remove(fragment);
     }

--- a/core/src/main/java/org/smooks/engine/memento/SimpleVisitorMemento.java
+++ b/core/src/main/java/org/smooks/engine/memento/SimpleVisitorMemento.java
@@ -49,6 +49,6 @@ import org.smooks.api.delivery.fragment.Fragment;
 public class SimpleVisitorMemento<T> extends VisitorMemento<T> {
     
     public SimpleVisitorMemento(final Fragment<?> fragment, final Visitor visitor, final T state) {
-        super(fragment, visitor, new TypedKey<>(state.getClass().getName()), state);
+        super(fragment, visitor, TypedKey.of(state.getClass().getName()), state);
     }
 }

--- a/core/src/main/java/org/smooks/engine/memento/TextAccumulatorMemento.java
+++ b/core/src/main/java/org/smooks/engine/memento/TextAccumulatorMemento.java
@@ -47,7 +47,7 @@ import org.smooks.api.delivery.fragment.Fragment;
 import org.smooks.api.memento.Memento;
 
 public class TextAccumulatorMemento implements Memento {
-    private static final TypedKey<String> ANCHOR_TYPED_KEY = new TypedKey<>();
+    private static final TypedKey<String> ANCHOR_TYPED_KEY = TypedKey.of();
 
     protected final Fragment<?> fragment;
     protected final StringBuilder stringBuilder = new StringBuilder();

--- a/core/src/main/java/org/smooks/engine/resource/config/DefaultResourceConfig.java
+++ b/core/src/main/java/org/smooks/engine/resource/config/DefaultResourceConfig.java
@@ -234,12 +234,12 @@ public class DefaultResourceConfig implements ResourceConfig {
 
 
     @Override
-    public void setSelector(final String selector, final Properties namespaces) {
+    public void setSelector(String selector, Properties namespaces) {
         if (selector != null) {
             if (selectorPath == null) {
                 selectorPath = SelectorPathFactory.newSelectorPath(selector, namespaces);
             } else {
-                selectorPath = SelectorPathFactory.newSelectorPath(selector, selectorPath);
+                selectorPath = SelectorPathFactory.newSelectorPath(selector, selectorPath.getNamespaces(), selectorPath.getConditionEvaluator());
                 selectorPath.getNamespaces().putAll(namespaces);
             }
         } else {
@@ -277,7 +277,7 @@ public class DefaultResourceConfig implements ResourceConfig {
 
     @Override
     public void setTargetProfile(String targetProfile) {
-        if (targetProfile == null || targetProfile.trim().equals("")) {
+        if (targetProfile == null || targetProfile.trim().isEmpty()) {
             // Default the target profile to everything if not specified.
             targetProfile = Profile.DEFAULT_PROFILE;
         }

--- a/core/src/main/java/org/smooks/engine/resource/config/xpath/ElementPositionCounter.java
+++ b/core/src/main/java/org/smooks/engine/resource/config/xpath/ElementPositionCounter.java
@@ -62,7 +62,7 @@ import org.w3c.dom.Node;
 public class ElementPositionCounter implements BeforeVisitor {
 
     private final SelectorStep selectorStep;
-    private final TypedKey<String> positionMementoTypedKey = new TypedKey<>();
+    private final TypedKey<String> positionMementoTypedKey = TypedKey.of();
 
     public ElementPositionCounter(SelectorStep selectorStep) {
         this.selectorStep = selectorStep;

--- a/core/src/main/java/org/smooks/engine/resource/config/xpath/SelectorPathFactory.java
+++ b/core/src/main/java/org/smooks/engine/resource/config/xpath/SelectorPathFactory.java
@@ -66,12 +66,12 @@ public final class SelectorPathFactory {
     }
 
     public static SelectorPath newSelectorPath(final SelectorPath selectorPath) {
-        return newSelectorPath(selectorPath.getSelector(), selectorPath);
+        return newSelectorPath(selectorPath.getSelector(), selectorPath.getNamespaces(), selectorPath.getConditionEvaluator());
     }
 
-    public static SelectorPath newSelectorPath(final String selector, SelectorPath selectorPath) {
-        SelectorPath newSelectorPath = newSelectorPath(selector, selectorPath.getNamespaces());
-        newSelectorPath.setConditionEvaluator(selectorPath.getConditionEvaluator());
+    public static SelectorPath newSelectorPath(final String selector, Properties namespaces, ExpressionEvaluator conditionEvaluator) {
+        SelectorPath newSelectorPath = newSelectorPath(selector, namespaces);
+        newSelectorPath.setConditionEvaluator(conditionEvaluator);
 
         return newSelectorPath;
     }

--- a/core/src/main/java/org/smooks/engine/resource/extension/ExtensionContext.java
+++ b/core/src/main/java/org/smooks/engine/resource/extension/ExtensionContext.java
@@ -61,7 +61,7 @@ import java.util.Stack;
  */
 public class ExtensionContext {
 
-    public static final TypedKey<ExtensionContext> EXTENSION_CONTEXT_TYPED_KEY = new TypedKey<>();
+    public static final TypedKey<ExtensionContext> EXTENSION_CONTEXT_TYPED_KEY = TypedKey.of();
 
     private final XMLConfigDigester xmlConfigDigester;
     private final String defaultProfile;

--- a/core/src/main/java/org/smooks/engine/resource/reader/DelegateReader.java
+++ b/core/src/main/java/org/smooks/engine/resource/reader/DelegateReader.java
@@ -87,8 +87,8 @@ import java.util.HashMap;
 import java.util.Optional;
 
 public class DelegateReader implements SmooksXMLReader {
-    private final TypedKey<Writer> contentHandlerTypedKey = new TypedKey<>();
-    private final TypedKey<ExecutionContext> executionContextTypedKey = new TypedKey<>();
+    private final TypedKey<Writer> contentHandlerTypedKey = TypedKey.of();
+    private final TypedKey<ExecutionContext> executionContextTypedKey = TypedKey.of();
     
     private ContentHandler contentHandler;
     private Smooks readerSmooks;

--- a/core/src/main/java/org/smooks/engine/resource/visitor/dom/DOMModel.java
+++ b/core/src/main/java/org/smooks/engine/resource/visitor/dom/DOMModel.java
@@ -56,7 +56,7 @@ import java.util.Map;
  */
 public class DOMModel {
 
-    public static final TypedKey<DOMModel> DOM_MODEL_TYPED_KEY = new TypedKey<>();
+    public static final TypedKey<DOMModel> DOM_MODEL_TYPED_KEY = TypedKey.of();
     private final Map<String, Element> models = new LinkedHashMap<String, Element>();
 
     public Map<String, Element> getModels() {

--- a/core/src/main/java/org/smooks/engine/resource/visitor/dom/DomModelCreator.java
+++ b/core/src/main/java/org/smooks/engine/resource/visitor/dom/DomModelCreator.java
@@ -135,7 +135,7 @@ import java.util.stream.Stream;
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
 public class DomModelCreator implements BeforeVisitor, AfterVisitor, Producer {
-    private static final TypedKey<Stack<DOMCreator>> DOM_CREATOR_STACK_TYPED_KEY = new TypedKey<>();
+    private static final TypedKey<Stack<DOMCreator>> DOM_CREATOR_STACK_TYPED_KEY = TypedKey.of();
     private final DocumentBuilder documentBuilder;
 
     @Inject

--- a/core/src/main/java/org/smooks/engine/resource/visitor/smooks/NestedSmooksVisitor.java
+++ b/core/src/main/java/org/smooks/engine/resource/visitor/smooks/NestedSmooksVisitor.java
@@ -114,9 +114,9 @@ public class NestedSmooksVisitor implements BeforeVisitor, AfterVisitor, Produce
         OUTPUT_TO
     }
 
-    protected static final TypedKey<Node> SOURCE_SESSION_TYPED_KEY = new TypedKey<>();
-    protected static final TypedKey<DocumentBuilder> CACHED_DOCUMENT_BUILDER_TYPED_KEY = new TypedKey<>();
-    protected static final TypedKey<ExecutionContext> NESTED_EXECUTION_CONTEXT_MEMENTO_TYPED_KEY = new TypedKey<>();
+    protected static final TypedKey<Node> SOURCE_SESSION_TYPED_KEY = TypedKey.of();
+    protected static final TypedKey<DocumentBuilder> CACHED_DOCUMENT_BUILDER_TYPED_KEY = TypedKey.of();
+    protected static final TypedKey<ExecutionContext> NESTED_EXECUTION_CONTEXT_MEMENTO_TYPED_KEY = TypedKey.of();
 
     protected BeanId bindBeanId;
 

--- a/core/src/main/java/org/smooks/engine/xml/DocType.java
+++ b/core/src/main/java/org/smooks/engine/xml/DocType.java
@@ -57,7 +57,7 @@ import java.util.List;
  */
 public abstract class DocType {
 
-    private static final TypedKey<DocumentTypeData> DOCTYPE_KEY = new TypedKey<>();
+    private static final TypedKey<DocumentTypeData> DOCTYPE_KEY = TypedKey.of();
 
     public static void setDocType(String name, String publicId, String systemId, String xmlns, ExecutionContext executionContext) {
         executionContext.put(DOCTYPE_KEY, new DocumentTypeData(name, publicId, systemId, xmlns));

--- a/core/src/main/java/org/smooks/engine/xml/NamespaceManager.java
+++ b/core/src/main/java/org/smooks/engine/xml/NamespaceManager.java
@@ -66,7 +66,7 @@ import java.util.Properties;
  */
 public class NamespaceManager {
 
-	public static final TypedKey<NamespaceDeclarationStack> NAMESPACE_DECLARATION_STACK_TYPED_KEY = new TypedKey<>();
+	public static final TypedKey<NamespaceDeclarationStack> NAMESPACE_DECLARATION_STACK_TYPED_KEY = TypedKey.of();
 
 	/**
      * Logger.

--- a/core/src/main/java/org/smooks/io/AbstractOutputStreamResource.java
+++ b/core/src/main/java/org/smooks/io/AbstractOutputStreamResource.java
@@ -173,16 +173,16 @@ public abstract class AbstractOutputStreamResource implements DOMVisitBefore, Co
      */
     protected void closeResource(final ExecutionContext executionContext) {
         try {
-            Closeable output = executionContext.get(new TypedKey<>(OUTPUTSTREAM_CONTEXT_KEY_PREFIX + getResourceName()));
+            Closeable output = executionContext.get(TypedKey.of(OUTPUTSTREAM_CONTEXT_KEY_PREFIX + getResourceName()));
             close(output);
         } finally {
-            executionContext.remove(new TypedKey<>(OUTPUTSTREAM_CONTEXT_KEY_PREFIX + getResourceName()));
-            executionContext.remove(new TypedKey<>(RESOURCE_CONTEXT_KEY_PREFIX + getResourceName()));
+            executionContext.remove(TypedKey.of(OUTPUTSTREAM_CONTEXT_KEY_PREFIX + getResourceName()));
+            executionContext.remove(TypedKey.of(RESOURCE_CONTEXT_KEY_PREFIX + getResourceName()));
         }
     }
 
     private void bind(final ExecutionContext executionContext) {
-        executionContext.put(new TypedKey<>(RESOURCE_CONTEXT_KEY_PREFIX + getResourceName()), this);
+        executionContext.put(TypedKey.of(RESOURCE_CONTEXT_KEY_PREFIX + getResourceName()), this);
     }
 
     private void close(final Closeable closeable) {

--- a/core/src/main/java/org/smooks/io/ResourceOutputStream.java
+++ b/core/src/main/java/org/smooks/io/ResourceOutputStream.java
@@ -75,11 +75,11 @@ public class ResourceOutputStream extends OutputStream {
      * @throws SmooksException Unable to access OutputStream.
      */
     protected OutputStream getOutputStream(final String resourceName, final ExecutionContext executionContext) throws SmooksException {
-        TypedKey<Object> resourceKey = new TypedKey<>(OUTPUTSTREAM_CONTEXT_KEY_PREFIX + resourceName);
+        TypedKey<Object> resourceKey = TypedKey.of(OUTPUTSTREAM_CONTEXT_KEY_PREFIX + resourceName);
         Object resourceIOObj = executionContext.get(resourceKey);
 
         if (resourceIOObj == null) {
-            AbstractOutputStreamResource resource = executionContext.get(new TypedKey<>(RESOURCE_CONTEXT_KEY_PREFIX + resourceName));
+            AbstractOutputStreamResource resource = executionContext.get(TypedKey.of(RESOURCE_CONTEXT_KEY_PREFIX + resourceName));
             OutputStream outputStream = openOutputStream(resource, resourceName, executionContext);
 
             executionContext.put(resourceKey, outputStream);

--- a/core/src/main/java/org/smooks/io/ResourceWriter.java
+++ b/core/src/main/java/org/smooks/io/ResourceWriter.java
@@ -97,11 +97,11 @@ public class ResourceWriter extends Writer {
      * @throws SmooksException Unable to access OutputStream.
      */
     protected Writer getOutputWriter(final String resourceName, final ExecutionContext executionContext) throws SmooksException {
-        final TypedKey<Object> resourceKey = new TypedKey<>(OUTPUTSTREAM_CONTEXT_KEY_PREFIX + resourceName);
+        final TypedKey<Object> resourceKey = TypedKey.of(OUTPUTSTREAM_CONTEXT_KEY_PREFIX + resourceName);
         final Object resourceIOObj = executionContext.get(resourceKey);
 
         if (resourceIOObj == null) {
-            final AbstractOutputStreamResource resource = executionContext.get(new TypedKey<>(RESOURCE_CONTEXT_KEY_PREFIX + resourceName));
+            final AbstractOutputStreamResource resource = executionContext.get(TypedKey.of(RESOURCE_CONTEXT_KEY_PREFIX + resourceName));
             final OutputStream outputStream = openOutputStream(resource, executionContext);
             if (outputStream != null) {
                 Writer outputStreamWriter = new java.io.OutputStreamWriter(outputStream, resource.getWriterEncoding());

--- a/core/src/main/java/org/smooks/io/Stream.java
+++ b/core/src/main/java/org/smooks/io/Stream.java
@@ -48,7 +48,7 @@ import org.smooks.api.TypedKey;
 import java.io.Writer;
 
 public final class Stream {
-    public static final TypedKey<Writer> STREAM_WRITER_TYPED_KEY = new TypedKey<>();
+    public static final TypedKey<Writer> STREAM_WRITER_TYPED_KEY = TypedKey.of();
     
     private Stream() {
 

--- a/core/src/main/java/org/smooks/io/payload/FilterResult.java
+++ b/core/src/main/java/org/smooks/io/payload/FilterResult.java
@@ -54,7 +54,7 @@ import javax.xml.transform.Result;
  */
 public abstract class FilterResult implements Result {
 
-    public static final TypedKey<Result[]> RESULTS_TYPED_KEY = new TypedKey<>();
+    public static final TypedKey<Result[]> RESULTS_TYPED_KEY = TypedKey.of();
 
     private String systemId;
 

--- a/core/src/main/java/org/smooks/io/payload/FilterSource.java
+++ b/core/src/main/java/org/smooks/io/payload/FilterSource.java
@@ -54,7 +54,7 @@ import javax.xml.transform.Source;
  */
 public abstract class FilterSource implements Source {
 
-    public static final TypedKey<Source> SOURCE_TYPED_KEY = new TypedKey<>();
+    public static final TypedKey<Source> SOURCE_TYPED_KEY = TypedKey.of();
 
     private String systemId;
 

--- a/core/src/main/java/org/smooks/support/FreeMarkerUtils.java
+++ b/core/src/main/java/org/smooks/support/FreeMarkerUtils.java
@@ -59,7 +59,7 @@ import java.util.Set;
  */
 public abstract class FreeMarkerUtils {
 
-    private static final TypedKey<Map<String, ElementToNodeModel>> ELEMENT_TO_NODE_MODEL_TYPED_KEY = new TypedKey<>();
+    private static final TypedKey<Map<String, ElementToNodeModel>> ELEMENT_TO_NODE_MODEL_TYPED_KEY = TypedKey.of();
     
     /**
      * Get a "merged" model for FreeMarker templating.

--- a/core/src/test/java/org/smooks/engine/DefaultExecutionContextTestCase.java
+++ b/core/src/test/java/org/smooks/engine/DefaultExecutionContextTestCase.java
@@ -64,7 +64,7 @@ public class DefaultExecutionContextTestCase {
 
     @Test
     public void testGetAttributes() {
-        final TypedKey<String> key = new TypedKey<>("testKey");
+        final TypedKey<String> key = TypedKey.of("testKey");
         final String value = "testValue";
         context.put(key, value);
 

--- a/core/src/test/java/org/smooks/engine/delivery/dom/serialize/ContextObjectSerializationUnitTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/dom/serialize/ContextObjectSerializationUnitTestCase.java
@@ -68,7 +68,7 @@ public class ContextObjectSerializationUnitTestCase {
         ParameterAccessor.setParameter(Filter.STREAM_FILTER_TYPE, "DOM", smooks);
 
         context = smooks.createExecutionContext();
-        context.put(new TypedKey<>("object-x"), "Hi there!");
+        context.put(TypedKey.of("object-x"), "Hi there!");
 
         String result = SmooksUtil.filterAndSerialize(context, new ByteArrayInputStream(("<context-object key='object-x' xmlns=\"" + Namespace.SMOOKS_URI + "\" />").getBytes()), smooks);
         assertEquals("Hi there!", result);

--- a/core/src/test/java/org/smooks/engine/resource/reader/DelegateReaderFunctionalTestCase.java
+++ b/core/src/test/java/org/smooks/engine/resource/reader/DelegateReaderFunctionalTestCase.java
@@ -64,7 +64,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class DelegateReaderFunctionalTestCase {
 
     public static class DelegateReaderResource implements ElementVisitor {
-        private final TypedKey<FragmentWriter> fragmentWriterTypedKey = new TypedKey<>();
+        private final TypedKey<FragmentWriter> fragmentWriterTypedKey = TypedKey.of();
 
         @Override
         public void visitBefore(Element element, ExecutionContext executionContext) {

--- a/core/src/test/java/org/smooks/io/AbstractOutputStreamResourceTestCase.java
+++ b/core/src/test/java/org/smooks/io/AbstractOutputStreamResourceTestCase.java
@@ -123,7 +123,7 @@ public class AbstractOutputStreamResourceTestCase
     }
 
     private Object getResource(AbstractOutputStreamResource resource, MockExecutionContext executionContext) {
-        return executionContext.get(new TypedKey<>(AbstractOutputStreamResource.RESOURCE_CONTEXT_KEY_PREFIX + resource.getResourceName()));
+        return executionContext.get(TypedKey.of(AbstractOutputStreamResource.RESOURCE_CONTEXT_KEY_PREFIX + resource.getResourceName()));
     }
 
     /**

--- a/core/src/test/java/org/smooks/support/MultiLineToStringBuilderTestCase.java
+++ b/core/src/test/java/org/smooks/support/MultiLineToStringBuilderTestCase.java
@@ -104,7 +104,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 		context.getBeanContext().addBean("objectMap", objectMap, null);
 
-		context.put(new TypedKey<>("multiline"), "hello\nworld");
+		context.put(TypedKey.of("multiline"), "hello\nworld");
 
 		String actual = MultiLineToStringBuilder.toString(context);
 


### PR DESCRIPTION
BREAKING CHANGE: `new TypedKey(String)` becomes `TypedKey#of(String)` and `new TypedKey()` becomes `TypedKey#of()`