### PR TITLE
refactor!: rename ConfigBuilderEvent

### DIFF
--- a/api/src/main/java/org/smooks/api/delivery/ContentDeliveryConfig.java
+++ b/api/src/main/java/org/smooks/api/delivery/ContentDeliveryConfig.java
@@ -42,7 +42,7 @@
  */
 package org.smooks.api.delivery;
 
-import org.smooks.api.delivery.event.ConfigBuilderEvent;
+import org.smooks.api.delivery.event.ContentDeliveryConfigExecutionEvent;
 import org.smooks.api.resource.config.ResourceConfig;
 import org.smooks.api.ExecutionContext;
 import org.smooks.api.SmooksConfigException;
@@ -127,7 +127,7 @@ public interface ContentDeliveryConfig {
      * the configuration.
      * @return The list of events.
      */
-    List<ConfigBuilderEvent> getConfigBuilderEvents();
+    List<ContentDeliveryConfigExecutionEvent> getContentDeliveryConfigExecutionEvents();
 
     /**
      * Is default serialization on..

--- a/api/src/main/java/org/smooks/api/delivery/FilterProvider.java
+++ b/api/src/main/java/org/smooks/api/delivery/FilterProvider.java
@@ -42,7 +42,7 @@
  */
 package org.smooks.api.delivery;
 
-import org.smooks.api.delivery.event.ConfigBuilderEvent;
+import org.smooks.api.delivery.event.ContentDeliveryConfigExecutionEvent;
 import org.smooks.api.resource.config.ResourceConfig;
 import org.smooks.api.ApplicationContext;
 import org.smooks.api.Registry;
@@ -61,7 +61,7 @@ import java.util.Map;
  */
 public interface FilterProvider {
 
-    ContentDeliveryConfig createContentDeliveryConfig(List<ContentHandlerBinding<Visitor>> visitorBindings, Registry registry, Map<String, List<ResourceConfig>> resourceConfigTable, List<ConfigBuilderEvent> configBuilderEvents);
+    ContentDeliveryConfig createContentDeliveryConfig(List<ContentHandlerBinding<Visitor>> visitorBindings, Registry registry, Map<String, List<ResourceConfig>> resourceConfigTable, List<ContentDeliveryConfigExecutionEvent> contentDeliveryConfigExecutionEvents);
     
     Boolean isProvider(List<ContentHandlerBinding<Visitor>> visitorBindings);
     

--- a/api/src/main/java/org/smooks/api/delivery/event/ContentDeliveryConfigExecutionEvent.java
+++ b/api/src/main/java/org/smooks/api/delivery/event/ContentDeliveryConfigExecutionEvent.java
@@ -1,8 +1,8 @@
 /*-
  * ========================LICENSE_START=================================
- * Core
+ * API
  * %%
- * Copyright (C) 2020 - 2021 Smooks
+ * Copyright (C) 2020 Smooks
  * %%
  * Licensed under the terms of the Apache License Version 2.0, or
  * the GNU Lesser General Public License version 3.0 or later.
@@ -40,42 +40,20 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.delivery.event;
+package org.smooks.api.delivery.event;
 
 import org.smooks.api.resource.config.ResourceConfig;
-import org.smooks.api.delivery.event.ConfigBuilderEvent;
 
-public class DefaultConfigBuilderEvent implements ConfigBuilderEvent {
-    private ResourceConfig resourceConfig;
-    private final String message;
-    private Throwable thrown;
+/**
+ * Configuration Builder Event.
+ * 
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public interface ContentDeliveryConfigExecutionEvent extends ExecutionEvent {
+    
+    ResourceConfig getResourceConfig();
 
-    public DefaultConfigBuilderEvent(String message) {
-        this.message = message;
-    }
+    String getMessage();
 
-    public DefaultConfigBuilderEvent(ResourceConfig resourceConfig, String message) {
-        this.resourceConfig = resourceConfig;
-        this.message = message;
-    }
-
-    public DefaultConfigBuilderEvent(ResourceConfig resourceConfig, String message, Throwable thrown) {
-        this(resourceConfig, message);
-        this.thrown = thrown;
-    }
-
-    @Override
-    public ResourceConfig getResourceConfig() {
-        return resourceConfig;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
-    }
-
-    @Override
-    public Throwable getThrown() {
-        return thrown;
-    }
+    Throwable getThrown();
 }

--- a/core/src/main/java/org/smooks/Smooks.java
+++ b/core/src/main/java/org/smooks/Smooks.java
@@ -64,7 +64,7 @@ import org.smooks.engine.DefaultExecutionContext;
 import org.smooks.api.delivery.event.ExecutionEventListener;
 import org.smooks.engine.delivery.AbstractFilter;
 import org.smooks.engine.delivery.DefaultContentHandlerBinding;
-import org.smooks.engine.delivery.event.FilterLifecycleEvent;
+import org.smooks.engine.delivery.event.FilterLifecycleExecutionEvent;
 import org.smooks.engine.injector.Scope;
 import org.smooks.api.bean.context.BeanContext;
 import org.smooks.engine.bean.context.preinstalled.Time;
@@ -506,7 +506,7 @@ public class Smooks implements Closeable {
 
         try {
             for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-                executionEventListener.onEvent(new FilterLifecycleEvent(FilterLifecycleEvent.EventType.STARTED, executionContext));
+                executionEventListener.onEvent(new FilterLifecycleExecutionEvent(FilterLifecycleExecutionEvent.EventType.STARTED, executionContext));
             }
 
             ContentDeliveryConfig contentDeliveryConfig = contentDeliveryRuntime.getContentDeliveryConfig();
@@ -572,7 +572,7 @@ public class Smooks implements Closeable {
             }
         } finally {
             for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-                executionEventListener.onEvent(new FilterLifecycleEvent(FilterLifecycleEvent.EventType.FINISHED, executionContext));
+                executionEventListener.onEvent(new FilterLifecycleExecutionEvent(FilterLifecycleExecutionEvent.EventType.FINISHED, executionContext));
             }
         }
     }

--- a/core/src/main/java/org/smooks/engine/delivery/AbstractContentDeliveryConfig.java
+++ b/core/src/main/java/org/smooks/engine/delivery/AbstractContentDeliveryConfig.java
@@ -50,7 +50,7 @@ import org.smooks.api.delivery.ContentDeliveryConfig;
 import org.smooks.api.delivery.ContentHandlerBinding;
 import org.smooks.api.delivery.Filter;
 import org.smooks.api.delivery.FilterBypass;
-import org.smooks.api.delivery.event.ConfigBuilderEvent;
+import org.smooks.api.delivery.event.ContentDeliveryConfigExecutionEvent;
 import org.smooks.api.lifecycle.PostExecutionLifecycle;
 import org.smooks.api.lifecycle.PreExecutionLifecycle;
 import org.smooks.api.resource.config.ResourceConfig;
@@ -92,7 +92,7 @@ public abstract class AbstractContentDeliveryConfig implements ContentDeliveryCo
     /**
      * Config builder events list.
      */
-    private final List<ConfigBuilderEvent> configBuilderEvents = new ArrayList<>();
+    private final List<ContentDeliveryConfigExecutionEvent> configBuilderEvents = new ArrayList<>();
 
     private final Set<PreExecutionLifecycle> preExecutionLifecycles = new LinkedHashSet<>();
     private final Set<PostExecutionLifecycle> postExecutionLifecycles = new LinkedHashSet<>();
@@ -171,7 +171,7 @@ public abstract class AbstractContentDeliveryConfig implements ContentDeliveryCo
     }
 
     @Override
-    public List<ConfigBuilderEvent> getConfigBuilderEvents() {
+    public List<ContentDeliveryConfigExecutionEvent> getContentDeliveryConfigExecutionEvents() {
         return configBuilderEvents;
     }
 

--- a/core/src/main/java/org/smooks/engine/delivery/DefaultContentDeliveryConfigBuilder.java
+++ b/core/src/main/java/org/smooks/engine/delivery/DefaultContentDeliveryConfigBuilder.java
@@ -55,7 +55,7 @@ import org.smooks.api.delivery.Filter;
 import org.smooks.api.delivery.FilterProvider;
 import org.smooks.api.delivery.ResourceConfigExpander;
 import org.smooks.api.delivery.VisitorAppender;
-import org.smooks.api.delivery.event.ConfigBuilderEvent;
+import org.smooks.api.delivery.event.ContentDeliveryConfigExecutionEvent;
 import org.smooks.api.lifecycle.ContentDeliveryConfigLifecycle;
 import org.smooks.api.lifecycle.LifecyclePhase;
 import org.smooks.api.profile.ProfileSet;
@@ -65,7 +65,7 @@ import org.smooks.api.resource.config.ResourceConfigSortComparator;
 import org.smooks.api.resource.config.xpath.SelectorStep;
 import org.smooks.api.resource.visitor.Visitor;
 import org.smooks.assertion.AssertArgument;
-import org.smooks.engine.delivery.event.DefaultConfigBuilderEvent;
+import org.smooks.engine.delivery.event.DefaultContentDeliveryConfigExecutionEvent;
 import org.smooks.engine.lifecycle.ContentDeliveryBuilderCreatedLifecyclePhase;
 import org.smooks.engine.lifecycle.ContentDeliveryConfigCreatedLifecyclePhase;
 import org.smooks.engine.lifecycle.ContentHandlersCreatedLifecyclePhase;
@@ -122,7 +122,7 @@ public class DefaultContentDeliveryConfigBuilder implements ContentDeliveryConfi
     /**
      * Config builder events list.
      */
-    private final List<ConfigBuilderEvent> configBuilderEvents = new ArrayList<>();
+    private final List<ContentDeliveryConfigExecutionEvent> configBuilderEvents = new ArrayList<>();
     private final List<FilterProvider> filterProviders;
 
     private volatile ContentDeliveryConfig contentDeliveryConfig;
@@ -177,8 +177,8 @@ public class DefaultContentDeliveryConfigBuilder implements ContentDeliveryConfi
         FilterProvider filterProvider = getFilterProvider();
 
         LOGGER.debug("Activating {} filter", filterProvider.getName());
-        configBuilderEvents.add(new DefaultConfigBuilderEvent("SAX/DOM support characteristics of the Resource Configuration map:\n" + getResourceFilterCharacteristics()));
-        configBuilderEvents.add(new DefaultConfigBuilderEvent(String.format("Activating %s filter", filterProvider.getName())));
+        configBuilderEvents.add(new DefaultContentDeliveryConfigExecutionEvent("SAX/DOM support characteristics of the Resource Configuration map:\n" + getResourceFilterCharacteristics()));
+        configBuilderEvents.add(new DefaultContentDeliveryConfigExecutionEvent(String.format("Activating %s filter", filterProvider.getName())));
 
         ContentDeliveryConfig contentDeliveryConfig = filterProvider.createContentDeliveryConfig(visitorBindings, registry, resourceConfigTable, configBuilderEvents);
         fireEvent(Event.CONTENT_DELIVERY_CONFIG_CREATED);
@@ -374,7 +374,7 @@ public class DefaultContentDeliveryConfigBuilder implements ContentDeliveryConfi
     }
 
     private void logExecutionEvent(ResourceConfig resourceConfig, String message) {
-        configBuilderEvents.add(new DefaultConfigBuilderEvent(resourceConfig, message));
+        configBuilderEvents.add(new DefaultContentDeliveryConfigExecutionEvent(resourceConfig, message));
     }
 
     private void fireEvent(Event event) {
@@ -490,7 +490,7 @@ public class DefaultContentDeliveryConfigBuilder implements ContentDeliveryConfi
             } catch (Throwable thrown) {
                 String message = "ContentHandlerFactory [" + contentHandlerFactory.getClass().getName() + "] unable to create resource processing instance for resource [" + resourceConfig + "]. ";
                 LOGGER.error(message + thrown.getMessage(), thrown);
-                configBuilderEvents.add(new DefaultConfigBuilderEvent(resourceConfig, message, thrown));
+                configBuilderEvents.add(new DefaultContentDeliveryConfigExecutionEvent(resourceConfig, message, thrown));
 
                 return false;
             }

--- a/core/src/main/java/org/smooks/engine/delivery/dom/DOMFilterProvider.java
+++ b/core/src/main/java/org/smooks/engine/delivery/dom/DOMFilterProvider.java
@@ -46,7 +46,7 @@ import org.smooks.api.Registry;
 import org.smooks.api.delivery.ContentDeliveryConfig;
 import org.smooks.api.delivery.ContentHandler;
 import org.smooks.api.delivery.ContentHandlerBinding;
-import org.smooks.api.delivery.event.ConfigBuilderEvent;
+import org.smooks.api.delivery.event.ContentDeliveryConfigExecutionEvent;
 import org.smooks.api.lifecycle.PostFragmentLifecycle;
 import org.smooks.api.resource.config.ResourceConfig;
 import org.smooks.api.resource.config.xpath.SelectorStep;
@@ -58,7 +58,7 @@ import org.smooks.api.resource.visitor.dom.Phase;
 import org.smooks.api.resource.visitor.dom.VisitPhase;
 import org.smooks.engine.delivery.AbstractFilterProvider;
 import org.smooks.engine.delivery.dom.serialize.DOMSerializerVisitor;
-import org.smooks.engine.delivery.event.DefaultConfigBuilderEvent;
+import org.smooks.engine.delivery.event.DefaultContentDeliveryConfigExecutionEvent;
 import org.smooks.engine.lookup.NamespaceManagerLookup;
 import org.smooks.engine.resource.config.ParameterAccessor;
 import org.smooks.engine.resource.config.xpath.step.ElementSelectorStep;
@@ -69,7 +69,7 @@ import java.util.Properties;
 
 public class DOMFilterProvider extends AbstractFilterProvider {
     @Override
-    public DOMContentDeliveryConfig createContentDeliveryConfig(final List<ContentHandlerBinding<Visitor>> visitorBindings, final Registry registry, Map<String, List<ResourceConfig>> resourceConfigTable, final List<ConfigBuilderEvent> configBuilderEvents) {
+    public DOMContentDeliveryConfig createContentDeliveryConfig(final List<ContentHandlerBinding<Visitor>> visitorBindings, final Registry registry, Map<String, List<ResourceConfig>> resourceConfigTable, final List<ContentDeliveryConfigExecutionEvent> contentDeliveryConfigExecutionEvents) {
         DOMContentDeliveryConfig domConfig = new DOMContentDeliveryConfig();
 
         for (ContentHandlerBinding<Visitor> contentHandlerBinding : visitorBindings) {
@@ -89,7 +89,7 @@ public class DOMFilterProvider extends AbstractFilterProvider {
             if (isDOMVisitor(visitor)) {
                 if (visitor instanceof DOMSerializerVisitor) {
                     domConfig.getSerializerVisitorIndex().put(targetElement, resourceConfig, (SerializerVisitor) visitor);
-                    configBuilderEvents.add(new DefaultConfigBuilderEvent(resourceConfig, "Added as a DOM " + SerializerVisitor.class.getSimpleName() + " resource."));
+                    contentDeliveryConfigExecutionEvents.add(new DefaultContentDeliveryConfigExecutionEvent(resourceConfig, "Added as a DOM " + SerializerVisitor.class.getSimpleName() + " resource."));
                 } else {
                     Phase phaseAnnotation = contentHandlerBinding.getContentHandler().getClass().getAnnotation(Phase.class);
                     String visitPhase = resourceConfig.getParameterValue("VisitPhase", String.class, VisitPhase.PROCESSING.toString());
@@ -120,7 +120,7 @@ public class DOMFilterProvider extends AbstractFilterProvider {
                         }
                     }
 
-                    configBuilderEvents.add(new DefaultConfigBuilderEvent(resourceConfig, "Added as a DOM " + visitPhase + " Phase resource."));
+                    contentDeliveryConfigExecutionEvents.add(new DefaultContentDeliveryConfigExecutionEvent(resourceConfig, "Added as a DOM " + visitPhase + " Phase resource."));
                 }
             }
 
@@ -131,7 +131,7 @@ public class DOMFilterProvider extends AbstractFilterProvider {
 
         domConfig.setRegistry(registry);
         domConfig.setResourceConfigs(resourceConfigTable);
-        domConfig.getConfigBuilderEvents().addAll(configBuilderEvents);
+        domConfig.getContentDeliveryConfigExecutionEvents().addAll(contentDeliveryConfigExecutionEvents);
 
         if (ParameterAccessor.getParameterValue(ContentDeliveryConfig.SMOOKS_VISITORS_SORT, Boolean.class, true, resourceConfigTable)) {
             domConfig.sort();

--- a/core/src/main/java/org/smooks/engine/delivery/dom/SmooksDOMFilter.java
+++ b/core/src/main/java/org/smooks/engine/delivery/dom/SmooksDOMFilter.java
@@ -412,7 +412,7 @@ public class SmooksDOMFilter extends AbstractFilter {
 
         // Register the DOM phase events...
         for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-            executionEventListener.onEvent(new DOMFilterLifecycleEvent(DOMFilterLifecycleEvent.DOMEventType.ASSEMBLY_STARTED, executionContext));
+            executionEventListener.onEvent(new DOMFilterLifecycleExecutionEvent(DOMFilterLifecycleExecutionEvent.DOMEventType.ASSEMBLY_STARTED, executionContext));
         }
         
         // Apply assembly phase, skipping it if there are no configured assembly units...
@@ -430,7 +430,7 @@ public class SmooksDOMFilter extends AbstractFilter {
 
         // Register the DOM phase events...
         for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-            executionEventListener.onEvent(new DOMFilterLifecycleEvent(DOMFilterLifecycleEvent.DOMEventType.PROCESSING_STARTED, executionContext));
+            executionEventListener.onEvent(new DOMFilterLifecycleExecutionEvent(DOMFilterLifecycleExecutionEvent.DOMEventType.PROCESSING_STARTED, executionContext));
         }
         
         // Apply processing phase...
@@ -483,7 +483,7 @@ public class SmooksDOMFilter extends AbstractFilter {
 
         // Register the "presence" of the element...
         for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-            executionEventListener.onEvent(new StartFragmentEvent<>(new NodeFragment(element)));
+            executionEventListener.onEvent(new StartFragmentExecutionEvent<>(new NodeFragment(element)));
         }
         
         List<ContentHandlerBinding<DOMVisitBefore>> elementVisitBefores;
@@ -536,7 +536,7 @@ public class SmooksDOMFilter extends AbstractFilter {
 
             // Register the targeting event.  No need to register it again in the visitAfter loop...
             for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-                executionEventListener.onEvent(new ResourceTargetingEvent(nodeFragment, resourceConfig, VisitSequence.BEFORE, VisitPhase.ASSEMBLY));
+                executionEventListener.onEvent(new ResourceTargetingExecutionEvent(nodeFragment, resourceConfig, VisitSequence.BEFORE, VisitPhase.ASSEMBLY));
             }
 
             DOMVisitBefore assemblyUnit = configMap.getContentHandler();
@@ -546,7 +546,7 @@ public class SmooksDOMFilter extends AbstractFilter {
                 }
                 assemblyUnit.visitBefore(element, executionContext);
                 for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-                    executionEventListener.onEvent(new VisitEvent<>(nodeFragment, configMap, VisitSequence.BEFORE, executionContext));
+                    executionEventListener.onEvent(new VisitExecutionEvent<>(nodeFragment, configMap, VisitSequence.BEFORE, executionContext));
                 }
             } catch (Throwable e) {
                 String errorMsg =
@@ -586,7 +586,7 @@ public class SmooksDOMFilter extends AbstractFilter {
             }
             visitAfter.visitAfter(element, executionContext);
             for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-                executionEventListener.onEvent(new VisitEvent<>(nodeFragment, visitAfterBinding, VisitSequence.AFTER, executionContext));
+                executionEventListener.onEvent(new VisitExecutionEvent<>(nodeFragment, visitAfterBinding, VisitSequence.AFTER, executionContext));
             }
         } catch (Throwable e) {
             String errorMsg = "(Assembly) visitAfter failed [" + visitAfter.getClass().getName() + "] on [" + executionContext.getDocumentSource() + ":" + DomUtils.getXPath(element) + "].";
@@ -610,7 +610,7 @@ public class SmooksDOMFilter extends AbstractFilter {
 
         // Register the "presence" of the element...
         for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-            executionEventListener.onEvent(new StartFragmentEvent<>(new NodeFragment(element)));
+            executionEventListener.onEvent(new StartFragmentExecutionEvent<>(new NodeFragment(element)));
         }
 
         elementName = DomUtils.getName(element);
@@ -810,7 +810,7 @@ public class SmooksDOMFilter extends AbstractFilter {
             if (visitSequence == VisitSequence.BEFORE) {
                 // Register the targeting event...
                 for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-                    executionEventListener.onEvent(new ResourceTargetingEvent(nodeFragment, resourceConfig, VisitSequence.BEFORE));
+                    executionEventListener.onEvent(new ResourceTargetingExecutionEvent(nodeFragment, resourceConfig, VisitSequence.BEFORE));
                 }
 
                 DOMVisitBefore visitor = (DOMVisitBefore) visitorBinding.getContentHandler();
@@ -820,7 +820,7 @@ public class SmooksDOMFilter extends AbstractFilter {
                     }
                     visitor.visitBefore(element, executionContext);
                     for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-                        executionEventListener.onEvent(new VisitEvent<>(nodeFragment, visitorBinding, VisitSequence.BEFORE, executionContext));
+                        executionEventListener.onEvent(new VisitExecutionEvent<>(nodeFragment, visitorBinding, VisitSequence.BEFORE, executionContext));
                     }
                 } catch (Throwable e) {
                     String errorMsg = "Failed to apply processing unit [" + visitor.getClass().getName() + "] to [" + executionContext.getDocumentSource() + ":" + DomUtils.getXPath(element) + "].";
@@ -829,7 +829,7 @@ public class SmooksDOMFilter extends AbstractFilter {
             } else if (visitSequence == VisitSequence.AFTER) {
                 // Register the targeting event...
                 for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-                    executionEventListener.onEvent(new ResourceTargetingEvent(nodeFragment, resourceConfig, VisitSequence.AFTER));
+                    executionEventListener.onEvent(new ResourceTargetingExecutionEvent(nodeFragment, resourceConfig, VisitSequence.AFTER));
                 }
 
                 DOMVisitAfter visitor = (DOMVisitAfter) visitorBinding.getContentHandler();
@@ -839,7 +839,7 @@ public class SmooksDOMFilter extends AbstractFilter {
                     }
                     visitor.visitAfter(element, executionContext);
                     for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-                        executionEventListener.onEvent(new VisitEvent<>(nodeFragment, visitorBinding, VisitSequence.AFTER, executionContext));
+                        executionEventListener.onEvent(new VisitExecutionEvent<>(nodeFragment, visitorBinding, VisitSequence.AFTER, executionContext));
                     }
                 } catch (Throwable e) {
                     String errorMsg = "Failed to apply processing unit [" + visitor.getClass().getName() + "] to [" + executionContext.getDocumentSource() + ":" + DomUtils.getXPath(element) + "].";
@@ -848,7 +848,7 @@ public class SmooksDOMFilter extends AbstractFilter {
             } else if (visitSequence == VisitSequence.CLEAN) {
                 // Register the targeting event...
                 for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-                    executionEventListener.onEvent(new ResourceTargetingEvent(nodeFragment, resourceConfig, VisitSequence.CLEAN));
+                    executionEventListener.onEvent(new ResourceTargetingExecutionEvent(nodeFragment, resourceConfig, VisitSequence.CLEAN));
                 }
 
                 ContentHandler contentHandler = visitorBinding.getContentHandler();
@@ -860,7 +860,7 @@ public class SmooksDOMFilter extends AbstractFilter {
                         }
                         lifecycleManager.applyPhase(visitor, new PostFragmentPhase(nodeFragment, executionContext));
                         for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-                            executionEventListener.onEvent(new VisitEvent<>(nodeFragment, visitorBinding, VisitSequence.CLEAN, executionContext));
+                            executionEventListener.onEvent(new VisitExecutionEvent<>(nodeFragment, visitorBinding, VisitSequence.CLEAN, executionContext));
                         }
                     } catch (Throwable e) {
                         String errorMsg = "Failed to clean up [" + visitor.getClass().getName() + "]. Targeted at [" + executionContext.getDocumentSource() + ":" + DomUtils.getXPath(element) + "].";
@@ -873,7 +873,7 @@ public class SmooksDOMFilter extends AbstractFilter {
 
     private void processVisitorException(Fragment<?> fragment, Throwable error, ContentHandlerBinding<? extends Visitor> configMapping, VisitSequence visitSequence, String errorMsg) throws SmooksException {
         for (ExecutionEventListener executionEventListener : executionContext.getContentDeliveryRuntime().getExecutionEventListeners()) {
-            executionEventListener.onEvent(new VisitEvent<>(fragment, configMapping, visitSequence, executionContext, error));
+            executionEventListener.onEvent(new VisitExecutionEvent<>(fragment, configMapping, visitSequence, executionContext, error));
         }
 
         executionContext.setTerminationError(error);

--- a/core/src/main/java/org/smooks/engine/delivery/dom/serialize/Serializer.java
+++ b/core/src/main/java/org/smooks/engine/delivery/dom/serialize/Serializer.java
@@ -56,9 +56,9 @@ import org.smooks.api.resource.config.ResourceConfig;
 import org.smooks.api.resource.visitor.SerializerVisitor;
 import org.smooks.engine.delivery.ContentHandlerBindingIndex;
 import org.smooks.engine.delivery.dom.DOMContentDeliveryConfig;
-import org.smooks.engine.delivery.event.DOMFilterLifecycleEvent;
-import org.smooks.engine.delivery.event.ResourceTargetingEvent;
-import org.smooks.engine.delivery.event.StartFragmentEvent;
+import org.smooks.engine.delivery.event.DOMFilterLifecycleExecutionEvent;
+import org.smooks.engine.delivery.event.ResourceTargetingExecutionEvent;
+import org.smooks.engine.delivery.event.StartFragmentExecutionEvent;
 import org.smooks.engine.delivery.fragment.NodeFragment;
 import org.smooks.engine.resource.config.ParameterAccessor;
 import org.smooks.engine.resource.config.ResourceConfigurationNotFoundException;
@@ -170,7 +170,7 @@ public class Serializer {
 
         // Register the DOM phase events...
         for (ExecutionEventListener executionEventListener : executionContext.getContentDeliveryRuntime().getExecutionEventListeners()) {
-            executionEventListener.onEvent(new DOMFilterLifecycleEvent(DOMFilterLifecycleEvent.DOMEventType.SERIALIZATION_STARTED, executionContext));
+            executionEventListener.onEvent(new DOMFilterLifecycleExecutionEvent(DOMFilterLifecycleExecutionEvent.DOMEventType.SERIALIZATION_STARTED, executionContext));
         }
 
         if (node instanceof Document) {
@@ -269,7 +269,7 @@ public class Serializer {
         final Fragment<Node> nodeFragment = new NodeFragment(element);
         // Register the "presence" of the element...
         for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-            executionEventListener.onEvent(new StartFragmentEvent(nodeFragment));
+            executionEventListener.onEvent(new StartFragmentExecutionEvent(nodeFragment));
         }
 
         if (isRoot) {
@@ -294,7 +294,7 @@ public class Serializer {
 
                 // Register the targeting event...
                 for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
-                    executionEventListener.onEvent(new ResourceTargetingEvent(nodeFragment, resourceConfig));
+                    executionEventListener.onEvent(new ResourceTargetingExecutionEvent(nodeFragment, resourceConfig));
                 }
 
                 if (LOGGER.isDebugEnabled()) {

--- a/core/src/main/java/org/smooks/engine/delivery/event/BasicExecutionEventListener.java
+++ b/core/src/main/java/org/smooks/engine/delivery/event/BasicExecutionEventListener.java
@@ -112,9 +112,9 @@ public class BasicExecutionEventListener implements ExecutionEventListener {
     }
 
     protected boolean ignoreEvent(ExecutionEvent event) {
-        if(event instanceof FilterLifecycleEvent) {
+        if(event instanceof FilterLifecycleExecutionEvent) {
             return false;
-        } else if(event instanceof StartFragmentEvent) {
+        } else if(event instanceof StartFragmentExecutionEvent) {
             return false;
         }
 
@@ -122,8 +122,8 @@ public class BasicExecutionEventListener implements ExecutionEventListener {
             return true;
         }
 
-        if(event instanceof VisitEvent) {
-            VisitEvent visitEvent = (VisitEvent) event;
+        if(event instanceof VisitExecutionEvent) {
+            VisitExecutionEvent visitEvent = (VisitExecutionEvent) event;
             ContentHandler handler = visitEvent.getVisitorBinding().getContentHandler();
             if(visitEvent.getSequence() == VisitSequence.BEFORE) {
                 VisitBeforeReport reportAnnotation = handler.getClass().getAnnotation(VisitBeforeReport.class);
@@ -141,7 +141,7 @@ public class BasicExecutionEventListener implements ExecutionEventListener {
         return false;
     }
 
-    private boolean evalReportCondition(VisitEvent visitEvent, String condition) {
+    private boolean evalReportCondition(VisitExecutionEvent visitEvent, String condition) {
         MVELExpressionEvaluator conditionEval = new MVELExpressionEvaluator();
         conditionEval.setExpression(condition);
         return conditionEval.eval(visitEvent.getResourceConfig());

--- a/core/src/main/java/org/smooks/engine/delivery/event/DOMFilterLifecycleExecutionEvent.java
+++ b/core/src/main/java/org/smooks/engine/delivery/event/DOMFilterLifecycleExecutionEvent.java
@@ -42,34 +42,44 @@
  */
 package org.smooks.engine.delivery.event;
 
-import org.smooks.api.delivery.event.ExecutionEvent;
-import org.smooks.api.delivery.fragment.Fragment;
-import org.smooks.support.DomUtils;
-import org.w3c.dom.Element;
+import org.smooks.api.ExecutionContext;
 
 /**
- * An element processing related event.
+ * Smooks DOM filter Lifecycle event.
  *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ * @see DOMFilterLifecycleExecutionEvent.DOMEventType
  */
-public abstract class FragmentEvent<T> implements ExecutionEvent {
+public class DOMFilterLifecycleExecutionEvent extends FilterLifecycleExecutionEvent {
 
-    private final Fragment<T> fragment;
-
-    public FragmentEvent(Fragment<T> fragment) {
-        this.fragment = fragment;
+    public enum DOMEventType {
+        /**
+         * The filtering process has started.
+         */
+        ASSEMBLY_STARTED,
+        /**
+         * The filtering process has finished.
+         */
+        PROCESSING_STARTED,
+        /**
+         * The filtering process has finished.
+         */
+        SERIALIZATION_STARTED,
     }
 
-    public Fragment<T> getFragment() {
-        return fragment;
+    private final DOMEventType eventType;
+
+    public DOMFilterLifecycleExecutionEvent(DOMEventType eventType, ExecutionContext executionContext) {
+        super(executionContext);
+        this.eventType = eventType;
     }
 
-    public int getDepth() {
-        T unwrappedFragment = fragment.unwrap();
-        if (unwrappedFragment instanceof Element) {
-            return DomUtils.getDepth((Element) unwrappedFragment);
-        }
+    public DOMEventType getDOMEventType() {
+        return eventType;
+    }
 
-        return 0;
+    @Override
+    public String toString() {
+        return eventType.toString();
     }
 }

--- a/core/src/main/java/org/smooks/engine/delivery/event/DefaultContentDeliveryConfigExecutionEvent.java
+++ b/core/src/main/java/org/smooks/engine/delivery/event/DefaultContentDeliveryConfigExecutionEvent.java
@@ -2,7 +2,7 @@
  * ========================LICENSE_START=================================
  * Core
  * %%
- * Copyright (C) 2020 Smooks
+ * Copyright (C) 2020 - 2021 Smooks
  * %%
  * Licensed under the terms of the Apache License Version 2.0, or
  * the GNU Lesser General Public License version 3.0 or later.
@@ -42,44 +42,40 @@
  */
 package org.smooks.engine.delivery.event;
 
-import org.smooks.api.ExecutionContext;
+import org.smooks.api.resource.config.ResourceConfig;
+import org.smooks.api.delivery.event.ContentDeliveryConfigExecutionEvent;
 
-/**
- * Smooks DOM filter Lifecycle event.
- *
- * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
- * @see DOMFilterLifecycleEvent.DOMEventType
- */
-public class DOMFilterLifecycleEvent extends FilterLifecycleEvent {
+public class DefaultContentDeliveryConfigExecutionEvent implements ContentDeliveryConfigExecutionEvent {
+    private ResourceConfig resourceConfig;
+    private final String message;
+    private Throwable thrown;
 
-    public enum DOMEventType {
-        /**
-         * The filtering process has started.
-         */
-        ASSEMBLY_STARTED,
-        /**
-         * The filtering process has finished.
-         */
-        PROCESSING_STARTED,
-        /**
-         * The filtering process has finished.
-         */
-        SERIALIZATION_STARTED,
+    public DefaultContentDeliveryConfigExecutionEvent(String message) {
+        this.message = message;
     }
 
-    private final DOMEventType eventType;
-
-    public DOMFilterLifecycleEvent(DOMEventType eventType, ExecutionContext executionContext) {
-        super(executionContext);
-        this.eventType = eventType;
+    public DefaultContentDeliveryConfigExecutionEvent(ResourceConfig resourceConfig, String message) {
+        this.resourceConfig = resourceConfig;
+        this.message = message;
     }
 
-    public DOMEventType getDOMEventType() {
-        return eventType;
+    public DefaultContentDeliveryConfigExecutionEvent(ResourceConfig resourceConfig, String message, Throwable thrown) {
+        this(resourceConfig, message);
+        this.thrown = thrown;
     }
 
     @Override
-    public String toString() {
-        return eventType.toString();
+    public ResourceConfig getResourceConfig() {
+        return resourceConfig;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public Throwable getThrown() {
+        return thrown;
     }
 }

--- a/core/src/main/java/org/smooks/engine/delivery/event/EndFragmentExecutionEvent.java
+++ b/core/src/main/java/org/smooks/engine/delivery/event/EndFragmentExecutionEvent.java
@@ -43,7 +43,6 @@
 package org.smooks.engine.delivery.event;
 
 import org.smooks.api.delivery.fragment.Fragment;
-import org.smooks.engine.delivery.event.FragmentEvent;
 
 /**
  * Element Present Event.
@@ -52,9 +51,9 @@ import org.smooks.engine.delivery.event.FragmentEvent;
  *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class StartFragmentEvent<T> extends FragmentEvent<T> {
+public class EndFragmentExecutionEvent<T> extends FragmentExecutionEvent<T> {
     
-    public StartFragmentEvent(final Fragment<T> fragment) {
+    public EndFragmentExecutionEvent(final Fragment<T> fragment) {
         super(fragment);
     }
 }

--- a/core/src/main/java/org/smooks/engine/delivery/event/FilterLifecycleExecutionEvent.java
+++ b/core/src/main/java/org/smooks/engine/delivery/event/FilterLifecycleExecutionEvent.java
@@ -51,7 +51,7 @@ import org.smooks.api.delivery.event.ExecutionEvent;
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  * @see EventType
  */
-public class FilterLifecycleEvent implements ExecutionEvent {
+public class FilterLifecycleExecutionEvent implements ExecutionEvent {
 
     protected final ExecutionContext executionContext;
 
@@ -68,12 +68,12 @@ public class FilterLifecycleEvent implements ExecutionEvent {
 
     private EventType eventType;
 
-    protected FilterLifecycleEvent(ExecutionContext executionContext) {
+    protected FilterLifecycleExecutionEvent(ExecutionContext executionContext) {
         // Allow package level extension...
         this.executionContext = executionContext;
     }
 
-    public FilterLifecycleEvent(EventType eventType, ExecutionContext executionContext) {
+    public FilterLifecycleExecutionEvent(EventType eventType, ExecutionContext executionContext) {
         this.eventType = eventType;
         this.executionContext = executionContext;
     }

--- a/core/src/main/java/org/smooks/engine/delivery/event/FragmentExecutionEvent.java
+++ b/core/src/main/java/org/smooks/engine/delivery/event/FragmentExecutionEvent.java
@@ -42,20 +42,34 @@
  */
 package org.smooks.engine.delivery.event;
 
+import org.smooks.api.delivery.event.ExecutionEvent;
 import org.smooks.api.delivery.fragment.Fragment;
-import org.smooks.engine.delivery.event.FragmentEvent;
+import org.smooks.support.DomUtils;
+import org.w3c.dom.Element;
 
 /**
- * Element Present Event.
- * <p/>
- * This event is fired for all elements in message.
+ * An element processing related event.
  *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class EndFragmentEvent extends FragmentEvent {
-    
-    public EndFragmentEvent(final Fragment fragment) {
-        super(fragment);
+public abstract class FragmentExecutionEvent<T> implements ExecutionEvent {
+
+    private final Fragment<T> fragment;
+
+    public FragmentExecutionEvent(Fragment<T> fragment) {
+        this.fragment = fragment;
+    }
+
+    public Fragment<T> getFragment() {
+        return fragment;
+    }
+
+    public int getDepth() {
+        T unwrappedFragment = fragment.unwrap();
+        if (unwrappedFragment instanceof Element) {
+            return DomUtils.getDepth((Element) unwrappedFragment);
+        }
+
+        return 0;
     }
 }
-              

--- a/core/src/main/java/org/smooks/engine/delivery/event/ResourceTargetingExecutionEvent.java
+++ b/core/src/main/java/org/smooks/engine/delivery/event/ResourceTargetingExecutionEvent.java
@@ -53,7 +53,7 @@ import java.util.Arrays;
  * 
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class ResourceTargetingEvent extends FragmentEvent implements ResourceBasedEvent {
+public class ResourceTargetingExecutionEvent<T> extends FragmentExecutionEvent<T> implements ResourceBasedEvent {
 
     private final ResourceConfig resourceConfig;
     private Object[] metadata;
@@ -66,7 +66,7 @@ public class ResourceTargetingEvent extends FragmentEvent implements ResourceBas
      * @param resourceConfig The resource configuration.
      * @param metadata Optional event metadata.
      */
-    public ResourceTargetingEvent(Fragment fragment, ResourceConfig resourceConfig, Object... metadata) {
+    public ResourceTargetingExecutionEvent(Fragment<T> fragment, ResourceConfig resourceConfig, Object... metadata) {
         super(fragment);
         this.resourceConfig = resourceConfig;
         this.metadata = metadata;
@@ -79,7 +79,7 @@ public class ResourceTargetingEvent extends FragmentEvent implements ResourceBas
      * @param resourceConfig The resource configuration.
      * @param metadata Optional event metadata.
      */
-    public ResourceTargetingEvent(Fragment fragment, ResourceConfig resourceConfig, VisitSequence sequence, Object... metadata) {
+    public ResourceTargetingExecutionEvent(Fragment fragment, ResourceConfig resourceConfig, VisitSequence sequence, Object... metadata) {
         this(fragment, resourceConfig, metadata);
         this.sequence = sequence;
     }

--- a/core/src/main/java/org/smooks/engine/delivery/event/StartFragmentExecutionEvent.java
+++ b/core/src/main/java/org/smooks/engine/delivery/event/StartFragmentExecutionEvent.java
@@ -40,15 +40,21 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.delivery.sax.ng;
+package org.smooks.engine.delivery.event;
 
 import org.smooks.api.delivery.fragment.Fragment;
-import org.smooks.engine.delivery.event.FragmentEvent;
-import org.w3c.dom.Node;
 
-public class CharDataFragmentEvent extends FragmentEvent<Node> {
+/**
+ * Element Present Event.
+ * <p/>
+ * This event is fired for all elements in message.
+ *
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class StartFragmentExecutionEvent<T> extends FragmentExecutionEvent<T> {
     
-    public CharDataFragmentEvent(final Fragment<Node> fragment) {
+    public StartFragmentExecutionEvent(final Fragment<T> fragment) {
         super(fragment);
     }
 }
+              

--- a/core/src/main/java/org/smooks/engine/delivery/event/VisitExecutionEvent.java
+++ b/core/src/main/java/org/smooks/engine/delivery/event/VisitExecutionEvent.java
@@ -68,9 +68,9 @@ import java.util.Map;
  *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class VisitEvent<F, T extends Visitor> extends FragmentEvent<F> implements ResourceBasedEvent {
+public class VisitExecutionEvent<F, T extends Visitor> extends FragmentExecutionEvent<F> implements ResourceBasedEvent {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(VisitEvent.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(VisitExecutionEvent.class);
 
     private final ContentHandlerBinding<T> visitorBinding;
     private final VisitSequence sequence;
@@ -80,14 +80,14 @@ public class VisitEvent<F, T extends Visitor> extends FragmentEvent<F> implement
     private String reportSummary;
     private String reportDetail;
 
-    public VisitEvent(Fragment<F> fragment, ContentHandlerBinding<T> visitorBinding, VisitSequence sequence, ExecutionContext executionContext) {
+    public VisitExecutionEvent(Fragment<F> fragment, ContentHandlerBinding<T> visitorBinding, VisitSequence sequence, ExecutionContext executionContext) {
         super(fragment);
         this.visitorBinding = visitorBinding;
         this.sequence = sequence;
         this.executionContext = executionContext;
     }
 
-    public VisitEvent(Fragment<F> fragment, ContentHandlerBinding<T> visitorBinding, VisitSequence sequence, ExecutionContext executionContext, Throwable error) {
+    public VisitExecutionEvent(Fragment<F> fragment, ContentHandlerBinding<T> visitorBinding, VisitSequence sequence, ExecutionContext executionContext, Throwable error) {
         this(fragment, visitorBinding, sequence, executionContext);
         this.error = error;
     }

--- a/core/src/main/java/org/smooks/engine/delivery/interceptor/EventInterceptor.java
+++ b/core/src/main/java/org/smooks/engine/delivery/interceptor/EventInterceptor.java
@@ -49,8 +49,8 @@ import org.smooks.api.resource.visitor.sax.ng.AfterVisitor;
 import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
 import org.smooks.api.resource.visitor.sax.ng.ChildrenVisitor;
 import org.smooks.api.resource.visitor.sax.ng.ElementVisitor;
-import org.smooks.engine.delivery.event.ResourceTargetingEvent;
-import org.smooks.engine.delivery.event.VisitEvent;
+import org.smooks.engine.delivery.event.ResourceTargetingExecutionEvent;
+import org.smooks.engine.delivery.event.VisitExecutionEvent;
 import org.smooks.engine.delivery.event.VisitSequence;
 import org.smooks.engine.delivery.fragment.NodeFragment;
 import org.w3c.dom.CharacterData;
@@ -63,7 +63,7 @@ public class EventInterceptor extends AbstractInterceptorVisitor implements Elem
     public void visitBefore(Element element, ExecutionContext executionContext) {
         if (getTarget().getContentHandler() instanceof BeforeVisitor) {
             for (ExecutionEventListener executionEventListener : executionContext.getContentDeliveryRuntime().getExecutionEventListeners()) {
-                executionEventListener.onEvent(new ResourceTargetingEvent(new NodeFragment(element), getTarget().getResourceConfig(), VisitSequence.BEFORE));
+                executionEventListener.onEvent(new ResourceTargetingExecutionEvent(new NodeFragment(element), getTarget().getResourceConfig(), VisitSequence.BEFORE));
             }
             intercept(visitBeforeInvocation, element, executionContext);
             onEvent(executionContext, new NodeFragment(element), VisitSequence.BEFORE);
@@ -100,7 +100,7 @@ public class EventInterceptor extends AbstractInterceptorVisitor implements Elem
 
     protected void onEvent(final ExecutionContext executionContext, final Fragment<Node> fragment, final VisitSequence visitSequence) {
         for (ExecutionEventListener executionEventListener : executionContext.getContentDeliveryRuntime().getExecutionEventListeners()) {
-            executionEventListener.onEvent(new VisitEvent<>(fragment, getTarget(), visitSequence, executionContext));
+            executionEventListener.onEvent(new VisitExecutionEvent<>(fragment, getTarget(), visitSequence, executionContext));
         }
     }
 }

--- a/core/src/main/java/org/smooks/engine/delivery/interceptor/ExceptionInterceptor.java
+++ b/core/src/main/java/org/smooks/engine/delivery/interceptor/ExceptionInterceptor.java
@@ -53,7 +53,7 @@ import org.smooks.api.delivery.fragment.Fragment;
 import org.smooks.api.resource.visitor.Visitor;
 import org.smooks.api.resource.visitor.dom.DOMElementVisitor;
 import org.smooks.api.resource.visitor.sax.ng.ElementVisitor;
-import org.smooks.engine.delivery.event.VisitEvent;
+import org.smooks.engine.delivery.event.VisitExecutionEvent;
 import org.smooks.engine.delivery.event.VisitSequence;
 import org.smooks.engine.delivery.fragment.NodeFragment;
 import org.smooks.engine.delivery.sax.ng.terminate.TerminateException;
@@ -111,7 +111,7 @@ public class ExceptionInterceptor extends AbstractInterceptorVisitor implements 
     
     private void processVisitorException(final Throwable t, final String exceptionMessage, final ExecutionContext executionContext, final Fragment<?> fragment, final VisitSequence visitSequence, final ContentHandlerBinding<Visitor> visitorBinding) {
         for (ExecutionEventListener executionEventListener : executionContext.getContentDeliveryRuntime().getExecutionEventListeners()) {
-            executionEventListener.onEvent(new VisitEvent<>(fragment, visitorBinding, visitSequence, executionContext, t));
+            executionEventListener.onEvent(new VisitExecutionEvent<>(fragment, visitorBinding, visitSequence, executionContext, t));
         }
         
         if (t instanceof TerminateException) {

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/CharDataFragmentExecutionEvent.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/CharDataFragmentExecutionEvent.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * API
+ * Core
  * %%
  * Copyright (C) 2020 Smooks
  * %%
@@ -40,20 +40,15 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.api.delivery.event;
+package org.smooks.engine.delivery.sax.ng;
 
-import org.smooks.api.resource.config.ResourceConfig;
+import org.smooks.api.delivery.fragment.Fragment;
+import org.smooks.engine.delivery.event.FragmentExecutionEvent;
+import org.w3c.dom.Node;
 
-/**
- * Configuration Builder Event.
- * 
- * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
- */
-public interface ConfigBuilderEvent extends ExecutionEvent {
+public class CharDataFragmentExecutionEvent extends FragmentExecutionEvent<Node> {
     
-    ResourceConfig getResourceConfig();
-
-    String getMessage();
-
-    Throwable getThrown();
+    public CharDataFragmentExecutionEvent(final Fragment<Node> fragment) {
+        super(fragment);
+    }
 }

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgFilterProvider.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgFilterProvider.java
@@ -45,7 +45,7 @@ package org.smooks.engine.delivery.sax.ng;
 import org.smooks.api.Registry;
 import org.smooks.api.SmooksConfigException;
 import org.smooks.api.delivery.ContentHandlerBinding;
-import org.smooks.api.delivery.event.ConfigBuilderEvent;
+import org.smooks.api.delivery.event.ContentDeliveryConfigExecutionEvent;
 import org.smooks.api.resource.config.ResourceConfig;
 import org.smooks.api.resource.config.xpath.SelectorStep;
 import org.smooks.api.resource.visitor.Visitor;
@@ -53,7 +53,7 @@ import org.smooks.api.resource.visitor.sax.ng.AfterVisitor;
 import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
 import org.smooks.api.resource.visitor.sax.ng.ChildrenVisitor;
 import org.smooks.engine.delivery.AbstractFilterProvider;
-import org.smooks.engine.delivery.event.DefaultConfigBuilderEvent;
+import org.smooks.engine.delivery.event.DefaultContentDeliveryConfigExecutionEvent;
 import org.smooks.engine.delivery.interceptor.InterceptorVisitorChainFactory;
 import org.smooks.engine.lookup.InterceptorVisitorFactoryLookup;
 import org.smooks.engine.lookup.NamespaceManagerLookup;
@@ -67,7 +67,7 @@ import java.util.Properties;
 public class SaxNgFilterProvider extends AbstractFilterProvider {
 
     @Override
-    public SaxNgContentDeliveryConfig createContentDeliveryConfig(final List<ContentHandlerBinding<Visitor>> visitorBindings, final Registry registry, Map<String, List<ResourceConfig>> resourceConfigTable, final List<ConfigBuilderEvent> configBuilderEvents) {
+    public SaxNgContentDeliveryConfig createContentDeliveryConfig(final List<ContentHandlerBinding<Visitor>> visitorBindings, final Registry registry, Map<String, List<ResourceConfig>> resourceConfigTable, final List<ContentDeliveryConfigExecutionEvent> contentDeliveryConfigExecutionEvents) {
         final SaxNgContentDeliveryConfig saxNgContentDeliveryConfig = new SaxNgContentDeliveryConfig();
         final InterceptorVisitorChainFactory interceptorVisitorChainFactory = registry.lookup(new InterceptorVisitorFactoryLookup());
 
@@ -106,13 +106,13 @@ public class SaxNgFilterProvider extends AbstractFilterProvider {
                     }
                 }
 
-                configBuilderEvents.add(new DefaultConfigBuilderEvent(interceptorChain.getResourceConfig(), "Added as a SAX NG visitor."));
+                contentDeliveryConfigExecutionEvents.add(new DefaultContentDeliveryConfigExecutionEvent(interceptorChain.getResourceConfig(), "Added as a SAX NG visitor."));
             }
         }
         
         saxNgContentDeliveryConfig.setRegistry(registry);
         saxNgContentDeliveryConfig.setResourceConfigs(resourceConfigTable);
-        saxNgContentDeliveryConfig.getConfigBuilderEvents().addAll(configBuilderEvents);
+        saxNgContentDeliveryConfig.getContentDeliveryConfigExecutionEvents().addAll(contentDeliveryConfigExecutionEvents);
         saxNgContentDeliveryConfig.addToExecutionLifecycleSets();
         
         return saxNgContentDeliveryConfig;

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgHandler.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgHandler.java
@@ -56,8 +56,8 @@ import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
 import org.smooks.api.resource.visitor.sax.ng.ChildrenVisitor;
 import org.smooks.api.resource.visitor.sax.ng.ParameterizedVisitor;
 import org.smooks.engine.delivery.SmooksContentHandler;
-import org.smooks.engine.delivery.event.EndFragmentEvent;
-import org.smooks.engine.delivery.event.StartFragmentEvent;
+import org.smooks.engine.delivery.event.EndFragmentExecutionEvent;
+import org.smooks.engine.delivery.event.StartFragmentExecutionEvent;
 import org.smooks.engine.delivery.fragment.NodeFragment;
 import org.smooks.engine.delivery.replay.EndElementEvent;
 import org.smooks.engine.delivery.replay.StartElementEvent;
@@ -159,7 +159,7 @@ public class SaxNgHandler extends SmooksContentHandler {
             contentHandlerState.setNullProcessor(true);
             contentHandlerState.setPreviousContentHandlerState(currentContentHandlerState);
             currentContentHandlerState = contentHandlerState;
-            final StartFragmentEvent<Node> startFragmentEvent = new StartFragmentEvent<>(currentNodeFragment);
+            final StartFragmentExecutionEvent<Node> startFragmentEvent = new StartFragmentExecutionEvent<>(currentNodeFragment);
             for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
                 executionEventListener.onEvent(startFragmentEvent);
             }
@@ -191,7 +191,7 @@ public class SaxNgHandler extends SmooksContentHandler {
     @Override
     public void endElement(final EndElementEvent endEvent) throws SAXException {
         if (!contentDeliveryRuntime.getExecutionEventListeners().isEmpty()) {
-            final EndFragmentEvent endFragmentEvent = new EndFragmentEvent(currentNodeFragment);
+            final EndFragmentExecutionEvent endFragmentEvent = new EndFragmentExecutionEvent(currentNodeFragment);
             for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
                 executionEventListener.onEvent(endFragmentEvent);
             }
@@ -289,7 +289,7 @@ public class SaxNgHandler extends SmooksContentHandler {
         }
 
         if (!contentDeliveryRuntime.getExecutionEventListeners().isEmpty()) {
-            final StartFragmentEvent<Node> startFragmentEvent = new StartFragmentEvent<>(currentNodeFragment);
+            final StartFragmentExecutionEvent<Node> startFragmentEvent = new StartFragmentExecutionEvent<>(currentNodeFragment);
             for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
                 executionEventListener.onEvent(startFragmentEvent);
             }
@@ -375,7 +375,7 @@ public class SaxNgHandler extends SmooksContentHandler {
             }
             
             if (!contentDeliveryRuntime.getExecutionEventListeners().isEmpty()) {
-                final CharDataFragmentEvent charFragmentEvent = new CharDataFragmentEvent(new NodeFragment(characterData));
+                final CharDataFragmentExecutionEvent charFragmentEvent = new CharDataFragmentExecutionEvent(new NodeFragment(characterData));
                 for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
                     executionEventListener.onEvent(charFragmentEvent);
                 }

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/bridge/BridgeAwareExecutionEventListener.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/bridge/BridgeAwareExecutionEventListener.java
@@ -44,12 +44,12 @@ package org.smooks.engine.delivery.sax.ng.bridge;
 
 import org.smooks.api.ExecutionContext;
 import org.smooks.engine.delivery.fragment.NodeFragment;
-import org.smooks.engine.delivery.sax.ng.CharDataFragmentEvent;
+import org.smooks.engine.delivery.sax.ng.CharDataFragmentExecutionEvent;
 import org.smooks.api.delivery.event.ExecutionEvent;
 import org.smooks.api.delivery.event.ExecutionEventListener;
-import org.smooks.engine.delivery.event.FragmentEvent;
-import org.smooks.engine.delivery.event.EndFragmentEvent;
-import org.smooks.engine.delivery.event.StartFragmentEvent;
+import org.smooks.engine.delivery.event.FragmentExecutionEvent;
+import org.smooks.engine.delivery.event.EndFragmentExecutionEvent;
+import org.smooks.engine.delivery.event.StartFragmentExecutionEvent;
 import org.w3c.dom.Node;
 
 public abstract class BridgeAwareExecutionEventListener implements ExecutionEventListener {
@@ -62,17 +62,17 @@ public abstract class BridgeAwareExecutionEventListener implements ExecutionEven
     
     @Override
     public void onEvent(final ExecutionEvent executionEvent) {
-        if (executionEvent instanceof FragmentEvent<?> && ((FragmentEvent<?>) executionEvent).getFragment() instanceof NodeFragment) {
-            final Node node = (Node) ((FragmentEvent<?>) executionEvent).getFragment().unwrap();
+        if (executionEvent instanceof FragmentExecutionEvent<?> && ((FragmentExecutionEvent<?>) executionEvent).getFragment() instanceof NodeFragment) {
+            final Node node = (Node) ((FragmentExecutionEvent<?>) executionEvent).getFragment().unwrap();
             if (Bridge.isBridge(node)) {
-                if (executionEvent instanceof StartFragmentEvent<?>) {
+                if (executionEvent instanceof StartFragmentExecutionEvent<?>) {
                     Bridge bridge = new Bridge(node);
                     if (bridge.getVisit().equals("visitBefore")) {
-                        doOnEvent(new StartFragmentEvent<>(new NodeFragment(executionContext.get(bridge.getSourceKey()))));
+                        doOnEvent(new StartFragmentExecutionEvent<>(new NodeFragment(executionContext.get(bridge.getSourceKey()))));
                     } else if (bridge.getVisit().equals("visitChildText")) {
-                        doOnEvent(new CharDataFragmentEvent(new NodeFragment(executionContext.get(bridge.getSourceKey()))));
+                        doOnEvent(new CharDataFragmentExecutionEvent(new NodeFragment(executionContext.get(bridge.getSourceKey()))));
                     } else if (bridge.getVisit().equals("visitAfter")) {
-                        doOnEvent(new EndFragmentEvent(new NodeFragment(executionContext.get(bridge.getSourceKey()))));
+                        doOnEvent(new EndFragmentExecutionEvent(new NodeFragment(executionContext.get(bridge.getSourceKey()))));
                     }
                 }
                 return;

--- a/core/src/main/java/org/smooks/engine/report/AbstractReportGenerator.java
+++ b/core/src/main/java/org/smooks/engine/report/AbstractReportGenerator.java
@@ -44,7 +44,7 @@ package org.smooks.engine.report;
 
 import org.smooks.api.SmooksException;
 import org.smooks.api.delivery.*;
-import org.smooks.api.delivery.event.ConfigBuilderEvent;
+import org.smooks.api.delivery.event.ContentDeliveryConfigExecutionEvent;
 import org.smooks.api.delivery.event.ExecutionEvent;
 import org.smooks.api.delivery.event.ResourceBasedEvent;
 import org.smooks.assertion.AssertArgument;
@@ -113,20 +113,20 @@ public abstract class AbstractReportGenerator extends BasicExecutionEventListene
             return;
         }
 
-        if (executionEvent instanceof FilterLifecycleEvent) {
-            processLifecycleEvent((FilterLifecycleEvent) executionEvent);
-        } else if (executionEvent instanceof StartFragmentEvent) {
-            ReportNode node = new ReportNode((StartFragmentEvent) executionEvent);
+        if (executionEvent instanceof FilterLifecycleExecutionEvent) {
+            processLifecycleEvent((FilterLifecycleExecutionEvent) executionEvent);
+        } else if (executionEvent instanceof StartFragmentExecutionEvent) {
+            ReportNode node = new ReportNode((StartFragmentExecutionEvent) executionEvent);
             allNodes.add(node);
             processNewElementEvent(node);
         } else {
             if (reportNodeStack.isEmpty()) {
                 // We haven't started to process the message/phase yet....
                 preProcessingEvents.add(executionEvent);
-            } else if (executionEvent instanceof FragmentEvent) {
+            } else if (executionEvent instanceof FragmentExecutionEvent) {
                 // We have started processing the message/phase, so attach the event to the ReportNode
                 // associated with the event element...
-                ReportNode reportNode = getReportNode(((FragmentEvent) executionEvent).getFragment().unwrap());
+                ReportNode reportNode = getReportNode(((FragmentExecutionEvent) executionEvent).getFragment().unwrap());
 
                 if (reportNode != null) {
                     reportNode.elementProcessingEvents.add(executionEvent);
@@ -152,23 +152,23 @@ public abstract class AbstractReportGenerator extends BasicExecutionEventListene
         return true;
     }
 
-    private void processLifecycleEvent(FilterLifecycleEvent event) {
+    private void processLifecycleEvent(FilterLifecycleExecutionEvent event) {
 
         try {
-            if (event.getEventType() != FilterLifecycleEvent.EventType.FINISHED) {
+            if (event.getEventType() != FilterLifecycleExecutionEvent.EventType.FINISHED) {
                 ContentDeliveryConfig deliveryConfig = event.getExecutionContext().getContentDeliveryRuntime().getContentDeliveryConfig();
-                if (event instanceof DOMFilterLifecycleEvent) {
-                    DOMFilterLifecycleEvent domEvent = (DOMFilterLifecycleEvent) event;
-                    if (domEvent.getDOMEventType() == DOMFilterLifecycleEvent.DOMEventType.PROCESSING_STARTED) {
+                if (event instanceof DOMFilterLifecycleExecutionEvent) {
+                    DOMFilterLifecycleExecutionEvent domEvent = (DOMFilterLifecycleExecutionEvent) event;
+                    if (domEvent.getDOMEventType() == DOMFilterLifecycleExecutionEvent.DOMEventType.PROCESSING_STARTED) {
                         // Assembly phase is done... output assembly report just at the start of the
                         // processing phase...
                         mapMessageNodeVists(((DOMReport)report).getAssemblies());
-                    } else if (domEvent.getDOMEventType() == DOMFilterLifecycleEvent.DOMEventType.SERIALIZATION_STARTED) {
+                    } else if (domEvent.getDOMEventType() == DOMFilterLifecycleExecutionEvent.DOMEventType.SERIALIZATION_STARTED) {
                         // Processing phase is done (if it was)... output processing report just at the start of the
                         // serialization phase...
                         mapMessageNodeVists(report.getProcessings());
                     }
-                } else if (event.getEventType() == FilterLifecycleEvent.EventType.STARTED) {
+                } else if (event.getEventType() == FilterLifecycleExecutionEvent.EventType.STARTED) {
                     executionContext = event.getExecutionContext();
 
                     if(deliveryConfig instanceof DOMContentDeliveryConfig) {
@@ -177,7 +177,7 @@ public abstract class AbstractReportGenerator extends BasicExecutionEventListene
                         report = new Report();
                     }
                     // Output the configuration builder events...
-                    mapConfigBuilderEvents(deliveryConfig.getConfigBuilderEvents());
+                    mapConfigBuilderEvents(deliveryConfig.getContentDeliveryConfigExecutionEvents());
                 }
             } else {
                 processFinishEvent();
@@ -258,7 +258,7 @@ public abstract class AbstractReportGenerator extends BasicExecutionEventListene
         }
     }
 
-    private void mapConfigBuilderEvents(List<ConfigBuilderEvent> configBuilderEvents) {
+    private void mapConfigBuilderEvents(List<ContentDeliveryConfigExecutionEvent> configBuilderEvents) {
     }
 
     private void mapMessageNodeVists(List<MessageNode> visits) throws IOException {
@@ -305,12 +305,12 @@ public abstract class AbstractReportGenerator extends BasicExecutionEventListene
         List<ExecutionEvent> events = reportNode.getElementProcessingEvents();
 
         for (ExecutionEvent event : events) {
-            if (event instanceof VisitEvent) {
-                VisitEvent visitEvent = (VisitEvent) event;
+            if (event instanceof VisitExecutionEvent) {
+                VisitExecutionEvent visitEvent = (VisitExecutionEvent) event;
 
                 if (visitEvent.getSequence() == visitSequence) {
                     ReportInfoNode reportInfoNode = new ReportInfoNode();
-                    ContentHandlerBinding configMapping = ((VisitEvent) event).getVisitorBinding();
+                    ContentHandlerBinding configMapping = ((VisitExecutionEvent) event).getVisitorBinding();
 
                     messageNode.addExecInfoNode(reportInfoNode);
 
@@ -346,7 +346,7 @@ public abstract class AbstractReportGenerator extends BasicExecutionEventListene
         private final int depth;
         private final List<ExecutionEvent> elementProcessingEvents = new ArrayList<ExecutionEvent>();
 
-        public ReportNode(StartFragmentEvent eventPresentEvent) {
+        public ReportNode(StartFragmentExecutionEvent eventPresentEvent) {
             this.element = eventPresentEvent.getFragment().unwrap();
             this.depth = eventPresentEvent.getDepth();
         }

--- a/core/src/main/java/org/smooks/engine/report/ReportConfiguration.java
+++ b/core/src/main/java/org/smooks/engine/report/ReportConfiguration.java
@@ -45,8 +45,8 @@ package org.smooks.engine.report;
 import org.smooks.assertion.AssertArgument;
 import org.smooks.api.SmooksConfigException;
 import org.smooks.api.delivery.event.ExecutionEvent;
-import org.smooks.api.delivery.event.ConfigBuilderEvent;
-import org.smooks.engine.delivery.event.VisitEvent;
+import org.smooks.api.delivery.event.ContentDeliveryConfigExecutionEvent;
+import org.smooks.engine.delivery.event.VisitExecutionEvent;
 
 import java.io.File;
 import java.io.Writer;
@@ -72,7 +72,7 @@ public class ReportConfiguration {
     public ReportConfiguration(Writer outputWriter) {
         AssertArgument.isNotNull(outputWriter, "outputWriter");
         this.outputWriter = outputWriter;
-        filterEvents = new Class[] {ConfigBuilderEvent.class, VisitEvent.class};
+        filterEvents = new Class[] {ContentDeliveryConfigExecutionEvent.class, VisitExecutionEvent.class};
     }
 
     public void setOutputWriter(Writer outputWriter) {

--- a/core/src/main/java/org/smooks/engine/resource/visitor/dom/DomModelCreator.java
+++ b/core/src/main/java/org/smooks/engine/resource/visitor/dom/DomModelCreator.java
@@ -51,10 +51,10 @@ import org.smooks.api.delivery.ordering.Producer;
 import org.smooks.api.resource.config.ResourceConfig;
 import org.smooks.api.resource.visitor.sax.ng.AfterVisitor;
 import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
-import org.smooks.engine.delivery.event.EndFragmentEvent;
-import org.smooks.engine.delivery.event.StartFragmentEvent;
+import org.smooks.engine.delivery.event.EndFragmentExecutionEvent;
+import org.smooks.engine.delivery.event.StartFragmentExecutionEvent;
 import org.smooks.engine.delivery.fragment.NodeFragment;
-import org.smooks.engine.delivery.sax.ng.CharDataFragmentEvent;
+import org.smooks.engine.delivery.sax.ng.CharDataFragmentExecutionEvent;
 import org.smooks.engine.delivery.sax.ng.bridge.BridgeAwareExecutionEventListener;
 import org.smooks.engine.resource.config.xpath.IndexedSelectorPath;
 import org.smooks.engine.resource.config.xpath.step.ElementSelectorStep;
@@ -234,8 +234,8 @@ public class DomModelCreator implements BeforeVisitor, AfterVisitor, Producer {
 
         @Override
         public void doOnEvent(ExecutionEvent executionEvent) {
-            if (executionEvent instanceof StartFragmentEvent) {
-                StartFragmentEvent<NodeFragment> startFragmentEvent = (StartFragmentEvent<NodeFragment>) executionEvent;
+            if (executionEvent instanceof StartFragmentExecutionEvent) {
+                StartFragmentExecutionEvent<NodeFragment> startFragmentEvent = (StartFragmentExecutionEvent<NodeFragment>) executionEvent;
                 Fragment<NodeFragment> fragment = startFragmentEvent.getFragment();
                 Element importNode = (Element) document.importNode((Node) fragment.unwrap(), true);
 
@@ -245,13 +245,13 @@ public class DomModelCreator implements BeforeVisitor, AfterVisitor, Producer {
 
                 currentNode.appendChild(importNode);
                 currentNode = importNode;
-            } else if (executionEvent instanceof CharDataFragmentEvent) {
+            } else if (executionEvent instanceof CharDataFragmentExecutionEvent) {
                 if (currentNode == document) {
                     // Just ignore for now...
                     return;
                 }
 
-                CharacterData characterData = (CharacterData) ((CharDataFragmentEvent) executionEvent).getFragment().unwrap();
+                CharacterData characterData = (CharacterData) ((CharDataFragmentExecutionEvent) executionEvent).getFragment().unwrap();
                 String textContent = characterData.getTextContent();
                 if (textContent.trim().isEmpty()) {
                     // Ignore pure whitespace...
@@ -270,7 +270,7 @@ public class DomModelCreator implements BeforeVisitor, AfterVisitor, Producer {
                         currentNode.appendChild(document.createComment(textContent));
                         break;
                 }
-            } else if (executionEvent instanceof EndFragmentEvent) {
+            } else if (executionEvent instanceof EndFragmentExecutionEvent) {
                 currentNode = currentNode.getParentNode();
             }
         }

--- a/core/src/main/java/org/smooks/engine/resource/visitor/smooks/ChildEventListener.java
+++ b/core/src/main/java/org/smooks/engine/resource/visitor/smooks/ChildEventListener.java
@@ -47,12 +47,12 @@ import org.smooks.api.delivery.fragment.Fragment;
 import org.smooks.engine.delivery.fragment.NodeFragment;
 import org.smooks.engine.memento.SimpleVisitorMemento;
 import org.smooks.engine.memento.VisitorMemento;
-import org.smooks.engine.delivery.sax.ng.CharDataFragmentEvent;
+import org.smooks.engine.delivery.sax.ng.CharDataFragmentExecutionEvent;
 import org.smooks.api.delivery.event.ExecutionEvent;
-import org.smooks.engine.delivery.event.FragmentEvent;
+import org.smooks.engine.delivery.event.FragmentExecutionEvent;
 import org.smooks.engine.delivery.sax.ng.bridge.BridgeAwareExecutionEventListener;
-import org.smooks.engine.delivery.event.EndFragmentEvent;
-import org.smooks.engine.delivery.event.StartFragmentEvent;
+import org.smooks.engine.delivery.event.EndFragmentExecutionEvent;
+import org.smooks.engine.delivery.event.StartFragmentExecutionEvent;
 import org.w3c.dom.Node;
 
 import java.io.Writer;
@@ -72,18 +72,18 @@ class ChildEventListener extends BridgeAwareExecutionEventListener {
 
     @Override
     public void doOnEvent(final ExecutionEvent executionEvent) {
-        if (executionEvent instanceof FragmentEvent) {
-            final Fragment<Node> childFragment = ((FragmentEvent<Node>) executionEvent).getFragment();
+        if (executionEvent instanceof FragmentExecutionEvent) {
+            final Fragment<Node> childFragment = ((FragmentExecutionEvent<Node>) executionEvent).getFragment();
             final VisitorMemento<Node> sourceTreeMemento = new SimpleVisitorMemento<>(visitedFragment, nestedSmooksVisitor, visitedFragment.unwrap());
             executionContext.getMementoCaretaker().restore(sourceTreeMemento);
 
-            if (executionEvent instanceof StartFragmentEvent) {
+            if (executionEvent instanceof StartFragmentExecutionEvent) {
                 if (!visitedFragment.equals(childFragment)) {
                     visitBefore(sourceTreeMemento, childFragment);
                 }
-            } else if (executionEvent instanceof CharDataFragmentEvent) {
+            } else if (executionEvent instanceof CharDataFragmentExecutionEvent) {
                 visitChildText(sourceTreeMemento, childFragment);
-            } else if (executionEvent instanceof EndFragmentEvent) {
+            } else if (executionEvent instanceof EndFragmentExecutionEvent) {
                 if (!visitedFragment.equals(childFragment)) {
                     visitAfter(sourceTreeMemento);
                 }

--- a/core/src/test/java/org/smooks/engine/delivery/ExecutionEventListenerTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/ExecutionEventListenerTestCase.java
@@ -46,8 +46,8 @@ import org.junit.jupiter.api.Test;
 import org.smooks.Smooks;
 import org.smooks.api.ExecutionContext;
 import org.smooks.engine.delivery.event.BasicExecutionEventListener;
-import org.smooks.engine.delivery.event.FilterLifecycleEvent;
-import org.smooks.engine.delivery.event.ResourceTargetingEvent;
+import org.smooks.engine.delivery.event.FilterLifecycleExecutionEvent;
+import org.smooks.engine.delivery.event.ResourceTargetingExecutionEvent;
 import org.smooks.io.NullWriter;
 import org.xml.sax.SAXException;
 
@@ -83,7 +83,7 @@ public class ExecutionEventListenerTestCase {
     public void test_02_dom() throws IOException, SAXException {
         BasicExecutionEventListener eventListener = new BasicExecutionEventListener();
 
-        eventListener.setFilterEvents(FilterLifecycleEvent.class);
+        eventListener.setFilterEvents(FilterLifecycleExecutionEvent.class);
         testListener(eventListener, "smooks-config-dom.xml");
         assertEquals(23, eventListener.getEvents().size());
     }
@@ -92,7 +92,7 @@ public class ExecutionEventListenerTestCase {
     public void test_03_dom() throws IOException, SAXException {
         BasicExecutionEventListener eventListener = new BasicExecutionEventListener();
 
-        eventListener.setFilterEvents(ResourceTargetingEvent.class);
+        eventListener.setFilterEvents(ResourceTargetingExecutionEvent.class);
         testListener(eventListener, "smooks-config-dom.xml");
         assertEquals(42, eventListener.getEvents().size());
     }
@@ -101,7 +101,7 @@ public class ExecutionEventListenerTestCase {
     public void test_04_dom() throws IOException, SAXException {
         BasicExecutionEventListener eventListener = new BasicExecutionEventListener();
 
-        eventListener.setFilterEvents(FilterLifecycleEvent.class, ResourceTargetingEvent.class);
+        eventListener.setFilterEvents(FilterLifecycleExecutionEvent.class, ResourceTargetingExecutionEvent.class);
         testListener(eventListener, "smooks-config-dom.xml");
         assertEquals(42, eventListener.getEvents().size());
     }


### PR DESCRIPTION
BREAKING CHANGE: rename org.smooks.api.delivery.event.ConfigBuilderEvent to org.smooks.api.delivery.event.ContentDeliveryConfigExecutionEvent; rename org.smooks.api.delivery.ContentDeliveryConfig#getConfigBuilderEvents method to org.smooks.api.delivery.ContentDeliveryConfig#getContentDeliveryConfigExecutionEvents