### PR TITLE
refactor!: rename Smooks#addConfiguration for consistency

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -117,8 +117,9 @@ Comparing the https://github.com/smooks/smooks/tree/v1.7.1/smooks-examples[code 
     * `org.milyn.delivery.VisitLifecycleCleanable` with `org.smooks.api.lifecycle.PostFragmentLifecycle`
     * `org.milyn.delivery.ConfigurationExpander` with `org.smooks.api.delivery.ResourceConfigExpander`
 . Remove references to  `org.milyn.util.CollectionsUtil` and write your own implementation for this class.
+. Implement from `org.smooks.api.resource.visitor.sax.ng.SaxNgVisitor` instead of `org.milyn.delivery.sax.SAXVisitor`.
+. Replace `Smooks#addConfiguration(...)` method calls with `Smooks#addResourceConfig(...)`.
 . Replace `org.milyn.*` Java package references with `org.smooks.api`, `org.smooks.engine`, `org.smooks.io` or `org.smooks.support`.
-. Inherit from `org.smooks.api.resource.visitor.sax.ng.SaxNgVisitor` instead of `org.milyn.delivery.sax.SAXVisitor`.
 . Change legacy document root fragment selectors from `$document` to `#document`.
 . Remove the `milyn-smooks-all` dependency from the Maven POM and import the https://www.smooks.org/maven#bill_of_materials_bom[Smooks BOM] instead. Declare the corresponding dependency of each Smooks cartridge used within the project but omit the artifact version.
 . Replace Smooks Maven coordinates to match the coordinates as described in the https://www.smooks.org/maven[Maven guide].

--- a/core/src/main/java/org/smooks/Smooks.java
+++ b/core/src/main/java/org/smooks/Smooks.java
@@ -150,7 +150,7 @@ public class Smooks implements Closeable {
      * Public Default Constructor.
      * <p/>
      * Resource configurations can be added through calls to
-     * {@link #addConfigurations(String)} or {@link #addConfigurations(String,java.io.InputStream)}.
+     * {@link #addConfigurations(String)} or {@link #addConfigurations(String, java.io.InputStream)}.
      */
     public Smooks() {
         applicationContext = new DefaultApplicationContextBuilder().build();
@@ -161,7 +161,7 @@ public class Smooks implements Closeable {
      * Public Default Constructor.
      * <p/>
      * Resource configurations can be added through calls to
-     * {@link #addConfigurations(String)} or {@link #addConfigurations(String,java.io.InputStream)}.
+     * {@link #addConfigurations(String)} or {@link #addConfigurations(String, java.io.InputStream)}.
      */
     public Smooks(final ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
@@ -175,7 +175,7 @@ public class Smooks implements Closeable {
      * which resolves the resourceURI parameter using a {@link org.smooks.resource.URIResourceLocator}.
      * <p/>
      * Additional resource configurations can be added through calls to
-     * {@link #addConfigurations(String)} or {@link #addConfigurations(String,java.io.InputStream)}.
+     * {@link #addConfigurations(String)} or {@link #addConfigurations(String, java.io.InputStream)}.
      *
      * @param resourceURI XML resource configuration stream URI.
      * @throws IOException  Error reading resource stream.
@@ -210,15 +210,17 @@ public class Smooks implements Closeable {
 
     /**
      * Set the filter settings for this Smooks instance.
+     *
      * @param filterSettings The filter settings to be used.
      */
     public void setFilterSettings(FilterSettings filterSettings) {
         AssertArgument.isNotNull(filterSettings, "filterSettings");
         filterSettings.applySettings(this);
     }
-    
+
     /**
      * Set the Exports for this Smooks instance.
+     *
      * @param exports The exports that will be created by this Smooks instance.
      */
     public Smooks setExports(Exports exports) {
@@ -231,18 +233,20 @@ public class Smooks implements Closeable {
 
     /**
      * Set the configuration for the reader to be used on this Smooks instance.
+     *
      * @param readerConfigurator {@link ReaderConfigurator} instance.
      */
     public void setReaderConfig(ReaderConfigurator readerConfigurator) {
         List<ResourceConfig> resourceConfigs = readerConfigurator.toConfig();
 
-        for(ResourceConfig resourceConfig : resourceConfigs) {
-            addConfiguration(resourceConfig);
+        for (ResourceConfig resourceConfig : resourceConfigs) {
+            addResourceConfig(resourceConfig);
         }
     }
 
     /**
      * Set the namespace prefix-to-uri mappings to be used on this Smooks instance.
+     *
      * @param namespaces The namespace prefix-to-uri mappings.
      */
     public void setNamespaces(Properties namespaces) {
@@ -265,7 +269,7 @@ public class Smooks implements Closeable {
     /**
      * Add a visitor instance to <code>this</code> Smooks instance.
      *
-     * @param visitor The visitor implementation.
+     * @param visitor        The visitor implementation.
      * @param targetSelector The message fragment target selector.
      */
     public ResourceConfig addVisitor(Visitor visitor, String targetSelector) {
@@ -282,11 +286,11 @@ public class Smooks implements Closeable {
     /**
      * Adds a {@link Visitor} to this <code>Smooks</code> via a {@link VisitorAppender}.
      *
-     * @param visitorAppender  the <code>VisitorAppender</code>
+     * @param visitorAppender the <code>VisitorAppender</code>
      */
     public void addVisitors(VisitorAppender visitorAppender) {
         getApplicationContext().getRegistry().lookup(new LifecycleManagerLookup()).applyPhase(visitorAppender, new PostConstructLifecyclePhase(new Scope(applicationContext.getRegistry())));
-        
+
         for (ContentHandlerBinding<Visitor> visitorBinding : visitorAppender.addVisitors()) {
             getApplicationContext().getRegistry().lookup(new LifecycleManagerLookup()).applyPhase(visitorBinding.getContentHandler(), new PostConstructLifecyclePhase(new Scope(applicationContext.getRegistry(), visitorBinding.getResourceConfig(), visitorBinding.getContentHandler())));
             this.visitorBindings.add(visitorBinding);
@@ -301,7 +305,7 @@ public class Smooks implements Closeable {
      *
      * @param resourceConfig The resource configuration to be added.
      */
-    public void addConfiguration(ResourceConfig resourceConfig) {
+    public void addResourceConfig(ResourceConfig resourceConfig) {
         AssertArgument.isNotNull(resourceConfig, "resourceConfig");
         assertIsConfigurable();
         applicationContext.getRegistry().registerResourceConfig(resourceConfig);
@@ -346,8 +350,8 @@ public class Smooks implements Closeable {
      * The base URI is required for resolving resource imports.  Just specify
      * the location of the resource file.
      *
-     * @param baseURI The base URI string for the resource configuration list. See
-     *                    {@link org.smooks.resource.URIResourceLocator}.
+     * @param baseURI              The base URI string for the resource configuration list. See
+     *                             {@link org.smooks.resource.URIResourceLocator}.
      * @param resourceConfigStream The resource configuration stream.
      * @throws IOException  Error reading resource stream.
      * @throws SAXException Error parsing the resource stream.
@@ -440,18 +444,18 @@ public class Smooks implements Closeable {
     }
 
     private synchronized void setNotConfigurable() {
-        if(!isConfigurable) {
+        if (!isConfigurable) {
             return;
         }
         isConfigurable = false;
     }
-    
+
     /**
      * Filter the content in the supplied {@link Source} instance.
      * <p/>
      * Not producing a {@link Result}.
      *
-     * @param source           The content Source.
+     * @param source The content Source.
      * @throws SmooksException Failed to filter.
      */
     public void filterSource(Source source) throws SmooksException {
@@ -462,8 +466,8 @@ public class Smooks implements Closeable {
      * Filter the content in the supplied {@link Source} instance, outputing data
      * to the supplied {@link Result} instances.
      *
-     * @param source           The filter Source.
-     * @param results          The filter Results.
+     * @param source  The filter Source.
+     * @param results The filter Results.
      * @throws SmooksException Failed to filter.
      */
     public void filterSource(Source source, Result... results) throws SmooksException {

--- a/core/src/main/java/org/smooks/engine/delivery/AbstractParser.java
+++ b/core/src/main/java/org/smooks/engine/delivery/AbstractParser.java
@@ -325,9 +325,9 @@ public class AbstractParser {
         }
     }
 
-    protected void configureReader(XMLReader xmlReader, DefaultHandler2 contentHandler, ExecutionContext execContext, Source source) throws SAXException {
+    protected void configureReader(XMLReader xmlReader, DefaultHandler2 contentHandler, ExecutionContext executionContext, Source source) throws SAXException {
 		if (xmlReader instanceof SmooksXMLReader) {
-            ((SmooksXMLReader) xmlReader).setExecutionContext(execContext);
+            ((SmooksXMLReader) xmlReader).setExecutionContext(executionContext);
         }
 
         if (xmlReader instanceof JavaXMLReader) {

--- a/core/src/main/java/org/smooks/engine/resource/config/XMLConfigDigester.java
+++ b/core/src/main/java/org/smooks/engine/resource/config/XMLConfigDigester.java
@@ -91,7 +91,7 @@ public final class XMLConfigDigester {
     private static final Logger LOGGER = LoggerFactory.getLogger(XMLConfigDigester.class);
     private static final ThreadLocal<Boolean> EXTENSION_DIGEST_ON = new ThreadLocal<>();
 
-    private final ResourceConfigSeq resourceConfigSeq;
+    private final ResourceConfigSeq resourceConfigList;
     private final Stack<SmooksConfig> configStack = new Stack<>();
     private final ExpressionEvaluatorFactory expressionEvaluatorFactory = new ExpressionEvaluatorFactory();
 
@@ -113,10 +113,10 @@ public final class XMLConfigDigester {
      * public/private nature of these methods may effect the behavior of the {@link #EXTENSION_DIGEST_ON}
      * ThreadLocal.
      *
-     * @param resourceConfigSeq Config list.
+     * @param resourceConfigList Config list.
      */
-    public XMLConfigDigester(ResourceConfigSeq resourceConfigSeq) {
-        this.resourceConfigSeq = resourceConfigSeq;
+    public XMLConfigDigester(ResourceConfigSeq resourceConfigList) {
+        this.resourceConfigList = resourceConfigList;
         configStack.push(new SmooksConfig("root-config"));
     }
 
@@ -216,7 +216,7 @@ public final class XMLConfigDigester {
      * @return The active resource configuration list.
      */
     public ResourceConfigSeq getResourceList() {
-        return resourceConfigSeq;
+        return resourceConfigList;
     }
 
     private void digestConfigRecursively(Reader stream, String baseURI) throws IOException, SAXException, URISyntaxException, SmooksConfigException {
@@ -241,7 +241,7 @@ public final class XMLConfigDigester {
             throw new SAXException("Cannot parse Smooks configuration.  Unsupported default Namespace '" + defaultNS + "'.");
         }
 
-        if (resourceConfigSeq.isEmpty()) {
+        if (resourceConfigList.isEmpty()) {
             throw new SAXException("Invalid Content Delivery Resource archive definition file: 0 Content Delivery Resource definitions.");
         }
     }
@@ -292,7 +292,7 @@ public final class XMLConfigDigester {
             ResourceConfig globalParamsConfig = new DefaultResourceConfig(ParameterAccessor.GLOBAL_PARAMETERS, new Properties());
 
             digestParameters(paramsElement, globalParamsConfig);
-            resourceConfigSeq.add(globalParamsConfig);
+            resourceConfigList.add(globalParamsConfig);
         }
     }
 
@@ -369,7 +369,7 @@ public final class XMLConfigDigester {
         configureFeatures(configElement, resourceConfig);
         configureParams(configElement, resourceConfig);
 
-        resourceConfigSeq.add(resourceConfig);
+        resourceConfigList.add(resourceConfig);
     }
 
     private void configureHandlers(Element configElement, ResourceConfig resourceConfig) {
@@ -459,9 +459,9 @@ public final class XMLConfigDigester {
         // Add the parameters...
         digestParameters(configElement, resourceConfig);
 
-        resourceConfigSeq.add(resourceConfig);
+        resourceConfigList.add(resourceConfig);
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Adding smooks-resource config from [" + resourceConfigSeq.getName() + "]: " + resourceConfig);
+            LOGGER.debug("Adding smooks-resource config from [" + resourceConfigList.getName() + "]: " + resourceConfig);
         }
     }
 
@@ -489,7 +489,7 @@ public final class XMLConfigDigester {
         // Copy the created resources from the ExtensionContext and onto the ResourceConfigList...
         List<ResourceConfig> resources = extentionContext.getResources();
         for (ResourceConfig resource : resources) {
-            resourceConfigSeq.add(resource);
+            resourceConfigList.add(resource);
         }
     }
 
@@ -622,7 +622,7 @@ public final class XMLConfigDigester {
                     profileSet.addProfiles(subProfiles.split(","));
                 }
 
-                resourceConfigSeq.add(profileSet);
+                resourceConfigList.add(profileSet);
             }
         }
     }

--- a/core/src/main/java/org/smooks/engine/resource/reader/DelegateReader.java
+++ b/core/src/main/java/org/smooks/engine/resource/reader/DelegateReader.java
@@ -123,7 +123,7 @@ public class DelegateReader implements SmooksXMLReader {
         readerSmooks = new Smooks(new DefaultApplicationContextBuilder().setRegisterSystemResources(false).setClassLoader(applicationContext.getClassLoader()).build());
         readerSmooks.setFilterSettings(new FilterSettings(StreamFilterType.SAX_NG).setCloseResult(false).setReaderPoolSize(-1));
         for (ResourceConfig resourceConfig : resourceConfigSeq) {
-            readerSmooks.addConfiguration(resourceConfig);
+            readerSmooks.addResourceConfig(resourceConfig);
         }
 
         final InterceptorVisitorChainFactory interceptorVisitorChainFactory = new InterceptorVisitorChainFactory();

--- a/core/src/main/java/org/smooks/engine/resource/visitor/smooks/NestedSmooksVisitor.java
+++ b/core/src/main/java/org/smooks/engine/resource/visitor/smooks/NestedSmooksVisitor.java
@@ -169,7 +169,7 @@ public class NestedSmooksVisitor implements BeforeVisitor, AfterVisitor, Produce
             nestedSmooks = new Smooks(new DefaultApplicationContextBuilder().setRegisterSystemResources(false).setClassLoader(applicationContext.getClassLoader()).build());
 
             for (ResourceConfig resourceConfig : resourceConfigSeq) {
-                nestedSmooks.addConfiguration(resourceConfig);
+                nestedSmooks.addResourceConfig(resourceConfig);
             }
         }
 

--- a/core/src/main/java/org/smooks/engine/xml/Namespace.java
+++ b/core/src/main/java/org/smooks/engine/xml/Namespace.java
@@ -42,24 +42,10 @@
  */
 package org.smooks.engine.xml;
 
-import java.util.Properties;
-
 /**
  * XML Namespace URI static definitions.
  * @author tfennelly
  */
 public interface Namespace {
-
-    Properties SMOOKS_PREFIX_MAPPINGS = new SmooksNamespaceMappings();
-
-    String SMOOKS_URI = SmooksNamespaceMappings.SMOOKS_URI;
-
-    class SmooksNamespaceMappings extends Properties {
-        private static final String SMOOKS_URI = "https://www.smooks.org";
-
-        private SmooksNamespaceMappings() {
-            setProperty("param-type", SMOOKS_URI + "/param-type");
-            setProperty("decoder", SMOOKS_URI + "/decoder");
-        }
-    }
+    String SMOOKS_URI = "https://www.smooks.org";
 }

--- a/core/src/test/java/org/smooks/engine/delivery/StreamReaderTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/StreamReaderTestCase.java
@@ -76,7 +76,7 @@ public class StreamReaderTestCase
     @BeforeEach
     public void setup() {
         smooks = new Smooks();
-        smooks.addConfiguration(new DefaultResourceConfig("org.xml.sax.driver", new Properties(), MockReader.class.getName()));
+        smooks.addResourceConfig(new DefaultResourceConfig("org.xml.sax.driver", new Properties(), MockReader.class.getName()));
     }
 
     @Test


### PR DESCRIPTION
remove unreferenced SmooksNamespaceMappings from org.smooks.engine.xml.Namespace

BREAKING CHANGE: rename Smooks#addConfiguration method to Smooks#addResourceConfig