### PR TITLE
refactor!: give better names to lifecycle classes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -135,6 +135,10 @@ Comparing the https://github.com/smooks/smooks/tree/v1.7.1/smooks-examples[code 
 . Follow the https://github.com/smooks/smooks-examples/tree/master/edifact-to-java[EDIFACT-to-Java example] to migrate an implementation that binds an EDIFACT document to a POJO.
 . Follow the https://github.com/smooks/smooks-examples/tree/master/java-to-edifact[Java-to-EDIFACT example] to migrate an implementation that deserialises a POJO into an EDIFACT document.
 . Set `ContainerResourceLocator` from `DefaultApplicationContextBuilder#setResourceLocator` instead from `ApplicationContext#setResourceLocator`.
+. Replace class implementations of:
+    * `org.milyn.delivery.ExecutionLifecycleInitializable` with `org.smooks.api.lifecycle.PreExecutionLifecycle`.
+    * `org.milyn.delivery.ExecutionLifecycleCleanable` with `org.smooks.api.lifecycle.PostExecutionLifecycle`.
+    * `org.milyn.delivery.VisitLifecycleCleanable` with `org.smooks.api.lifecycle.PostFragmentLifecycle`.
 
 === FAQs
 
@@ -2053,52 +2057,52 @@ smooks.filterSource(new StreamSource(inReader), new StreamResult(outWriter));
 
 ==== Visitor Instance Lifecycle
 
-One aspect of the visitor lifecycle has already been discussed in the general context of Smooks component link:#initialize-and-uninitialize[initialization and uninitialization].
+One aspect of the visitor lifecycle has already been discussed in the general context of Smooks component link:#initialize-and-uninitialize[initialization and un-initialization].
 
-Smooks supports two additional component lifecycle events, specific to visitor components, via the `+ExecutionLifecycleCleanable+` and `+VisitLifecycleCleanable+` interfaces.
+Smooks supports two additional component lifecycle events, specific to visitor components, via the `+PostExecutionLifecycle+` and `+PostFragmentLifecycle+` interfaces.
 
-===== ExecutionLifecycleCleanable
+===== PostExecutionLifecycle
 
 Visitor components implementing this lifecycle interface will be able to perform post `+Smooks.filterSource+` lifecycle operations.
 
 [source,java]
 ----
-public interface ExecutionLifecycleCleanable extends Visitor {
+public interface PostExecutionLifecycle {
 
-    void executeExecutionLifecycleCleanup(ExecutionContext executionContext);
+    void onPostExecution(ExecutionContext executionContext);
 }
 ----
 
-The basic call sequence can be described as follows (note the executeExecutionLifecycleCleanup calls):
+The basic call sequence can be described as follows (note the onPostExecution calls):
 
 [source,java]
 ----
 smooks = new Smooks(..);
 
         smooks.filterSource(...);
-            ** VisitorXX.executeExecutionLifecycleCleanup **
+            ** VisitorXX.onPostExecution **
         smooks.filterSource(...);
-            ** VisitorXX.executeExecutionLifecycleCleanup **
+            ** VisitorXX.onPostExecution **
         smooks.filterSource(...);
-            ** VisitorXX.executeExecutionLifecycleCleanup **
+            ** VisitorXX.onPostExecution **
         ... etc ...
 ----
 
 This lifecycle method allows you to ensure that resources scoped around the `+Smooks.filterSource+` execution lifecycle can be cleaned up for the associated `+ExecutionContext+`.
 
-===== VisitLifecycleCleanable
+===== PostFragmentLifecycle
 
 Visitor components implementing this lifecycle interface will be able to perform post `+AfterVisitor.visitAfter+` lifecycle operations.
 
 [source,java]
 ----
-public interface VisitLifecycleCleanable extends Visitor {
+public interface PostFragmentLifecycle extends Visitor {
 
-    void executeVisitLifecycleCleanup(ExecutionContext executionContext);
+    void onPostFragment(Fragment<?> fragment, ExecutionContext executionContext);
 }
 ----
 
-The basic call sequence can be described as follows (note the executeVisitLifecycleCleanup calls):
+The basic call sequence can be described as follows (note the onPostFragment calls):
 
 ....
 smooks.filterSource(...);
@@ -2109,15 +2113,15 @@ smooks.filterSource(...);
             <child>                      <--- VisitorXX.visitChildElement
             </child>
         </target-fragment>     <--- VisitorXX.visitAfter
-        ** VisitorXX.executeVisitLifecycleCleanup **
+        ** VisitorXX.onPostFragment **
         <target-fragment>      <--- VisitorXX.visitBefore
             Text!!                       <--- VisitorXX.visitChildText
             <child>                      <--- VisitorXX.visitChildElement
             </child>
         </target-fragment>     <--- VisitorXX.visitAfter
-        ** VisitorXX.executeVisitLifecycleCleanup **
+        ** VisitorXX.onPostFragment **
     </message>
-    VisitorXX.executeExecutionLifecycleCleanup
+    VisitorXX.onPostExecution
 
 smooks.filterSource(...);
 
@@ -2127,15 +2131,15 @@ smooks.filterSource(...);
             <child>                      <--- VisitorXX.visitChildElement
             </child>
         </target-fragment>     <--- VisitorXX.visitAfter
-        ** VisitorXX.executeVisitLifecycleCleanup **
+        ** VisitorXX.onPostFragment **
         <target-fragment>      <--- VisitorXX.visitBefore
             Text!!                       <--- VisitorXX.visitChildText
             <child>                      <--- VisitorXX.visitChildElement
             </child>
         </target-fragment>     <--- VisitorXX.visitAfter
-        ** VisitorXX.executeVisitLifecycleCleanup **
+        ** VisitorXX.onPostFragment **
     </message>
-    VisitorXX.executeExecutionLifecycleCleanup
+    VisitorXX.onPostExecution
 ....
 
 This lifecycle method allows you to ensure that resources scoped around a single fragment execution of a SaxNgVisitor implementation can be cleaned up for the associated `+ExecutionContext+`.

--- a/api/src/main/java/org/smooks/api/lifecycle/PostExecutionLifecycle.java
+++ b/api/src/main/java/org/smooks/api/lifecycle/PostExecutionLifecycle.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * Core
+ * API
  * %%
  * Copyright (C) 2020 Smooks
  * %%
@@ -40,26 +40,23 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.delivery.lifecyclecleanup;
+package org.smooks.api.lifecycle;
 
-import org.smooks.api.SmooksException;
 import org.smooks.api.ExecutionContext;
-import org.smooks.api.resource.visitor.dom.DOMVisitBefore;
-import org.smooks.api.resource.visitor.dom.Phase;
-import org.smooks.api.resource.visitor.dom.VisitPhase;
-import org.w3c.dom.Element;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
+ * Post Execution Lifecycle resource.
+ * 
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-@Phase(value = VisitPhase.PROCESSING)
-public class DomProcessingVisitCleanableChecker implements DOMVisitBefore {
+public interface PostExecutionLifecycle {
 
-    public void visitBefore(Element element, ExecutionContext executionContext) throws SmooksException {
-        if(!DomProcessingVisitCleanable.cleaned) {
-            fail("Resource should have been cleaned!");
-        }
-    }
+    /**
+     * Cleanup the resources allocated by this resource for the specified ExecutionContext.
+     * <p/>
+     * Executes the cleanup at the end of the filter execution.
+     *
+     * @param executionContext The ExecutionContext.
+     */
+    void onPostExecution(ExecutionContext executionContext);
 }

--- a/api/src/main/java/org/smooks/api/lifecycle/PostFragmentLifecycle.java
+++ b/api/src/main/java/org/smooks/api/lifecycle/PostFragmentLifecycle.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * Core
+ * API
  * %%
  * Copyright (C) 2020 Smooks
  * %%
@@ -40,24 +40,26 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.delivery.lifecyclecleanup;
+package org.smooks.api.lifecycle;
 
 import org.smooks.api.ExecutionContext;
-import org.smooks.api.SmooksException;
-import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
-import org.w3c.dom.Element;
-
-import static org.junit.jupiter.api.Assertions.fail;
+import org.smooks.api.resource.visitor.Visitor;
+import org.smooks.api.delivery.fragment.Fragment;
 
 /**
+ * Post Fragment Lifecycle resource.
+ *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class SaxVisitCleanableChecker implements BeforeVisitor {
+public interface PostFragmentLifecycle extends Visitor {
 
-    @Override
-    public void visitBefore(Element element, ExecutionContext executionContext) throws SmooksException {
-        if(!SaxVisitCleanable.cleaned) {
-            fail("Resource should have been cleaned!");
-        }
-    }
+    /**
+     * Cleanup the resources allocated by this resource for the specified ExecutionContext.
+     * <p/>
+     * Executes the cleanup at the end of the fragment visit.
+     *
+     * @param fragment The fragment.
+     * @param executionContext The ExecutionContext.
+     */
+    void onPostFragment(Fragment<?> fragment, ExecutionContext executionContext);
 }

--- a/api/src/main/java/org/smooks/api/lifecycle/PreExecutionLifecycle.java
+++ b/api/src/main/java/org/smooks/api/lifecycle/PreExecutionLifecycle.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * Core
+ * API
  * %%
  * Copyright (C) 2020 Smooks
  * %%
@@ -40,27 +40,23 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.lifecycle;
+package org.smooks.api.lifecycle;
 
 import org.smooks.api.ExecutionContext;
-import org.smooks.api.delivery.fragment.Fragment;
-import org.smooks.api.lifecycle.VisitLifecycleCleanable;
-import org.smooks.api.lifecycle.LifecyclePhase;
 
-public class VisitCleanupPhase implements LifecyclePhase {
+/**
+ * Execution Lifecycle Initializable resource.
+ *
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public interface PreExecutionLifecycle {
 
-    private final ExecutionContext executionContext;
-    private final Fragment<?> fragment;
-
-    public VisitCleanupPhase(final Fragment<?> fragment, final ExecutionContext executionContext) {
-        this.fragment = fragment;
-        this.executionContext = executionContext;
-    }
-    
-    @Override
-    public void apply(final Object o) {
-        if (o instanceof VisitLifecycleCleanable) {
-            ((VisitLifecycleCleanable) o).executeVisitLifecycleCleanup(fragment, executionContext);
-        }
-    }
+    /**
+     * Initialize the resources allocated by this resource for the specified ExecutionContext.
+     * <p/>
+     * Executes the initialization at the start of the filter execution.
+     *
+     * @param executionContext The ExecutionContext.
+     */
+    void onPreExecution(ExecutionContext executionContext);
 }

--- a/benchmark/src/main/java/org/smooks/benchmark/CounterVisitor.java
+++ b/benchmark/src/main/java/org/smooks/benchmark/CounterVisitor.java
@@ -44,11 +44,11 @@ package org.smooks.benchmark;
 
 import org.smooks.api.ExecutionContext;
 import org.smooks.api.TypedKey;
-import org.smooks.api.lifecycle.ExecutionLifecycleInitializable;
+import org.smooks.api.lifecycle.PreExecutionLifecycle;
 import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
 import org.w3c.dom.Element;
 
-public class CounterVisitor implements BeforeVisitor, ExecutionLifecycleInitializable {
+public class CounterVisitor implements BeforeVisitor, PreExecutionLifecycle {
     
     private final TypedKey<Long> counterTypedKey = TypedKey.of();
     
@@ -58,7 +58,7 @@ public class CounterVisitor implements BeforeVisitor, ExecutionLifecycleInitiali
     }
 
     @Override
-    public void executeExecutionLifecycleInitialize(ExecutionContext executionContext) {
+    public void onPreExecution(ExecutionContext executionContext) {
         executionContext.put(counterTypedKey, 0L);
     }
 }

--- a/commons/src/main/java/org/smooks/classpath/Scanner.java
+++ b/commons/src/main/java/org/smooks/classpath/Scanner.java
@@ -79,7 +79,7 @@ public class Scanner {
         }
 
         URL[] urls = ((URLClassLoader) classLoader).getURLs();
-        Set<String> alreadyScanned = new HashSet<String>();
+        Set<String> alreadyScanned = new HashSet<>();
 
         for (URL url : urls) {
             String urlPath = url.getFile();

--- a/commons/src/main/java/org/smooks/support/ClassUtils.java
+++ b/commons/src/main/java/org/smooks/support/ClassUtils.java
@@ -70,7 +70,7 @@ import java.util.Set;
 public final class ClassUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClassUtils.class);
-    private static final Map<String, Class> primitives;
+    private static final Map<String, Class<?>> primitives;
 
     static {
         primitives = new HashMap<>();
@@ -96,10 +96,10 @@ public final class ClassUtils {
      * @return The specified class.
      * @throws ClassNotFoundException If the class cannot be found.
      */
-    public static Class forName(final String className, final Class caller) throws ClassNotFoundException {
+    public static Class<?> forName(final String className, final Class<?> caller) throws ClassNotFoundException {
         final ClassLoader threadClassLoader = Thread.currentThread().getContextClassLoader();
 
-        Class primitiveClass = primitives.get(className);
+        Class<?> primitiveClass = primitives.get(className);
         if (primitiveClass != null) {
             return primitiveClass;
         }
@@ -129,7 +129,7 @@ public final class ClassUtils {
      * @param caller       The class of the caller.
      * @return The input stream for the resource or null if not found.
      */
-    public static InputStream getResourceAsStream(final String resourceName, final Class caller) {
+    public static InputStream getResourceAsStream(final String resourceName, final Class<?> caller) {
         final String resource;
 
         if (!resourceName.startsWith("/")) {

--- a/core/src/main/java/org/smooks/engine/DefaultApplicationContext.java
+++ b/core/src/main/java/org/smooks/engine/DefaultApplicationContext.java
@@ -85,14 +85,6 @@ public class DefaultApplicationContext implements ApplicationContext {
      * Private constructor.
      */
     DefaultApplicationContext() {
-		IsAnnotationPresentFilter isAnnotationPresentFilter = new IsAnnotationPresentFilter(Resource.class);
-		Scanner scanner = new Scanner(isAnnotationPresentFilter);
-		try {
-			scanner.scanClasspath(this.getClass().getClassLoader());
-		} catch (IOException e) {
-			throw new SmooksException(e.getMessage(), e);
-		}
-		List<Class<?>> classes = isAnnotationPresentFilter.getClasses();
 		resourceLocator = new URIResourceLocator();
         ((URIResourceLocator)resourceLocator).setBaseURI(URI.create(URIResourceLocator.SCHEME_CLASSPATH + ":/"));
     }

--- a/core/src/main/java/org/smooks/engine/DefaultRegistry.java
+++ b/core/src/main/java/org/smooks/engine/DefaultRegistry.java
@@ -113,7 +113,7 @@ public class DefaultRegistry implements Registry {
         AssertArgument.isNotNull(value, "value");
 
         final String name;
-        if (value.getClass().isAnnotationPresent(Resource.class) && value.getClass().getAnnotation(Resource.class).name().length() > 0) {
+        if (value.getClass().isAnnotationPresent(Resource.class) && !value.getClass().getAnnotation(Resource.class).name().isEmpty()) {
             name = value.getClass().getAnnotation(Resource.class).name();
         } else {
             name = value.getClass().getName() + ":" + UUID.randomUUID();

--- a/core/src/main/java/org/smooks/engine/converter/PreprocessTypeConverter.java
+++ b/core/src/main/java/org/smooks/engine/converter/PreprocessTypeConverter.java
@@ -87,7 +87,7 @@ public class PreprocessTypeConverter implements Configurable, TypeConverter<Stri
         if (delegateTypeConverterFactoryName != null) {
             TypeConverterFactory<String, Object> delegateTypeConverterFactory;
             try {
-                final Class<TypeConverterFactory<?, ?>> typeConverterFactoryClass = ClassUtils.forName(delegateTypeConverterFactoryName, TypeConverterFactory.class);
+                final Class<TypeConverterFactory<?, ?>> typeConverterFactoryClass = (Class<TypeConverterFactory<?, ?>>) ClassUtils.forName(delegateTypeConverterFactoryName, TypeConverterFactory.class);
                 try {
                     delegateTypeConverterFactory = (TypeConverterFactory<String, Object>) typeConverterFactoryClass.newInstance();
                 } catch (InstantiationException | IllegalAccessException e) {

--- a/core/src/main/java/org/smooks/engine/delivery/dom/DOMContentDeliveryConfig.java
+++ b/core/src/main/java/org/smooks/engine/delivery/dom/DOMContentDeliveryConfig.java
@@ -47,7 +47,7 @@ import org.smooks.api.SmooksConfigException;
 import org.smooks.api.delivery.ContentDeliveryConfig;
 import org.smooks.api.delivery.Filter;
 import org.smooks.api.delivery.FilterBypass;
-import org.smooks.api.lifecycle.VisitLifecycleCleanable;
+import org.smooks.api.lifecycle.PostFragmentLifecycle;
 import org.smooks.api.resource.visitor.SerializerVisitor;
 import org.smooks.api.resource.visitor.dom.DOMVisitAfter;
 import org.smooks.api.resource.visitor.dom.DOMVisitBefore;
@@ -67,7 +67,7 @@ public class DOMContentDeliveryConfig extends AbstractContentDeliveryConfig {
     private ContentHandlerBindingIndex<DOMVisitBefore> processingVisitBeforeIndex = new ContentHandlerBindingIndex<>();
     private ContentHandlerBindingIndex<DOMVisitAfter> processingVisitAfterIndex = new ContentHandlerBindingIndex<>();
     private ContentHandlerBindingIndex<SerializerVisitor> serializerVisitorIndex = new ContentHandlerBindingIndex<>();
-    private ContentHandlerBindingIndex<VisitLifecycleCleanable> visitLifecycleCleanableIndex = new ContentHandlerBindingIndex<>();
+    private ContentHandlerBindingIndex<PostFragmentLifecycle> postFragmentLifecycleIndex = new ContentHandlerBindingIndex<>();
     private FilterBypass filterBypass;
 
     public ContentHandlerBindingIndex<DOMVisitBefore> getAssemblyVisitBeforeIndex() {
@@ -111,12 +111,12 @@ public class DOMContentDeliveryConfig extends AbstractContentDeliveryConfig {
     }
 
     @SuppressWarnings("WeakerAccess")
-    public ContentHandlerBindingIndex<VisitLifecycleCleanable> getVisitLifecycleCleanableIndex() {
-        return visitLifecycleCleanableIndex;
+    public ContentHandlerBindingIndex<PostFragmentLifecycle> getPostFragmentLifecycleIndex() {
+        return postFragmentLifecycleIndex;
     }
 
-    public void setVisitLifecycleCleanableIndex(ContentHandlerBindingIndex<VisitLifecycleCleanable> visitLifecycleCleanableIndex) {
-        this.visitLifecycleCleanableIndex = visitLifecycleCleanableIndex;
+    public void setPostFragmentLifecycleIndex(ContentHandlerBindingIndex<PostFragmentLifecycle> postFragmentLifecycleIndex) {
+        this.postFragmentLifecycleIndex = postFragmentLifecycleIndex;
     }
 
     @Override

--- a/core/src/main/java/org/smooks/engine/delivery/dom/DOMFilterProvider.java
+++ b/core/src/main/java/org/smooks/engine/delivery/dom/DOMFilterProvider.java
@@ -47,7 +47,7 @@ import org.smooks.api.delivery.ContentDeliveryConfig;
 import org.smooks.api.delivery.ContentHandler;
 import org.smooks.api.delivery.ContentHandlerBinding;
 import org.smooks.api.delivery.event.ConfigBuilderEvent;
-import org.smooks.api.lifecycle.VisitLifecycleCleanable;
+import org.smooks.api.lifecycle.PostFragmentLifecycle;
 import org.smooks.api.resource.config.ResourceConfig;
 import org.smooks.api.resource.config.xpath.SelectorStep;
 import org.smooks.api.resource.visitor.SerializerVisitor;
@@ -123,8 +123,8 @@ public class DOMFilterProvider extends AbstractFilterProvider {
                 }
             }
 
-            if (visitor instanceof VisitLifecycleCleanable) {
-                domConfig.getVisitLifecycleCleanableIndex().put(targetElement, resourceConfig, (VisitLifecycleCleanable) visitor);
+            if (visitor instanceof PostFragmentLifecycle) {
+                domConfig.getPostFragmentLifecycleIndex().put(targetElement, resourceConfig, (PostFragmentLifecycle) visitor);
             }
         }
 

--- a/core/src/main/java/org/smooks/engine/delivery/interceptor/AbstractInterceptorVisitor.java
+++ b/core/src/main/java/org/smooks/engine/delivery/interceptor/AbstractInterceptorVisitor.java
@@ -128,7 +128,7 @@ public abstract class AbstractInterceptorVisitor implements InterceptorVisitor {
     public interface Invocation<T extends Visitor> {
         Object invoke(T visitor, Object... args);
 
-        Class<T> getTarget();
+        Class<?> getTarget();
     }
 
     protected static class VisitChildTextInvocation implements Invocation<ChildrenVisitor> {

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgHandler.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgHandler.java
@@ -61,7 +61,7 @@ import org.smooks.engine.delivery.event.StartFragmentEvent;
 import org.smooks.engine.delivery.fragment.NodeFragment;
 import org.smooks.engine.delivery.replay.EndElementEvent;
 import org.smooks.engine.delivery.replay.StartElementEvent;
-import org.smooks.engine.lifecycle.VisitCleanupPhase;
+import org.smooks.engine.lifecycle.PostFragmentPhase;
 import org.smooks.engine.lookup.LifecycleManagerLookup;
 import org.smooks.engine.memento.TextAccumulatorMemento;
 import org.smooks.engine.xml.DocType;
@@ -230,10 +230,10 @@ public class SaxNgHandler extends SmooksContentHandler {
             }
 
             final List<ContentHandlerBinding<? extends Visitor>> visitorBindings = currentContentHandlerState.getVisitorBindings().getAll();
-            final VisitCleanupPhase visitCleanupPhase = new VisitCleanupPhase(currentNodeFragment, executionContext);
+            final PostFragmentPhase postFragmentPhase = new PostFragmentPhase(currentNodeFragment, executionContext);
             for (final ContentHandlerBinding<? extends Visitor> visitorBinding : visitorBindings) {
                 if (currentNodeFragment.isMatch(visitorBinding.getResourceConfig().getSelectorPath(), executionContext)) {
-                    lifecycleManager.applyPhase(visitorBinding.getContentHandler(), visitCleanupPhase);
+                    lifecycleManager.applyPhase(visitorBinding.getContentHandler(), postFragmentPhase);
                 }
             }
         }

--- a/core/src/main/java/org/smooks/engine/lifecycle/PostFragmentPhase.java
+++ b/core/src/main/java/org/smooks/engine/lifecycle/PostFragmentPhase.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * API
+ * Core
  * %%
  * Copyright (C) 2020 Smooks
  * %%
@@ -40,26 +40,27 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.api.lifecycle;
+package org.smooks.engine.lifecycle;
 
 import org.smooks.api.ExecutionContext;
-import org.smooks.api.resource.visitor.Visitor;
 import org.smooks.api.delivery.fragment.Fragment;
+import org.smooks.api.lifecycle.PostFragmentLifecycle;
+import org.smooks.api.lifecycle.LifecyclePhase;
 
-/**
- * Visit Lifecycle Cleanable resource.
- *
- * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
- */
-public interface VisitLifecycleCleanable extends Visitor {
+public class PostFragmentPhase implements LifecyclePhase {
 
-    /**
-     * Cleanup the resources allocated by this resource for the specified ExecutionContext.
-     * <p/>
-     * Executes the cleanup at the end of the fragment visit.
-     *
-     * @param fragment The fragment.
-     * @param executionContext The ExecutionContext.
-     */
-    void executeVisitLifecycleCleanup(Fragment<?> fragment, ExecutionContext executionContext);
+    private final ExecutionContext executionContext;
+    private final Fragment<?> fragment;
+
+    public PostFragmentPhase(final Fragment<?> fragment, final ExecutionContext executionContext) {
+        this.fragment = fragment;
+        this.executionContext = executionContext;
+    }
+    
+    @Override
+    public void apply(final Object o) {
+        if (o instanceof PostFragmentLifecycle) {
+            ((PostFragmentLifecycle) o).onPostFragment(fragment, executionContext);
+        }
+    }
 }

--- a/core/src/main/java/org/smooks/engine/lookup/converter/NameTypeConverterFactoryLookup.java
+++ b/core/src/main/java/org/smooks/engine/lookup/converter/NameTypeConverterFactoryLookup.java
@@ -63,7 +63,7 @@ public class NameTypeConverterFactoryLookup<S, T> implements TypeConverterFactor
             final Set<TypeConverterFactory<?, ?>> typeConverterFactories = (Set<TypeConverterFactory<?, ?>>) registryEntries.get(TYPE_CONVERTER_FACTORY_REGISTRY_KEY);
             typeConverterFactory = typeConverterFactories.stream().filter(t -> t.getClass().isAnnotationPresent(Resource.class) && t.getClass().getAnnotation(Resource.class).name().equals(name)).findFirst().orElse(null);
             if (typeConverterFactory == null) {
-                final Class typeConverterFactoryClass;
+                final Class<?> typeConverterFactoryClass;
                 try {
                     typeConverterFactoryClass = ClassUtils.forName(name, NameTypeConverterFactoryLookup.class);
                     typeConverterFactory = typeConverterFactories.stream().filter(t -> t.getClass().equals(typeConverterFactoryClass)).findFirst().orElse(null);

--- a/core/src/main/java/org/smooks/engine/resource/visitor/smooks/NestedSmooksVisitor.java
+++ b/core/src/main/java/org/smooks/engine/resource/visitor/smooks/NestedSmooksVisitor.java
@@ -53,7 +53,7 @@ import org.smooks.api.bean.repository.BeanId;
 import org.smooks.api.delivery.Filter;
 import org.smooks.api.delivery.fragment.Fragment;
 import org.smooks.api.delivery.ordering.Producer;
-import org.smooks.api.lifecycle.ExecutionLifecycleInitializable;
+import org.smooks.api.lifecycle.PreExecutionLifecycle;
 import org.smooks.api.memento.MementoCaretaker;
 import org.smooks.api.resource.config.ResourceConfig;
 import org.smooks.api.resource.config.ResourceConfigSeq;
@@ -99,10 +99,9 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URISyntaxException;
 import java.util.*;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-public class NestedSmooksVisitor implements BeforeVisitor, AfterVisitor, Producer, ExecutionLifecycleInitializable {
+public class NestedSmooksVisitor implements BeforeVisitor, AfterVisitor, Producer, PreExecutionLifecycle {
     
     public enum Action {
         REPLACE,
@@ -204,7 +203,7 @@ public class NestedSmooksVisitor implements BeforeVisitor, AfterVisitor, Produce
     }
 
     @Override
-    public void executeExecutionLifecycleInitialize(final ExecutionContext executionContext) {
+    public void onPreExecution(final ExecutionContext executionContext) {
         final DocumentBuilder documentBuilder;
         try {
             documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();

--- a/core/src/main/java/org/smooks/io/AbstractOutputStreamResource.java
+++ b/core/src/main/java/org/smooks/io/AbstractOutputStreamResource.java
@@ -52,8 +52,8 @@ import org.smooks.api.resource.visitor.dom.DOMVisitBefore;
 import org.smooks.api.delivery.fragment.Fragment;
 import org.smooks.api.delivery.ordering.Consumer;
 import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
-import org.smooks.api.lifecycle.ExecutionLifecycleCleanable;
-import org.smooks.api.lifecycle.VisitLifecycleCleanable;
+import org.smooks.api.lifecycle.PostExecutionLifecycle;
+import org.smooks.api.lifecycle.PostFragmentLifecycle;
 import org.w3c.dom.Element;
 
 import javax.inject.Inject;
@@ -87,7 +87,7 @@ import java.nio.charset.StandardCharsets;
  * @author <a href="mailto:daniel.bevenius@gmail.com">Daniel Bevenius</a>
  *
  */
-public abstract class AbstractOutputStreamResource implements DOMVisitBefore, Consumer, VisitLifecycleCleanable, ExecutionLifecycleCleanable, BeforeVisitor {
+public abstract class AbstractOutputStreamResource implements DOMVisitBefore, Consumer, PostFragmentLifecycle, PostExecutionLifecycle, BeforeVisitor {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractOutputStreamResource.class);
 
     static final String RESOURCE_CONTEXT_KEY_PREFIX = AbstractOutputStreamResource.class.getName() + "#outputresource:";
@@ -148,14 +148,14 @@ public abstract class AbstractOutputStreamResource implements DOMVisitBefore, Co
     }
 
     @Override
-    public void executeVisitLifecycleCleanup(Fragment fragment, ExecutionContext executionContext) {
+    public void onPostFragment(Fragment<?> fragment, ExecutionContext executionContext) {
         if (closeCondition(executionContext)) {
             closeResource(executionContext);
         }
     }
 
     @Override
-    public void executeExecutionLifecycleCleanup(ExecutionContext executionContext) {
+    public void onPostExecution(ExecutionContext executionContext) {
         closeResource(executionContext);
     }
 

--- a/core/src/test/java/org/smooks/engine/delivery/SaxNgHandlerTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/SaxNgHandlerTestCase.java
@@ -51,7 +51,7 @@ import org.smooks.Smooks;
 import org.smooks.api.ExecutionContext;
 import org.smooks.api.SmooksException;
 import org.smooks.api.delivery.fragment.Fragment;
-import org.smooks.api.lifecycle.VisitLifecycleCleanable;
+import org.smooks.api.lifecycle.PostFragmentLifecycle;
 import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
 import org.w3c.dom.Element;
 
@@ -85,9 +85,9 @@ public class SaxNgHandlerTestCase {
     /**
      * Parse a simple XML file containing two tags only distinguished by their namespaces.
      *
-     * This test checks that the {@see VisitLifecycleCleanable#executeVisitLifecycleCleanup(Fragment, ExecutionContext)} are only
+     * This test checks that the {@see PostFragmentLifecycle#onPostFragment(Fragment, ExecutionContext)} are only
      * called for elements matching the full qualified tag name, including the namespace.
-     * Additionally it will also ensure this for {@see SAXVisitBefore#visitBefore(SAXElement, ExecutionContext)}.
+     * Additionally, it will also ensure this for {@see SAXVisitBefore#visitBefore(SAXElement, ExecutionContext)}.
      *
      * Test for MILYN-648 Only execute clean-up handlers targeted at element.
      *
@@ -96,8 +96,8 @@ public class SaxNgHandlerTestCase {
     @Test
     public void executeLifeCycleCleanup_onlyForTargetElements() throws SmooksException {
         // given
-        final VisitBeforeAndLifecycleCleanable firstMock = mock(VisitBeforeAndLifecycleCleanable.class);
-        final VisitBeforeAndLifecycleCleanable secondMock = mock(VisitBeforeAndLifecycleCleanable.class);
+        final VisitBeforeAndPostFragmentLifecycle firstMock = mock(VisitBeforeAndPostFragmentLifecycle.class);
+        final VisitBeforeAndPostFragmentLifecycle secondMock = mock(VisitBeforeAndPostFragmentLifecycle.class);
 
         final Smooks smooks = createSmooks();
         smooks.addVisitor(firstMock, "simple:simple/first:sample");
@@ -114,10 +114,10 @@ public class SaxNgHandlerTestCase {
                 argThat(isSaxElementWithQName(QNAME_FOR_SECOND_SAMPLE)),
                 any(ExecutionContext.class));
 
-        verify(firstMock).executeVisitLifecycleCleanup(
+        verify(firstMock).onPostFragment(
                 argThat(isSaxFragmentWithQName(QNAME_FOR_FIRST_SAMPLE)),
                 any(ExecutionContext.class));
-        verify(firstMock, never()).executeVisitLifecycleCleanup(
+        verify(firstMock, never()).onPostFragment(
                 argThat(isSaxFragmentWithQName(QNAME_FOR_SECOND_SAMPLE)),
                 any(ExecutionContext.class));
 
@@ -128,10 +128,10 @@ public class SaxNgHandlerTestCase {
                 argThat(isSaxElementWithQName(QNAME_FOR_FIRST_SAMPLE)),
                 any(ExecutionContext.class));
 
-        verify(secondMock).executeVisitLifecycleCleanup(
+        verify(secondMock).onPostFragment(
                 argThat(isSaxFragmentWithQName(QNAME_FOR_SECOND_SAMPLE)),
                 any(ExecutionContext.class));
-        verify(secondMock, never()).executeVisitLifecycleCleanup(
+        verify(secondMock, never()).onPostFragment(
                 argThat(isSaxFragmentWithQName(QNAME_FOR_FIRST_SAMPLE)),
                 any(ExecutionContext.class));
 
@@ -159,7 +159,7 @@ public class SaxNgHandlerTestCase {
         return namespaces;
     }
 
-    private interface VisitBeforeAndLifecycleCleanable extends BeforeVisitor, VisitLifecycleCleanable {
+    private interface VisitBeforeAndPostFragmentLifecycle extends BeforeVisitor, PostFragmentLifecycle {
     }
 
     static class SAXMatchers {

--- a/core/src/test/java/org/smooks/engine/delivery/lifecycle/DomAssemblyAfter.java
+++ b/core/src/test/java/org/smooks/engine/delivery/lifecycle/DomAssemblyAfter.java
@@ -40,11 +40,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.delivery.lifecyclecleanup;
+package org.smooks.engine.delivery.lifecycle;
 
 import org.smooks.api.SmooksException;
 import org.smooks.api.ExecutionContext;
-import org.smooks.api.lifecycle.ExecutionLifecycleCleanable;
+import org.smooks.api.lifecycle.PostExecutionLifecycle;
 import org.smooks.api.resource.visitor.dom.DOMVisitAfter;
 import org.smooks.api.resource.visitor.dom.Phase;
 import org.smooks.api.resource.visitor.dom.VisitPhase;
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
 @Phase(value = VisitPhase.ASSEMBLY)
-public class DomAssemblyAfter implements DOMVisitAfter, ExecutionLifecycleCleanable {
+public class DomAssemblyAfter implements DOMVisitAfter, PostExecutionLifecycle {
 
     public static boolean cleaned;
 
@@ -67,7 +67,7 @@ public class DomAssemblyAfter implements DOMVisitAfter, ExecutionLifecycleCleana
     }
 
     @Override
-    public void executeExecutionLifecycleCleanup(ExecutionContext executionContext) {
+    public void onPostExecution(ExecutionContext executionContext) {
         cleaned = true;
     }
 }

--- a/core/src/test/java/org/smooks/engine/delivery/lifecycle/DomAssemblyAfterWithException.java
+++ b/core/src/test/java/org/smooks/engine/delivery/lifecycle/DomAssemblyAfterWithException.java
@@ -40,13 +40,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.delivery.lifecyclecleanup;
+package org.smooks.engine.delivery.lifecycle;
 
 import org.smooks.api.SmooksException;
 import org.smooks.api.ExecutionContext;
-import org.smooks.api.lifecycle.ExecutionLifecycleCleanable;
-import org.smooks.api.lifecycle.ExecutionLifecycleInitializable;
-import org.smooks.api.resource.visitor.dom.DOMVisitBefore;
+import org.smooks.api.lifecycle.PostExecutionLifecycle;
+import org.smooks.api.resource.visitor.dom.DOMVisitAfter;
 import org.smooks.api.resource.visitor.dom.Phase;
 import org.smooks.api.resource.visitor.dom.VisitPhase;
 import org.w3c.dom.Element;
@@ -56,29 +55,21 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-@Phase(value = VisitPhase.PROCESSING)
-public class DomProcessingBefore implements DOMVisitBefore, ExecutionLifecycleInitializable, ExecutionLifecycleCleanable {
+@Phase(value = VisitPhase.ASSEMBLY)
+public class DomAssemblyAfterWithException implements DOMVisitAfter, PostExecutionLifecycle {
 
-    public static boolean initialized;
     public static boolean cleaned;
 
     @Override
-    public void visitBefore(Element element, ExecutionContext executionContext) throws SmooksException {
-        if(!initialized) {
-            fail("Resource should be initialized!");
-        }
+    public void visitAfter(Element element, ExecutionContext executionContext) throws SmooksException {
         if(cleaned) {
-            fail("Resource shouldn't be cleaned yet!");
+            fail("Resource shouldn't be clened yet!");
         }
     }
 
     @Override
-    public void executeExecutionLifecycleInitialize(ExecutionContext executionContext) {
-        initialized = true;
-    }
-
-    @Override
-    public void executeExecutionLifecycleCleanup(ExecutionContext executionContext) {
+    public void onPostExecution(ExecutionContext executionContext) {
         cleaned = true;
+        throw new RuntimeException("Blah");
     }
 }

--- a/core/src/test/java/org/smooks/engine/delivery/lifecycle/DomAssemblyBefore.java
+++ b/core/src/test/java/org/smooks/engine/delivery/lifecycle/DomAssemblyBefore.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * API
+ * Core
  * %%
  * Copyright (C) 2020 Smooks
  * %%
@@ -40,24 +40,35 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.api.lifecycle;
+package org.smooks.engine.delivery.lifecycle;
 
+import org.smooks.api.SmooksException;
 import org.smooks.api.ExecutionContext;
-import org.smooks.api.resource.visitor.Visitor;
+import org.smooks.api.lifecycle.PostExecutionLifecycle;
+import org.smooks.api.resource.visitor.dom.DOMVisitBefore;
+import org.smooks.api.resource.visitor.dom.Phase;
+import org.smooks.api.resource.visitor.dom.VisitPhase;
+import org.w3c.dom.Element;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Execution Lifecycle Cleanable resource.
- * 
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public interface ExecutionLifecycleCleanable extends Visitor {
+@Phase(value = VisitPhase.ASSEMBLY)
+public class DomAssemblyBefore implements DOMVisitBefore, PostExecutionLifecycle {
 
-    /**
-     * Cleanup the resources allocated by this resource for the specified ExecutionContext.
-     * <p/>
-     * Executes the cleanup at the end of the filter execution.
-     *
-     * @param executionContext The ExecutionContext.
-     */
-    void executeExecutionLifecycleCleanup(ExecutionContext executionContext);
+    public static boolean cleaned;
+
+    @Override
+    public void visitBefore(Element element, ExecutionContext executionContext) throws SmooksException {
+        if(cleaned) {
+            fail("Resource shouldn't be cleaned yet!");
+        }
+    }
+
+    @Override
+    public void onPostExecution(ExecutionContext executionContext) {
+        cleaned = true;
+    }
 }

--- a/core/src/test/java/org/smooks/engine/delivery/lifecycle/DomProcessingAfter.java
+++ b/core/src/test/java/org/smooks/engine/delivery/lifecycle/DomProcessingAfter.java
@@ -40,12 +40,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.delivery.lifecyclecleanup;
+package org.smooks.engine.delivery.lifecycle;
 
 import static org.junit.jupiter.api.Assertions.*;
 import org.smooks.api.SmooksException;
 import org.smooks.api.ExecutionContext;
-import org.smooks.api.lifecycle.ExecutionLifecycleCleanable;
+import org.smooks.api.lifecycle.PostExecutionLifecycle;
 import org.smooks.api.resource.visitor.dom.DOMVisitAfter;
 import org.smooks.api.resource.visitor.dom.Phase;
 import org.smooks.api.resource.visitor.dom.VisitPhase;
@@ -55,7 +55,7 @@ import org.w3c.dom.Element;
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
 @Phase(value = VisitPhase.PROCESSING)
-public class DomProcessingAfter implements DOMVisitAfter, ExecutionLifecycleCleanable {
+public class DomProcessingAfter implements DOMVisitAfter, PostExecutionLifecycle {
 
     public static boolean cleaned;
 
@@ -67,7 +67,7 @@ public class DomProcessingAfter implements DOMVisitAfter, ExecutionLifecycleClea
     }
 
     @Override
-    public void executeExecutionLifecycleCleanup(ExecutionContext executionContext) {
+    public void onPostExecution(ExecutionContext executionContext) {
         cleaned = true;
     }
 }

--- a/core/src/test/java/org/smooks/engine/delivery/lifecycle/DomProcessingBefore.java
+++ b/core/src/test/java/org/smooks/engine/delivery/lifecycle/DomProcessingBefore.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * API
+ * Core
  * %%
  * Copyright (C) 2020 Smooks
  * %%
@@ -40,24 +40,45 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.api.lifecycle;
+package org.smooks.engine.delivery.lifecycle;
 
+import org.smooks.api.SmooksException;
 import org.smooks.api.ExecutionContext;
-import org.smooks.api.resource.visitor.Visitor;
+import org.smooks.api.lifecycle.PostExecutionLifecycle;
+import org.smooks.api.lifecycle.PreExecutionLifecycle;
+import org.smooks.api.resource.visitor.dom.DOMVisitBefore;
+import org.smooks.api.resource.visitor.dom.Phase;
+import org.smooks.api.resource.visitor.dom.VisitPhase;
+import org.w3c.dom.Element;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Execution Lifecycle Initializable resource.
- *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public interface ExecutionLifecycleInitializable extends Visitor {
+@Phase(value = VisitPhase.PROCESSING)
+public class DomProcessingBefore implements DOMVisitBefore, PreExecutionLifecycle, PostExecutionLifecycle {
 
-    /**
-     * Initialize the resources allocated by this resource for the specified ExecutionContext.
-     * <p/>
-     * Executes the initialization at the start of the filter execution.
-     *
-     * @param executionContext The ExecutionContext.
-     */
-    void executeExecutionLifecycleInitialize(ExecutionContext executionContext);
+    public static boolean initialized;
+    public static boolean cleaned;
+
+    @Override
+    public void visitBefore(Element element, ExecutionContext executionContext) throws SmooksException {
+        if(!initialized) {
+            fail("Resource should be initialized!");
+        }
+        if(cleaned) {
+            fail("Resource shouldn't be cleaned yet!");
+        }
+    }
+
+    @Override
+    public void onPreExecution(ExecutionContext executionContext) {
+        initialized = true;
+    }
+
+    @Override
+    public void onPostExecution(ExecutionContext executionContext) {
+        cleaned = true;
+    }
 }

--- a/core/src/test/java/org/smooks/engine/delivery/lifecycle/DomProcessingPostFragmentLifecycle.java
+++ b/core/src/test/java/org/smooks/engine/delivery/lifecycle/DomProcessingPostFragmentLifecycle.java
@@ -40,23 +40,25 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.delivery.lifecyclecleanup;
+package org.smooks.engine.delivery.lifecycle;
 
 import org.smooks.api.SmooksException;
 import org.smooks.api.ExecutionContext;
-import org.smooks.api.lifecycle.ExecutionLifecycleCleanable;
+import org.smooks.api.resource.visitor.dom.DOMVisitAfter;
 import org.smooks.api.resource.visitor.dom.DOMVisitBefore;
 import org.smooks.api.resource.visitor.dom.Phase;
 import org.smooks.api.resource.visitor.dom.VisitPhase;
+import org.smooks.api.delivery.fragment.Fragment;
+import org.smooks.api.lifecycle.PostFragmentLifecycle;
 import org.w3c.dom.Element;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-@Phase(value = VisitPhase.ASSEMBLY)
-public class DomAssemblyBefore implements DOMVisitBefore, ExecutionLifecycleCleanable {
+@Phase(value = VisitPhase.PROCESSING)
+public class DomProcessingPostFragmentLifecycle implements DOMVisitBefore, DOMVisitAfter, PostFragmentLifecycle {
 
     public static boolean cleaned;
 
@@ -68,7 +70,14 @@ public class DomAssemblyBefore implements DOMVisitBefore, ExecutionLifecycleClea
     }
 
     @Override
-    public void executeExecutionLifecycleCleanup(ExecutionContext executionContext) {
+    public void visitAfter(Element element, ExecutionContext executionContext) throws SmooksException {
+        if(cleaned) {
+            fail("Resource shouldn't be cleaned yet!");
+        }
+    }
+
+    @Override
+    public void onPostFragment(Fragment fragment, ExecutionContext executionContext) {
         cleaned = true;
     }
 }

--- a/core/src/test/java/org/smooks/engine/delivery/lifecycle/DomProcessingVisitPostFragmentChecker.java
+++ b/core/src/test/java/org/smooks/engine/delivery/lifecycle/DomProcessingVisitPostFragmentChecker.java
@@ -40,42 +40,26 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.delivery.lifecyclecleanup;
+package org.smooks.engine.delivery.lifecycle;
 
-import org.smooks.api.ExecutionContext;
 import org.smooks.api.SmooksException;
-import org.smooks.api.lifecycle.ExecutionLifecycleCleanable;
-import org.smooks.api.lifecycle.ExecutionLifecycleInitializable;
-import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
+import org.smooks.api.ExecutionContext;
+import org.smooks.api.resource.visitor.dom.DOMVisitBefore;
+import org.smooks.api.resource.visitor.dom.Phase;
+import org.smooks.api.resource.visitor.dom.VisitPhase;
 import org.w3c.dom.Element;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class SaxVisitBefore implements BeforeVisitor, ExecutionLifecycleInitializable, ExecutionLifecycleCleanable {
+@Phase(value = VisitPhase.PROCESSING)
+public class DomProcessingVisitPostFragmentChecker implements DOMVisitBefore {
 
-    public static boolean initialized;
-    public static boolean cleaned;
-
-    @Override
     public void visitBefore(Element element, ExecutionContext executionContext) throws SmooksException {
-        if(!initialized) {
-            fail("Resource should be initialized!");
+        if(!DomProcessingPostFragmentLifecycle.cleaned) {
+            fail("Resource should have been cleaned!");
         }
-        if(cleaned) {
-            fail("Resource shouldn't be cleaned yet!");
-        }
-    }
-
-    @Override
-    public void executeExecutionLifecycleInitialize(ExecutionContext executionContext) {
-        initialized = true;
-    }
-
-    @Override
-    public void executeExecutionLifecycleCleanup(ExecutionContext executionContext) {
-        cleaned = true;
     }
 }

--- a/core/src/test/java/org/smooks/engine/delivery/lifecycle/ExecutionLifecycleTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/lifecycle/ExecutionLifecycleTestCase.java
@@ -40,7 +40,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.delivery.lifecyclecleanup;
+package org.smooks.engine.delivery.lifecycle;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,8 +69,8 @@ public class ExecutionLifecycleTestCase {
         SaxVisitBefore.initialized = false;
         SaxVisitBefore.cleaned = false;
         SaxVisitAfter.cleaned = false;
-        DomProcessingVisitCleanable.cleaned = false;
-        SaxVisitCleanable.cleaned = false;
+        DomProcessingPostFragmentLifecycle.cleaned = false;
+        SaxVisitPostFragmentLifecycle.cleaned = false;
     }
 
 	@Test
@@ -91,7 +91,7 @@ public class ExecutionLifecycleTestCase {
         Smooks smooks = new Smooks(getClass().getResourceAsStream("dom-config-02.xml"));
 
         smooks.filterSource(new StringSource("<a></a>"), null);
-        assertTrue(DomProcessingVisitCleanable.cleaned);
+        assertTrue(DomProcessingPostFragmentLifecycle.cleaned);
     }
 
 	@Test
@@ -109,6 +109,6 @@ public class ExecutionLifecycleTestCase {
         Smooks smooks = new Smooks(getClass().getResourceAsStream("sax-config-02.xml"));
 
         smooks.filterSource(new StringSource("<a></a>"), null);
-        assertTrue(SaxVisitCleanable.cleaned);
+        assertTrue(SaxVisitPostFragmentLifecycle.cleaned);
     }
 }

--- a/core/src/test/java/org/smooks/engine/delivery/lifecycle/SaxVisitAfter.java
+++ b/core/src/test/java/org/smooks/engine/delivery/lifecycle/SaxVisitAfter.java
@@ -40,14 +40,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.delivery.lifecyclecleanup;
+package org.smooks.engine.delivery.lifecycle;
 
 import org.smooks.api.ExecutionContext;
 import org.smooks.api.SmooksException;
-import org.smooks.api.delivery.fragment.Fragment;
-import org.smooks.api.lifecycle.VisitLifecycleCleanable;
+import org.smooks.api.lifecycle.PostExecutionLifecycle;
 import org.smooks.api.resource.visitor.sax.ng.AfterVisitor;
-import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
 import org.w3c.dom.Element;
 
 import static org.junit.jupiter.api.Assertions.fail;
@@ -55,16 +53,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class SaxVisitCleanable implements BeforeVisitor, AfterVisitor, VisitLifecycleCleanable {
+public class SaxVisitAfter implements AfterVisitor, PostExecutionLifecycle {
 
     public static boolean cleaned;
-
-    @Override
-    public void visitBefore(Element element, ExecutionContext executionContext) throws SmooksException {
-        if(cleaned) {
-            fail("Resource shouldn't be cleaned yet!");
-        }
-    }
 
     @Override
     public void visitAfter(Element element, ExecutionContext executionContext) throws SmooksException {
@@ -74,7 +65,7 @@ public class SaxVisitCleanable implements BeforeVisitor, AfterVisitor, VisitLife
     }
 
     @Override
-    public void executeVisitLifecycleCleanup(Fragment fragment, ExecutionContext executionContext) {
+    public void onPostExecution(ExecutionContext executionContext) {
         cleaned = true;
     }
 }

--- a/core/src/test/java/org/smooks/engine/delivery/lifecycle/SaxVisitBefore.java
+++ b/core/src/test/java/org/smooks/engine/delivery/lifecycle/SaxVisitBefore.java
@@ -40,36 +40,42 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.delivery.lifecyclecleanup;
+package org.smooks.engine.delivery.lifecycle;
 
-import org.smooks.api.SmooksException;
 import org.smooks.api.ExecutionContext;
-import org.smooks.api.lifecycle.ExecutionLifecycleCleanable;
-import org.smooks.api.resource.visitor.dom.DOMVisitAfter;
-import org.smooks.api.resource.visitor.dom.Phase;
-import org.smooks.api.resource.visitor.dom.VisitPhase;
+import org.smooks.api.SmooksException;
+import org.smooks.api.lifecycle.PostExecutionLifecycle;
+import org.smooks.api.lifecycle.PreExecutionLifecycle;
+import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
 import org.w3c.dom.Element;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-@Phase(value = VisitPhase.ASSEMBLY)
-public class DomAssemblyAfterWithException implements DOMVisitAfter, ExecutionLifecycleCleanable {
+public class SaxVisitBefore implements BeforeVisitor, PreExecutionLifecycle, PostExecutionLifecycle {
 
+    public static boolean initialized;
     public static boolean cleaned;
 
     @Override
-    public void visitAfter(Element element, ExecutionContext executionContext) throws SmooksException {
+    public void visitBefore(Element element, ExecutionContext executionContext) throws SmooksException {
+        if(!initialized) {
+            fail("Resource should be initialized!");
+        }
         if(cleaned) {
-            fail("Resource shouldn't be clened yet!");
+            fail("Resource shouldn't be cleaned yet!");
         }
     }
 
     @Override
-    public void executeExecutionLifecycleCleanup(ExecutionContext executionContext) {
+    public void onPreExecution(ExecutionContext executionContext) {
+        initialized = true;
+    }
+
+    @Override
+    public void onPostExecution(ExecutionContext executionContext) {
         cleaned = true;
-        throw new RuntimeException("Blah");
     }
 }

--- a/core/src/test/java/org/smooks/engine/delivery/lifecycle/SaxVisitPostFragmentChecker.java
+++ b/core/src/test/java/org/smooks/engine/delivery/lifecycle/SaxVisitPostFragmentChecker.java
@@ -40,12 +40,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.delivery.lifecyclecleanup;
+package org.smooks.engine.delivery.lifecycle;
 
 import org.smooks.api.ExecutionContext;
 import org.smooks.api.SmooksException;
-import org.smooks.api.lifecycle.ExecutionLifecycleCleanable;
-import org.smooks.api.resource.visitor.sax.ng.AfterVisitor;
+import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
 import org.w3c.dom.Element;
 
 import static org.junit.jupiter.api.Assertions.fail;
@@ -53,19 +52,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class SaxVisitAfter implements AfterVisitor, ExecutionLifecycleCleanable {
-
-    public static boolean cleaned;
+public class SaxVisitPostFragmentChecker implements BeforeVisitor {
 
     @Override
-    public void visitAfter(Element element, ExecutionContext executionContext) throws SmooksException {
-        if(cleaned) {
-            fail("Resource shouldn't be cleaned yet!");
+    public void visitBefore(Element element, ExecutionContext executionContext) throws SmooksException {
+        if(!SaxVisitPostFragmentLifecycle.cleaned) {
+            fail("Resource should have been cleaned!");
         }
-    }
-
-    @Override
-    public void executeExecutionLifecycleCleanup(ExecutionContext executionContext) {
-        cleaned = true;
     }
 }

--- a/core/src/test/java/org/smooks/engine/delivery/lifecycle/SaxVisitPostFragmentLifecycle.java
+++ b/core/src/test/java/org/smooks/engine/delivery/lifecycle/SaxVisitPostFragmentLifecycle.java
@@ -40,16 +40,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.delivery.lifecyclecleanup;
+package org.smooks.engine.delivery.lifecycle;
 
-import org.smooks.api.SmooksException;
 import org.smooks.api.ExecutionContext;
-import org.smooks.api.resource.visitor.dom.DOMVisitAfter;
-import org.smooks.api.resource.visitor.dom.DOMVisitBefore;
-import org.smooks.api.resource.visitor.dom.Phase;
-import org.smooks.api.resource.visitor.dom.VisitPhase;
+import org.smooks.api.SmooksException;
 import org.smooks.api.delivery.fragment.Fragment;
-import org.smooks.api.lifecycle.VisitLifecycleCleanable;
+import org.smooks.api.lifecycle.PostFragmentLifecycle;
+import org.smooks.api.resource.visitor.sax.ng.AfterVisitor;
+import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
 import org.w3c.dom.Element;
 
 import static org.junit.jupiter.api.Assertions.fail;
@@ -57,8 +55,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-@Phase(value = VisitPhase.PROCESSING)
-public class DomProcessingVisitCleanable implements DOMVisitBefore, DOMVisitAfter, VisitLifecycleCleanable {
+public class SaxVisitPostFragmentLifecycle implements BeforeVisitor, AfterVisitor, PostFragmentLifecycle {
 
     public static boolean cleaned;
 
@@ -77,7 +74,7 @@ public class DomProcessingVisitCleanable implements DOMVisitBefore, DOMVisitAfte
     }
 
     @Override
-    public void executeVisitLifecycleCleanup(Fragment fragment, ExecutionContext executionContext) {
+    public void onPostFragment(Fragment fragment, ExecutionContext executionContext) {
         cleaned = true;
     }
 }

--- a/core/src/test/java/org/smooks/engine/resource/visitor/smooks/NestedSmooksVisitorTestCase.java
+++ b/core/src/test/java/org/smooks/engine/resource/visitor/smooks/NestedSmooksVisitorTestCase.java
@@ -124,7 +124,7 @@ public class NestedSmooksVisitorTestCase {
         ExecutionContext executionContext = new MockExecutionContext();
         executionContext.setContentEncoding("ISO-8859-1");
 
-        nestedSmooksVisitor.executeExecutionLifecycleInitialize(executionContext);
+        nestedSmooksVisitor.onPreExecution(executionContext);
         nestedSmooksVisitor.filterSource(new NodeFragment(DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument()), new NodeFragment(DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument()), null, executionContext, null);
     }
 
@@ -142,7 +142,7 @@ public class NestedSmooksVisitorTestCase {
         ExecutionContext executionContext = new MockExecutionContext();
         executionContext.put(DOMModel.DOM_MODEL_TYPED_KEY, domModel);
 
-        nestedSmooksVisitor.executeExecutionLifecycleInitialize(executionContext);
+        nestedSmooksVisitor.onPreExecution(executionContext);
         nestedSmooksVisitor.filterSource(new NodeFragment(DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument()), new NodeFragment(DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument()), null, executionContext, null);
     }
 

--- a/core/src/test/java/org/smooks/io/AbstractOutputStreamResourceTestCase.java
+++ b/core/src/test/java/org/smooks/io/AbstractOutputStreamResourceTestCase.java
@@ -63,15 +63,14 @@ import static org.junit.jupiter.api.Assertions.*;
  * 
  * @author <a href="mailto:daniel.bevenius@gmail.com">Daniel Bevenius</a>
  */
-public class AbstractOutputStreamResourceTestCase
-{
-	@Test
-	public void getOutputStream () throws ParserConfigurationException {
-		AbstractOutputStreamResource resource = new MockAbstractOutputStreamResource();
-		MockExecutionContext executionContext = new MockExecutionContext();
+public class AbstractOutputStreamResourceTestCase {
+    @Test
+    public void getOutputStream() throws ParserConfigurationException {
+        AbstractOutputStreamResource resource = new MockAbstractOutputStreamResource();
+        MockExecutionContext executionContext = new MockExecutionContext();
 
         assertNull(getResource(resource, executionContext));
-        resource.visitBefore( (Element)null, executionContext );
+        resource.visitBefore(null, executionContext);
         assertNotNull(getResource(resource, executionContext));
 
         ResourceOutputStream outputStreamWriter = new ResourceOutputStream(executionContext, resource.getResourceName());
@@ -83,39 +82,39 @@ public class AbstractOutputStreamResourceTestCase
         try {
             new ResourceWriter(executionContext, resource.getResourceName());
             fail("Expected SmooksException");
-        } catch(SmooksException e) {
+        } catch (SmooksException e) {
             assertEquals("An OutputStream to the 'Mock' resource is already open.  Cannot open a Writer to this resource now!", e.getMessage());
         }
 
-        resource.executeVisitLifecycleCleanup(new NodeFragment(DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument()), executionContext);
+        resource.onPostFragment(new NodeFragment(DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument()), executionContext);
 
         // Should be unbound "after" and the stream should be closed...
         assertNull(getResource(resource, executionContext));
         assertTrue(MockAbstractOutputStreamResource.isClosed);
-	}
+    }
 
     @Test
-    public void getOutputWriter () throws ParserConfigurationException {
+    public void getOutputWriter() throws ParserConfigurationException {
         AbstractOutputStreamResource resource = new MockAbstractOutputStreamResource();
         MockExecutionContext executionContext = new MockExecutionContext();
 
         assertNull(getResource(resource, executionContext));
-        resource.visitBefore( (Element)null, executionContext );
+        resource.visitBefore(null, executionContext);
         assertNotNull(getResource(resource, executionContext));
 
         Writer writer = new ResourceWriter(executionContext, resource.getResourceName()).getDelegateWriter();
         assertNotNull(writer);
-        assertTrue( writer instanceof java.io.OutputStreamWriter);
+        assertTrue(writer instanceof java.io.OutputStreamWriter);
 
         // Should get an error now if we try get an OutputStream to the same resource...
         try {
             new ResourceOutputStream(executionContext, resource.getResourceName());
             fail("Expected SmooksException");
-        } catch(SmooksException e) {
+        } catch (SmooksException e) {
             assertEquals("An Writer to the 'Mock' resource is already open.  Cannot open an OutputStream to this resource now!", e.getMessage());
         }
 
-        resource.executeVisitLifecycleCleanup(new NodeFragment(DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument()), executionContext);
+        resource.onPostFragment(new NodeFragment(DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument()), executionContext);
 
         // Should be unbound "after" and the stream should be closed...
         assertNull(getResource(resource, executionContext));
@@ -127,15 +126,13 @@ public class AbstractOutputStreamResourceTestCase
     }
 
     /**
-	 * Mock class for testing
-	 */
-	private static class MockAbstractOutputStreamResource extends AbstractOutputStreamResource
-	{
+     * Mock class for testing
+     */
+    private static class MockAbstractOutputStreamResource extends AbstractOutputStreamResource {
         public static boolean isClosed;
 
-		@Override
-		public OutputStream getOutputStream( final ExecutionContext executionContext )
-		{
+        @Override
+        public OutputStream getOutputStream(final ExecutionContext executionContext) {
             isClosed = false;
             return new ByteArrayOutputStream() {
                 @Override
@@ -144,18 +141,16 @@ public class AbstractOutputStreamResourceTestCase
                     super.close();
                 }
             };
-		}
+        }
 
-		@Override
-		public String getResourceName()
-		{
-			return "Mock";
-		}
+        @Override
+        public String getResourceName() {
+            return "Mock";
+        }
 
         @Override
         public Charset getWriterEncoding() {
             return StandardCharsets.UTF_8;
         }
     }
-
 }

--- a/core/src/test/java/org/smooks/tck/delivery/dom/MockContentDeliveryConfig.java
+++ b/core/src/test/java/org/smooks/tck/delivery/dom/MockContentDeliveryConfig.java
@@ -66,7 +66,7 @@ public class MockContentDeliveryConfig extends DOMContentDeliveryConfig {
     setProcessingVisitBeforeIndex(new ContentHandlerBindingIndex());
     setProcessingVisitAfterIndex(new ContentHandlerBindingIndex());
     setSerializerVisitorIndex(new ContentHandlerBindingIndex());
-    setVisitLifecycleCleanableIndex(new ContentHandlerBindingIndex());
+    setPostFragmentLifecycleIndex(new ContentHandlerBindingIndex());
   }
 
   /* (non-Javadoc)

--- a/core/src/test/resources/org/smooks/engine/delivery/lifecycle/dom-config-01.xml
+++ b/core/src/test/resources/org/smooks/engine/delivery/lifecycle/dom-config-01.xml
@@ -44,8 +44,32 @@
 
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd">
 
-    <resource-config selector="#document">
-        <resource>org.smooks.engine.delivery.lifecyclecleanup.SaxVisitCleanable</resource>
+    <resource-config selector="a">
+        <resource>org.smooks.engine.delivery.lifecycle.DomAssemblyBefore</resource>
+    </resource-config>
+
+    <resource-config selector="b">
+        <resource>org.smooks.engine.delivery.lifecycle.DomAssemblyAfterWithException</resource>
+    </resource-config>
+
+    <resource-config selector="b">
+        <resource>org.smooks.engine.delivery.lifecycle.DomAssemblyAfter</resource>
+    </resource-config>
+
+    <resource-config selector="b">
+        <resource>org.smooks.engine.delivery.lifecycle.DomProcessingPostFragmentLifecycle</resource>
+    </resource-config>
+
+    <resource-config selector="c">
+        <resource>org.smooks.engine.delivery.lifecycle.DomProcessingVisitPostFragmentChecker</resource>
+    </resource-config>
+
+    <resource-config selector="c">
+        <resource>org.smooks.engine.delivery.lifecycle.DomProcessingBefore</resource>
+    </resource-config>
+
+    <resource-config selector="d">
+        <resource>org.smooks.engine.delivery.lifecycle.DomProcessingAfter</resource>
     </resource-config>
 
 </smooks-resource-list>

--- a/core/src/test/resources/org/smooks/engine/delivery/lifecycle/dom-config-02.xml
+++ b/core/src/test/resources/org/smooks/engine/delivery/lifecycle/dom-config-02.xml
@@ -44,20 +44,8 @@
 
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd">
 
-    <resource-config selector="a">
-        <resource>org.smooks.engine.delivery.lifecyclecleanup.SaxVisitBefore</resource>
-    </resource-config>
-
-    <resource-config selector="b">
-        <resource>org.smooks.engine.delivery.lifecyclecleanup.SaxVisitAfter</resource>
-    </resource-config>
-
-    <resource-config selector="b">
-        <resource>org.smooks.engine.delivery.lifecyclecleanup.SaxVisitCleanable</resource>
-    </resource-config>
-
-    <resource-config selector="c">
-        <resource>org.smooks.engine.delivery.lifecyclecleanup.SaxVisitCleanableChecker</resource>
+    <resource-config selector="#document">
+        <resource>org.smooks.engine.delivery.lifecycle.DomProcessingPostFragmentLifecycle</resource>
     </resource-config>
 
 </smooks-resource-list>

--- a/core/src/test/resources/org/smooks/engine/delivery/lifecycle/sax-config-01.xml
+++ b/core/src/test/resources/org/smooks/engine/delivery/lifecycle/sax-config-01.xml
@@ -44,8 +44,20 @@
 
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd">
 
-    <resource-config selector="#document">
-        <resource>org.smooks.engine.delivery.lifecyclecleanup.DomProcessingVisitCleanable</resource>
+    <resource-config selector="a">
+        <resource>org.smooks.engine.delivery.lifecycle.SaxVisitBefore</resource>
+    </resource-config>
+
+    <resource-config selector="b">
+        <resource>org.smooks.engine.delivery.lifecycle.SaxVisitAfter</resource>
+    </resource-config>
+
+    <resource-config selector="b">
+        <resource>org.smooks.engine.delivery.lifecycle.SaxVisitPostFragmentLifecycle</resource>
+    </resource-config>
+
+    <resource-config selector="c">
+        <resource>org.smooks.engine.delivery.lifecycle.SaxVisitPostFragmentChecker</resource>
     </resource-config>
 
 </smooks-resource-list>

--- a/core/src/test/resources/org/smooks/engine/delivery/lifecycle/sax-config-02.xml
+++ b/core/src/test/resources/org/smooks/engine/delivery/lifecycle/sax-config-02.xml
@@ -44,32 +44,8 @@
 
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd">
 
-    <resource-config selector="a">
-        <resource>org.smooks.engine.delivery.lifecyclecleanup.DomAssemblyBefore</resource>
-    </resource-config>
-
-    <resource-config selector="b">
-        <resource>org.smooks.engine.delivery.lifecyclecleanup.DomAssemblyAfterWithException</resource>
-    </resource-config>
-
-    <resource-config selector="b">
-        <resource>org.smooks.engine.delivery.lifecyclecleanup.DomAssemblyAfter</resource>
-    </resource-config>
-
-    <resource-config selector="b">
-        <resource>org.smooks.engine.delivery.lifecyclecleanup.DomProcessingVisitCleanable</resource>
-    </resource-config>
-
-    <resource-config selector="c">
-        <resource>org.smooks.engine.delivery.lifecyclecleanup.DomProcessingVisitCleanableChecker</resource>
-    </resource-config>
-
-    <resource-config selector="c">
-        <resource>org.smooks.engine.delivery.lifecyclecleanup.DomProcessingBefore</resource>
-    </resource-config>
-
-    <resource-config selector="d">
-        <resource>org.smooks.engine.delivery.lifecyclecleanup.DomProcessingAfter</resource>
+    <resource-config selector="#document">
+        <resource>org.smooks.engine.delivery.lifecycle.SaxVisitPostFragmentLifecycle</resource>
     </resource-config>
 
 </smooks-resource-list>


### PR DESCRIPTION
decouple ExecutionLifecycleCleanable from Visitor

BREAKING CHANGE: ExecutionLifecycleCleanable#executeExecutionLifecycleCleanup renamed to PostExecutionLifecycle#onPostExecution; VisitLifecycleCleanable#executeVisitLifecycleCleanup renamed to PostFragmentLifecycle#onPostFragment; ExecutionLifecycleInitializable#executeExecutionLifecycleInitialize renamed to PreExecutionLifecycle#onPreExecution