### PR TITLE
feat!: add management module

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
     paths-ignore:
-      - '.github/ISSUE_TEMPLATE/**'
       - 'docs/**'
       - '**.adoc'
 

--- a/README.adoc
+++ b/README.adoc
@@ -105,6 +105,7 @@ Smooks 2 introduces the https://github.com/smooks/smooks-dfdl-cartridge[DFDL car
 * Numerous dependency updates
 * Maven coordinates change: we are now publishing Smooks artifacts under Maven group IDs prefixed with `+org.smooks+`
 * Replaced default SAX parser implementation from Apache Xerces to https://github.com/FasterXML/woodstox[FasterXML's Woodstox]: benchmarks consistently showed Woodstox outperforming Xerces
+* link:#_instrumentation[Monitoring and management support] with JMX
 
 === Migrating from Smooks 1.7 to 2.0
 
@@ -1201,7 +1202,7 @@ Smooks supports a number of options when it comes to splitting and routing fragm
 // tag::extending-smooks[]
 == Extending Smooks
 
-All existing Smooks functionality (Java Binding, EDI processing, etc...) is built through extension of a number of well defined APIs. We will look at these APIs in the coming sections.
+All existing Smooks functionality (Java Binding, EDI processing, etc...) is built through extension of a number of well-defined APIs. We will look at these APIs in the coming sections.
 
 The main extension points/APIs in Smooks are:
 
@@ -2173,6 +2174,276 @@ public class MySmooksResource {
 }
 ----
 // end::extending-smooks[]
+
+// tag::instrumentation[]
+== Instrumentation
+
+NOTE: Smooks instrumentation is available starting from v2.0.0-RC4.
+
+A Smooks application can be instrumented with https://docs.oracle.com/javase/8/docs/technotes/guides/jmx/index.html[JMX] which allows IT operations to monitor and manage Smooks from tools such as JConsole, Grafana, and NewRelic. Apart from the MBeans provided by the Java runtime and third-party libraries, Smooks provides MBeans for:
+
+* resources (e.g., resource config parameters)
+* visitors (e.g., performance metrics, failure visit count, events visited)
+* reader pools (e.g., no. of active readers)
+
+=== Activating instrumentation
+
+To instrument Smooks, you need to:
+
+1. Add the `smooks-management` module to your Java class path. The Maven coordinates for this module are:
++
+[source,xml]
+----
+<dependency>
+    <groupId>org.smooks</groupId>
+    <artifactId>smooks-management</artifactId>notificaitons
+    <version>TBA</version>
+</dependency>
+----
+
+2. Declare `management:instrumentationResource` in the Smooks config to activate instrumentation:
++
+[source,xml]
+----
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+                      xmlns:core="https://www.smooks.org/xsd/smooks/smooks-core-1.6.xsd"
+                      xmlns:management="https://www.smooks.org/xsd/smooks/management-1.0.xsd">
+
+    <management:instrumentationResource/>
+
+    ...
+    ...
+</smooks-resource-list>
+----
++
+`management:instrumentationResource` supports the following attributes:
++
+[cols="1,1,1"]
+|===
+|Name |Description | Default
+
+|usePlatformMBeanServer
+|Whether to use the MBeanServer from this JVM.
+|true
+
+|mBeanServerDefaultDomain
+|The default JMX domain of the MBeanServer.
+|org.smooks
+
+|mBeanObjectDomainName
+|The JMX domain that all object names will use.
+|org.smooks
+
+|includeHostName
+|Whether to include the hostname in the MBean naming.
+|false
+|===
+
+3. Optionally, declare the `org.smooks.management.InstrumentationInterceptor` interceptor to instrument visitors:
++
+[source,xml]
+----
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+                      xmlns:core="https://www.smooks.org/xsd/smooks/smooks-core-1.6.xsd"
+                      xmlns:management="https://www.smooks.org/xsd/smooks/management-1.0.xsd">
+
+    <management:instrumentationResource/>
+
+    <core:interceptors>
+        <core:interceptor class="org.smooks.management.InstrumentationInterceptor"/>
+    </core:interceptors>
+
+    ...
+    ...
+</smooks-resource-list>
+----
+
+=== Instrumenting application classes
+
+In addition to the Smooks classes that are already instrumented, you can further instrument your own classes with the help of annotations located in the `org.smooks.management.annotation` package which are listed below:
+
+=== @ManagedResource
+
+Annotating a class with `org.smooks.management.annotation.ManagedResource` effectively turns the class into an MBean which allows an instance of the class to be registered with an MBean server. Here is an example of a class annotated with `@ManagedResource`:
+
+[source,java,linenums]
+----
+...
+...
+import org.smooks.api.ApplicationContext;
+import org.smooks.api.management.InstrumentationAgent;
+import org.smooks.api.management.InstrumentationResource;
+import org.smooks.management.annotation.ManagedResource;
+
+@ManagedResource(description = "My Class")
+public class MyManagedClass {
+
+    public MyManagedClass(ApplicationContext applicationContext) {
+        InstrumentationResource instrumentationResource = applicationContext.getRegistry().lookup(InstrumentationResource.INSTRUMENTATION_RESOURCE_TYPED_KEY);
+        InstrumentationAgent instrumentationAgent = instrumentationResource.getInstrumentationAgent();
+
+        instrumentationAgent.register(this, "MyManagedClass");
+    }
+
+    ...
+    ...
+}
+----
+
+Line 17 from the snippet above uses `InsturmentationAgent` to register the `@ManagedResource` annotated object with the MBean server so that it can be queried and invoked by JMX clients. `InstrumentationAgent` is obtained from an instance of `org.smooks.api.management.InstrumentationResource`. The singleton `InstrumentationResource` can be looked up from the Smooks registry as shown in line 12.
+
+IMPORTANT: link:#_activating_instrumentation[Instrumentation needs to be activated] in order to obtain a non-null `InstrumentationResource` from the lookup.
+
+=== @ManagedAttribute
+
+Annotating a method with `org.smooks.management.annotation.ManagedAttribute` exposes the method as an MBean attribute. Here is an example of a method annotated with `@ManagedAttribute`:
+
+[source,java]
+----
+...
+...
+import org.smooks.management.annotation.ManagedAnnotation;
+import org.smooks.management.annotation.ManagedResource;
+
+@ManagedResource
+public class MyManagedClass {
+
+    private String myAttribute;
+    ...
+    ...
+
+    @ManagedAttribute(description = "My attribute")
+    public String getMyAttribute() {
+        return myAttribute;
+    }
+}
+----
+
+=== @ManagedOperation
+
+Annotating a method with `org.smooks.management.annotation.ManagedOperation` exposes the method and its parameters as an MBean operation. Here is an example of a method annotated with `@ManagedOperation`:
+
+[source,java]
+----
+...
+...
+import org.smooks.management.annotation.ManagedOperation;
+import org.smooks.management.annotation.ManagedResource;
+
+@ManagedResource
+public class MyManagedClass {
+
+    ...
+    ...
+
+    @ManagedOperation(description = "My operation")
+    public void myOperation(String myFirstParam, Integer mySecondParam) {
+        ...
+        ...
+    }
+}
+----
+
+=== @ManagedNotification
+
+Annotating a class with `org.smooks.management.annotation.ManagedNotification` allows JMX clients to subscribe to notifications broadcasted from instances of this class. Here is an example of a method annotated with `@ManagedNotification`:
+
+[source,java,linenums]
+----
+...
+...
+import org.smooks.api.ApplicationContext;
+import org.smooks.api.management.InstrumentationAgent;
+import org.smooks.api.management.InstrumentationResource;
+import org.smooks.management.ModelMBeanAssembler;
+import org.smooks.management.annotation.ManagedNotification;
+import org.smooks.management.annotation.ManagedResource;
+
+import javax.management.MBeanException;
+import javax.management.Notification;
+import javax.management.modelmbean.ModelMBeanInfo;
+import javax.management.modelmbean.RequiredModelMBean;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+@ManagedResource
+@ManagedNotification(name = "My Notification", notificationTypes = {"javax.management.Notification"})
+public class MyManagedClass {
+
+    private final RequiredModelMBean requiredModelMBean;
+    private final AtomicLong sequenceNumber = new AtomicLong();
+
+    public MyManagedClass(ApplicationContext applicationContext) {
+        InstrumentationResource instrumentationResource = applicationContext.getRegistry().lookup(InstrumentationResource.INSTRUMENTATION_RESOURCE_TYPED_KEY);
+        InstrumentationAgent instrumentationAgent = instrumentationResource.getInstrumentationAgent();
+
+        ModelMBeanAssembler modelMBeanAssembler = new ModelMBeanAssembler();
+        ModelMBeanInfo modelMBeanInfo = modelMBeanAssembler.getModelMbeanInfo(this.getClass());
+        requiredModelMBean = instrumentationAgent.register(this, this.getObjectName(), modelMBeanInfo, false);
+    }
+
+    public void sendNotification(String message) throws MBeanException {
+        Notification notification = new Notification("My Notification", requiredModelMBean, sequenceNumber.addAndGet(1), message);
+        requiredModelMBean.sendNotification(message);
+    }
+}
+----
+
+As illustrated above in lines 25-31, to register a `@ManagedNotification` instance, the MBean descriptor should be assembled dynamically with `org.smooks.management.ModelMBeanAssembler`. The assembled `javax.management.modelmbean.ModelMBeanInfo` is then registered using `InstrumentationAgent` as shown in line 32. `InstrumentationAgent.register(Object, ObjectName, ModelMBeanInfo, boolean)` returns a `RequiredModelMBean` object that can be referenced to broadcast notifications, seen in line 37.
+
+=== @ManagedNotifications
+
+Adding more than one notification type can be achieved with `org.smooks.management.annotation.ManagedNotifications`. Here is an example of a method annotated with `@ManagedNotifications`:
+
+[source,java]
+----
+...
+...
+import org.smooks.api.ApplicationContext;
+import org.smooks.api.management.InstrumentationAgent;
+import org.smooks.api.management.InstrumentationResource;
+import org.smooks.management.ModelMBeanAssembler;
+import org.smooks.management.annotation.ManagedNotification;
+import org.smooks.management.annotation.ManagedNotifications;
+import org.smooks.management.annotation.ManagedResource;
+
+import javax.management.MBeanException;
+import javax.management.Notification;
+import javax.management.modelmbean.ModelMBeanInfo;
+import javax.management.modelmbean.RequiredModelMBean;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+@ManagedResource
+@ManagedNotifications(value = {@ManagedNotification(name = "My Notification", notificationTypes = {"javax.management.Notification"}),
+@ManagedNotification(name = "Another Notification", notificationTypes = {"javax.management.Notification"})})
+public class MyManagedClass {
+
+    private final RequiredModelMBean requiredModelMBean;
+    private final AtomicLong sequenceNumber = new AtomicLong();
+
+    public MyManagedClass(ApplicationContext applicationContext) {
+        InstrumentationResource instrumentationResource = applicationContext.getRegistry().lookup(InstrumentationResource.INSTRUMENTATION_RESOURCE_TYPED_KEY);
+        InstrumentationAgent instrumentationAgent = instrumentationResource.getInstrumentationAgent();
+
+        ModelMBeanAssembler modelMBeanAssembler = new ModelMBeanAssembler();
+        ModelMBeanInfo modelMBeanInfo = modelMBeanAssembler.getModelMbeanInfo(this.getClass());
+        requiredModelMBean = instrumentationAgent.register(this, this.getObjectName(), modelMBeanInfo, false);
+    }
+
+    public void sendMyNotification(String message) throws MBeanException {
+        Notification notification = new Notification("My Notification", requiredModelMBean, sequenceNumber.addAndGet(1), message);
+        requiredModelMBean.sendNotification(message);
+    }
+
+    public void sendAnotherNotification(String message) throws MBeanException {
+        Notification notification = new Notification("Another Notification", requiredModelMBean, sequenceNumber.addAndGet(1), message);
+        requiredModelMBean.sendNotification(message);
+    }
+}
+----
+
+// end::instrumentation[]
 
 == Community
 

--- a/api/src/main/java/org/smooks/api/Registry.java
+++ b/api/src/main/java/org/smooks/api/Registry.java
@@ -67,7 +67,7 @@ public interface Registry {
      * Registers an object with its key derived from the object's {@link Resource#name()} attribute or the object's class name.
      *
      * @param value object to register
-     * @throws SmooksException if the value with the assigned name already exists
+     * @throws SmooksException          if the value with the assigned name already exists
      * @throws IllegalArgumentException if the value is null
      */
     void registerObject(Object value);
@@ -75,9 +75,9 @@ public interface Registry {
     /**
      * Adds an object with the given key to this <code>Registry</code>.
      *
-     * @param key object that maps to the <code>value</code> to register
+     * @param key   object that maps to the <code>value</code> to register
      * @param value object to register which can be retrieved by its <code>key</code>
-     * @throws SmooksException if the value with the assigned name already exists
+     * @throws SmooksException          if the value with the assigned name already exists
      * @throws IllegalArgumentException if the name or the value is null
      */
     void registerObject(Object key, Object value);
@@ -93,7 +93,7 @@ public interface Registry {
      * Looks up a registered object by function.
      *
      * @param function function to apply for looking up an object
-     * @param <R> type of object to be returned
+     * @param <R>      type of object to be returned
      * @return registered object if it exists or null
      */
     <R> R lookup(Function<Map<Object, Object>, R> function);
@@ -108,9 +108,18 @@ public interface Registry {
     <T> T lookup(Object key);
 
     /**
+     * Looks up a registered object by its typed key.
+     *
+     * @param key typed key of registered object
+     * @param <T> type of object to be returned
+     * @return the registered object if it exists or null
+     */
+    <T> T lookup(TypedKey<T> key);
+
+    /**
      * Registers the set of resources specified in the supplied XML configuration stream.
      *
-     * @param baseURI base URI to be associated with the configuration stream
+     * @param baseURI              base URI to be associated with the configuration stream
      * @param resourceConfigStream XML resource configuration stream
      * @return {@link ResourceConfigSeq} created from the added resource configuration
      * @throws SAXException if error happens while parsing the resource stream

--- a/api/src/main/java/org/smooks/api/SmooksException.java
+++ b/api/src/main/java/org/smooks/api/SmooksException.java
@@ -49,6 +49,10 @@ public class SmooksException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
 
+	public SmooksException() {
+		super();
+	}
+
     public SmooksException(String message) {
         super(message);
     }

--- a/api/src/main/java/org/smooks/api/delivery/ContentDeliveryRuntimeFactory.java
+++ b/api/src/main/java/org/smooks/api/delivery/ContentDeliveryRuntimeFactory.java
@@ -45,8 +45,10 @@ package org.smooks.api.delivery;
 import org.smooks.api.profile.ProfileSet;
 import org.smooks.api.resource.visitor.Visitor;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.List;
 
+@ThreadSafe
 public interface ContentDeliveryRuntimeFactory {
 
     ContentDeliveryRuntime create(ProfileSet profileSet, List<ContentHandlerBinding<Visitor>> extendedContentHandlerBindings);

--- a/api/src/main/java/org/smooks/api/delivery/ReaderPool.java
+++ b/api/src/main/java/org/smooks/api/delivery/ReaderPool.java
@@ -6,7 +6,7 @@
  * %%
  * Licensed under the terms of the Apache License Version 2.0, or
  * the GNU Lesser General Public License version 3.0 or later.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
  * 
  * ======================================================================
@@ -44,20 +44,32 @@ package org.smooks.api.delivery;
 
 import org.xml.sax.XMLReader;
 
+import javax.annotation.concurrent.ThreadSafe;
+import java.util.Map;
+import java.util.Properties;
+
+@ThreadSafe
 public interface ReaderPool {
 
     /**
-     * Get an {@link XMLReader} instance from the 
+     * Gets an {@link XMLReader} instance from the
      * reader pool associated with this ContentDelivery config instance.
-     * @return An XMLReader instance if the pool is not empty, otherwise null.
+     *
+     * @return An XMLReader instance if the pool is not empty, otherwise null
      */
     XMLReader borrowXMLReader();
 
     /**
-     * Return an {@link XMLReader} instance to the
-     * reader pool associated with this ContentDelivery config instance.
-     * @param xmlReader The XMLReader instance to be returned.  If the pool is full, the instance
-     * is left to the GC (i.e. lost).
+     * Returns an {@link XMLReader} instance to the reader pool associated with this ContentDelivery config instance.
+     *
+     * @param xmlReader XMLReader instance to be returned
      */
     void returnXMLReader(XMLReader xmlReader);
+
+    /**
+     * Returns implementation-specific {@link Properties}.
+     *
+     * @return Implementation-specific {@link Properties} of <code>this</code> reader pool
+     */
+    Map<String, String> getProperties();
 }

--- a/api/src/main/java/org/smooks/api/delivery/ReaderPoolFactory.java
+++ b/api/src/main/java/org/smooks/api/delivery/ReaderPoolFactory.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * Core
+ * API
  * %%
  * Copyright (C) 2020 - 2024 Smooks
  * %%
@@ -40,22 +40,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.lifecycle;
+package org.smooks.api.delivery;
 
-import org.smooks.api.ExecutionContext;
-import org.smooks.api.lifecycle.FilterLifecycle;
-import org.smooks.api.lifecycle.LifecyclePhase;
+public interface ReaderPoolFactory {
 
-public class FilterStartedLifecyclePhase implements LifecyclePhase {
-
-    private final ExecutionContext executionContext;
-
-    public FilterStartedLifecyclePhase(ExecutionContext executionContext) {
-        this.executionContext = executionContext;
-    }
-
-    @Override
-    public void apply(Object o) {
-        ((FilterLifecycle) o).onStarted(executionContext);
-    }
+    ReaderPool create(int readerPoolSize);
 }

--- a/api/src/main/java/org/smooks/api/lifecycle/FilterLifecycle.java
+++ b/api/src/main/java/org/smooks/api/lifecycle/FilterLifecycle.java
@@ -46,6 +46,6 @@ import org.smooks.api.ExecutionContext;
 
 public interface FilterLifecycle {
 
-    void onStarted(ExecutionContext executionContext);
-    void onFinished(ExecutionContext executionContext);
+    void onPreFilter(ExecutionContext executionContext);
+    void onPostFilter(ExecutionContext executionContext);
 }

--- a/api/src/main/java/org/smooks/api/management/InstrumentationAgent.java
+++ b/api/src/main/java/org/smooks/api/management/InstrumentationAgent.java
@@ -1,0 +1,57 @@
+/*-
+ * ========================LICENSE_START=================================
+ * API
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.api.management;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.modelmbean.ModelMBeanInfo;
+import javax.management.modelmbean.RequiredModelMBean;
+
+public interface InstrumentationAgent {
+
+    void register(Object object, ObjectName objectName);
+
+    RequiredModelMBean register(Object object, ObjectName objectName, ModelMBeanInfo modelMBeanInfo, boolean forceRegistration);
+
+    MBeanServer getMBeanServer();
+}

--- a/api/src/main/java/org/smooks/api/management/InstrumentationAgentFactory.java
+++ b/api/src/main/java/org/smooks/api/management/InstrumentationAgentFactory.java
@@ -1,0 +1,48 @@
+/*-
+ * ========================LICENSE_START=================================
+ * API
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.api.management;
+
+public interface InstrumentationAgentFactory {
+
+    InstrumentationAgent create(boolean usePlatformMBeanServer, String mBeanServerDefaultDomain);
+}

--- a/api/src/main/java/org/smooks/api/management/InstrumentationResource.java
+++ b/api/src/main/java/org/smooks/api/management/InstrumentationResource.java
@@ -1,0 +1,55 @@
+/*-
+ * ========================LICENSE_START=================================
+ * API
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.api.management;
+
+import org.smooks.api.TypedKey;
+
+public interface InstrumentationResource {
+
+    TypedKey<InstrumentationResource> INSTRUMENTATION_RESOURCE_TYPED_KEY = TypedKey.of();
+
+    String getMBeanObjectDomainName();
+    Boolean getIncludeHostName();
+    InstrumentationAgent getInstrumentationAgent();
+
+}

--- a/api/src/main/java/org/smooks/api/management/MBean.java
+++ b/api/src/main/java/org/smooks/api/management/MBean.java
@@ -1,0 +1,49 @@
+/*-
+ * ========================LICENSE_START=================================
+ * API
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.api.management;
+
+import javax.management.ObjectName;
+
+public interface MBean {
+    ObjectName getObjectName();
+}

--- a/api/src/main/java/org/smooks/api/resource/config/ParameterDecodeException.java
+++ b/api/src/main/java/org/smooks/api/resource/config/ParameterDecodeException.java
@@ -42,11 +42,13 @@
  */
 package org.smooks.api.resource.config;
 
+import org.smooks.api.SmooksException;
+
 /**
  * Unable to decode smooks-resource parameter value.
  * @author tfennelly
  */
-public class ParameterDecodeException extends RuntimeException {
+public class ParameterDecodeException extends SmooksException {
 
 	/**
      * 

--- a/api/src/main/java/org/smooks/api/resource/config/ResourceConfig.java
+++ b/api/src/main/java/org/smooks/api/resource/config/ResourceConfig.java
@@ -208,17 +208,17 @@ public interface ResourceConfig {
      * Gets the target profile/s of this <code>ResourceConfig</code>.
      *
      * @return target profile/s
-     * @see    #setTargetProfile(String)
+     * @see    #setProfile(String)
      */
-    String getTargetProfile();
+    String getProfile();
 
     /**
      * Sets the target profile of this <code>ResourceConfig</code>.
      *
-     * @param targetProfile comma-separated list of {@link ProfileTargetingExpression ProfileTargetingExpressions}
-     * @see                 #getTargetProfile()
+     * @param profile comma-separated list of {@link ProfileTargetingExpression ProfileTargetingExpressions}
+     * @see                 #getProfile()
      */
-    void setTargetProfile(String targetProfile);
+    void setProfile(String profile);
 
     /**
      * Sets the resource type (e.g., "class", "xsl", "groovy", etc...)

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -63,8 +63,8 @@
         </dependency>
         <dependency>
             <groupId>org.smooks</groupId>
-            <artifactId>smooks-core</artifactId>
-            <version>${project.parent.version}</version>
+            <artifactId>smooks-management</artifactId>
+            <version>${parent.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/benchmark/src/main/resources/smooks-config.xml
+++ b/benchmark/src/main/resources/smooks-config.xml
@@ -43,7 +43,14 @@
   -->
 
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
-                      xmlns:core="https://www.smooks.org/xsd/smooks/smooks-core-1.6.xsd">
+                      xmlns:core="https://www.smooks.org/xsd/smooks/smooks-core-1.6.xsd"
+                      xmlns:management="https://www.smooks.org/xsd/smooks/management-1.0.xsd">
+
+    <core:interceptors>
+        <core:interceptor class="org.smooks.management.InstrumentationInterceptor"/>
+    </core:interceptors>
+
+    <management:instrumentationResource/>
 
     <resource-config selector="org.xml.sax.driver">
         <resource>com.fasterxml.aalto.sax.BenchmarkAaltoXMLReader</resource>

--- a/core/src/main/java/org/smooks/engine/converter/StringToBigDecimalConverterFactory.java
+++ b/core/src/main/java/org/smooks/engine/converter/StringToBigDecimalConverterFactory.java
@@ -69,9 +69,9 @@ public class StringToBigDecimalConverterFactory implements TypeConverterFactory<
                     try {
                         Number number = numberFormat.parse(value.trim());
 
-                        if(number instanceof BigDecimal) {
+                        if (number instanceof BigDecimal) {
                             return (BigDecimal) number;
-                        } else if(number instanceof BigInteger) {
+                        } else if (number instanceof BigInteger) {
                             return new BigDecimal((BigInteger) number);
                         }
 

--- a/core/src/main/java/org/smooks/engine/delivery/AbstractParser.java
+++ b/core/src/main/java/org/smooks/engine/delivery/AbstractParser.java
@@ -45,6 +45,7 @@ package org.smooks.engine.delivery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smooks.api.ExecutionContext;
+import org.smooks.api.SmooksConfigException;
 import org.smooks.api.SmooksException;
 import org.smooks.api.TypedKey;
 import org.smooks.api.delivery.ContentDeliveryConfig;
@@ -278,7 +279,7 @@ public class AbstractParser {
             JavaSource javaSource = (JavaSource) source;
 
             if (isFeatureOn(JavaSource.FEATURE_GENERATE_EVENT_STREAM, saxDriverConfig) && !javaSource.isEventStreamRequired()) {
-                throw new SAXException("Invalid Smooks configuration.  Feature '" + JavaSource.FEATURE_GENERATE_EVENT_STREAM + "' is explicitly configured 'on' in the Smooks configuration, while the supplied JavaSource has explicitly configured event streaming to be off (through a call to JavaSource.setEventStreamRequired).");
+                throw new SmooksConfigException(String.format("Invalid Smooks configuration. Feature [%s] is explicitly configured 'on' in the Smooks configuration, while the supplied JavaSource has explicitly configured event streaming to be off (through a call to JavaSource.setEventStreamRequired).", JavaSource.FEATURE_GENERATE_EVENT_STREAM));
             }
 
             // Event streaming must be explicitly turned off.  If is on as long as it is (a) not configured "off" in
@@ -332,7 +333,7 @@ public class AbstractParser {
 
         if (xmlReader instanceof JavaXMLReader) {
             if (!(source instanceof JavaSource)) {
-                throw new SAXException("A " + JavaSource.class.getName() + " source must be supplied for " + JavaXMLReader.class.getName() + " implementations.");
+                throw new SmooksException("A " + JavaSource.class.getName() + " source must be supplied for " + JavaXMLReader.class.getName() + " implementations.");
             }
             ((JavaXMLReader) xmlReader).setSourceObjects(((JavaSource) source).getSourceObjects());
         }
@@ -346,7 +347,7 @@ public class AbstractParser {
         }
     }
 
-    private void setHandlers(XMLReader reader) throws SAXException {
+    private void setHandlers(XMLReader reader) {
         if (saxDriverConfig != null) {
             List<Parameter<?>> handlers;
 
@@ -369,11 +370,11 @@ public class AbstractParser {
         }
     }
 
-    private Object createHandler(String handlerName) throws SAXException {
+    private Object createHandler(String handlerName) {
         try {
             return ClassUtils.forName(handlerName, getClass()).newInstance();
         } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
-            throw new SAXException("Failed to create SAX Handler '" + handlerName + "'.", e);
+            throw new SmooksException("Failed to create SAX Handler '" + handlerName + "'.", e);
         }
     }
 
@@ -411,23 +412,23 @@ public class AbstractParser {
         }
     }
 
-    public static boolean isFeatureOn(String name, ResourceConfig saxDriverConfig) throws SAXException {
+    public static boolean isFeatureOn(String name, ResourceConfig saxDriverConfig) {
         boolean featureOn = isFeature(name, FeatureValue.ON, saxDriverConfig);
 
         // Make sure the same feature is not also configured off...
         if (featureOn && isFeature(name, FeatureValue.OFF, saxDriverConfig)) {
-            throw new SAXException("Invalid Smooks configuration.  Feature '" + name + "' is explicitly configured 'on' and 'off'.  Must be one or the other!");
+            throw new SmooksException("Invalid Smooks configuration.  Feature '" + name + "' is explicitly configured 'on' and 'off'.  Must be one or the other!");
         }
 
         return featureOn;
     }
 
-    public static boolean isFeatureOff(String name, ResourceConfig saxDriverConfig) throws SAXException {
+    public static boolean isFeatureOff(String name, ResourceConfig saxDriverConfig) {
         boolean featureOff = isFeature(name, FeatureValue.OFF, saxDriverConfig);
 
         // Make sure the same feature is not also configured on...
         if (featureOff && isFeature(name, FeatureValue.ON, saxDriverConfig)) {
-            throw new SAXException("Invalid Smooks configuration.  Feature '" + name + "' is explicitly configured 'on' and 'off'.  Must be one or the other!");
+            throw new SmooksException("Invalid Smooks configuration.  Feature '" + name + "' is explicitly configured 'on' and 'off'.  Must be one or the other!");
         }
 
         return featureOff;

--- a/core/src/main/java/org/smooks/engine/delivery/DefaultReaderPool.java
+++ b/core/src/main/java/org/smooks/engine/delivery/DefaultReaderPool.java
@@ -6,35 +6,35 @@
  * %%
  * Licensed under the terms of the Apache License Version 2.0, or
  * the GNU Lesser General Public License version 3.0 or later.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
- * 
+ *
  * ======================================================================
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * ======================================================================
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -42,36 +42,78 @@
  */
 package org.smooks.engine.delivery;
 
+import jakarta.annotation.Resource;
 import org.smooks.api.delivery.ReaderPool;
 import org.xml.sax.XMLReader;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
+@Resource(name = "DefaultReaderPool")
 public class DefaultReaderPool implements ReaderPool {
-    private final AtomicReferenceArray<XMLReader> xmlReaderPool;
+    private final AtomicReferenceArray<Optional<XMLReader>> xmlReaderPool;
+    private final int maxReaderPoolSize;
 
     public DefaultReaderPool(final int maxReaderPoolSize) {
+        this.maxReaderPoolSize = maxReaderPoolSize;
         xmlReaderPool = new AtomicReferenceArray<>(maxReaderPoolSize);
     }
-    
+
     @Override
     public XMLReader borrowXMLReader() {
         for (int i = 0; i < xmlReaderPool.length(); i++) {
-            final XMLReader xmlReader = xmlReaderPool.getAndSet(i, null);
+            Optional<XMLReader> xmlReader = xmlReaderPool.get(i);
             if (xmlReader != null) {
-                return xmlReader;
+                xmlReader = xmlReaderPool.getAndSet(i, Optional.empty());
+                if (xmlReader.isPresent()) {
+                    return xmlReader.get();
+                }
             }
         }
 
         return null;
     }
-    
+
+    /**
+     * Return an {@link XMLReader} instance to the reader pool associated with this ContentDelivery config instance.
+     *
+     * @param xmlReader The XMLReader instance to be returned. If the pool is full, the instance is left to the GC (i.e. lost).
+     */
     @Override
-    public void returnXMLReader(final XMLReader xmlReader) {
+    public void returnXMLReader(XMLReader xmlReader) {
         for (int i = 0; i < xmlReaderPool.length(); i++) {
-            if (xmlReaderPool.compareAndSet(i, null, xmlReader)) {
-                break;
+            Optional<XMLReader> optionalXMLReader = Optional.of(xmlReader);
+            if (xmlReaderPool.compareAndSet(i, Optional.empty(), optionalXMLReader) ||
+                    xmlReaderPool.compareAndSet(i, null, optionalXMLReader)) {
+                return;
             }
         }
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        Map<String, String> properties = new HashMap<>(3);
+        properties.put("maxReadersSize", String.valueOf(maxReaderPoolSize));
+        int unallocatedReaders = 0;
+        int activeReaders = 0;
+        for (int i = 0; i < xmlReaderPool.length(); i++) {
+            Optional<XMLReader> xmlReader = xmlReaderPool.get(i);
+            if (xmlReader == null || xmlReader.isPresent()) {
+                unallocatedReaders++;
+            } else {
+                activeReaders++;
+            }
+        }
+        properties.put("unallocatedReaders", String.valueOf(unallocatedReaders));
+        properties.put("activeReaders", String.valueOf(activeReaders));
+
+        return properties;
+    }
+
+    public int getMaxReaderPoolSize() {
+        return maxReaderPoolSize;
     }
 }

--- a/core/src/main/java/org/smooks/engine/delivery/DefaultReaderPoolFactory.java
+++ b/core/src/main/java/org/smooks/engine/delivery/DefaultReaderPoolFactory.java
@@ -1,0 +1,57 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Core
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.engine.delivery;
+
+import org.smooks.api.delivery.ReaderPool;
+import org.smooks.api.delivery.ReaderPoolFactory;
+
+public class DefaultReaderPoolFactory implements ReaderPoolFactory {
+    @Override
+    public ReaderPool create(int readerPoolSize) {
+        if (readerPoolSize == -1) {
+            return new DynamicReaderPool();
+        } else {
+            return new DefaultReaderPool(readerPoolSize);
+        }
+    }
+}

--- a/core/src/main/java/org/smooks/engine/delivery/DynamicReaderPool.java
+++ b/core/src/main/java/org/smooks/engine/delivery/DynamicReaderPool.java
@@ -6,35 +6,35 @@
  * %%
  * Licensed under the terms of the Apache License Version 2.0, or
  * the GNU Lesser General Public License version 3.0 or later.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
- * 
+ *
  * ======================================================================
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * ======================================================================
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -45,38 +45,78 @@ package org.smooks.engine.delivery;
 import org.smooks.api.delivery.ReaderPool;
 import org.xml.sax.XMLReader;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
+/**
+ * A pool of readers without an upper bound which means that it grows on-demand.
+ */
 public class DynamicReaderPool implements ReaderPool {
-    private final AtomicReference<AtomicReferenceArray<XMLReader>> xmlReaderPoolReference = new AtomicReference<>();
+    private final AtomicReference<AtomicReferenceArray<Optional<XMLReader>>> xmlReaderPoolReference = new AtomicReference<>();
 
     public DynamicReaderPool() {
         xmlReaderPoolReference.set(new AtomicReferenceArray<>(16));
     }
-    
+
     @Override
     public XMLReader borrowXMLReader() {
-        final AtomicReferenceArray<XMLReader> readerPool = xmlReaderPoolReference.get();
-        for (int i = 0; i < readerPool.length(); i++) {
-            final XMLReader xmlReader = readerPool.getAndSet(i, null);
+        final AtomicReferenceArray<Optional<XMLReader>> xmlReaderPool = xmlReaderPoolReference.get();
+        for (int i = 0; i < xmlReaderPool.length(); i++) {
+            Optional<XMLReader> xmlReader = xmlReaderPool.get(i);
             if (xmlReader != null) {
-                return xmlReader;
+                xmlReader = xmlReaderPool.getAndSet(i, Optional.empty());
+                if (xmlReader.isPresent()) {
+                    return xmlReader.get();
+                }
             }
         }
 
         return null;
     }
-    
+
+    /**
+     * Return an {@link XMLReader} instance to the reader pool associated with this ContentDelivery config instance.
+     *
+     * @param xmlReader The XMLReader instance to be returned. If the pool is full, the pool is re-sized to accommodate
+     *                  the new reader.
+     */
     @Override
     public void returnXMLReader(final XMLReader xmlReader) {
-        final AtomicReferenceArray<XMLReader> xmlReaderPool = xmlReaderPoolReference.get();
+        final AtomicReferenceArray<Optional<XMLReader>> xmlReaderPool = xmlReaderPoolReference.get();
         for (int i = 0; i < xmlReaderPool.length(); i++) {
-            if (xmlReaderPool.compareAndSet(i, null, xmlReader)) {
+            Optional<XMLReader> optionalXMLReader = Optional.of(xmlReader);
+            if (xmlReaderPool.compareAndSet(i, Optional.empty(), optionalXMLReader) ||
+                    xmlReaderPool.compareAndSet(i, null, optionalXMLReader)) {
                 return;
             }
         }
-        
+
         xmlReaderPoolReference.compareAndSet(xmlReaderPool, new AtomicReferenceArray<>(xmlReaderPool.length() * 2));
+        returnXMLReader(xmlReader);
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        final AtomicReferenceArray<Optional<XMLReader>> xmlReaderPool = xmlReaderPoolReference.get();
+        Map<String, String> properties = new HashMap<>(3);
+        properties.put("readerPoolSize", String.valueOf(xmlReaderPool.length()));
+        int unallocatedReaders = 0;
+        int activeReaders = 0;
+        for (int i = 0; i < xmlReaderPool.length(); i++) {
+            Optional<XMLReader> xmlReader = xmlReaderPool.get(i);
+            if (xmlReader == null || xmlReader.isPresent()) {
+                unallocatedReaders++;
+            } else {
+                activeReaders++;
+            }
+        }
+        properties.put("unallocatedReaders", String.valueOf(unallocatedReaders));
+        properties.put("activeReaders", String.valueOf(activeReaders));
+
+        return properties;
     }
 }

--- a/core/src/main/java/org/smooks/engine/delivery/dom/DOMBuilderContentHandler.java
+++ b/core/src/main/java/org/smooks/engine/delivery/dom/DOMBuilderContentHandler.java
@@ -69,9 +69,9 @@ import java.util.Stack;
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
 @SuppressWarnings("unchecked")
-public class DOMBuilder extends SmooksContentHandler {
+public class DOMBuilderContentHandler extends SmooksContentHandler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DOMBuilder.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DOMBuilderContentHandler.class);
     private static final DocumentBuilder documentBuilder;
 
     private final ExecutionContext execContext;
@@ -90,11 +90,11 @@ public class DOMBuilder extends SmooksContentHandler {
 		}
     }
 
-    public DOMBuilder(ExecutionContext execContext) {
+    public DOMBuilderContentHandler(ExecutionContext execContext) {
         this(execContext, null);
     }
 
-    public DOMBuilder(ExecutionContext execContext, SmooksContentHandler parentContentHandler) {
+    public DOMBuilderContentHandler(ExecutionContext execContext, SmooksContentHandler parentContentHandler) {
         super(execContext, parentContentHandler);
 
         this.execContext = execContext;

--- a/core/src/main/java/org/smooks/engine/delivery/dom/DOMParser.java
+++ b/core/src/main/java/org/smooks/engine/delivery/dom/DOMParser.java
@@ -94,111 +94,116 @@ public class DOMParser extends AbstractParser {
 	 * <p/>
 	 * This constructor attempts to lookup a SAX Parser config under the "org.xml.sax.driver" selector string.
 	 * See <a href="#parserconfig">.cdrl Configuration</a>.
-	 * @param execContext The execution context that the parser is being instantiated on behalf of.
+	 *
+	 * @param executionContext The execution context that the parser is being instantiated on behalf of.
 	 */
-	public DOMParser(ExecutionContext execContext) {
-        super(execContext);
+	public DOMParser(ExecutionContext executionContext) {
+		super(executionContext);
 	}
 
 	/**
 	 * Public constructor.
-	 * @param execContext The Smooks Container Request that the parser is being instantiated on behalf of.
+	 *
+	 * @param executionContext     The Smooks Container Request that the parser is being instantiated on behalf of.
 	 * @param saxDriverConfig SAX Parser configuration. See <a href="#parserconfig">.cdrl Configuration</a>.
 	 */
-    public DOMParser(ExecutionContext execContext, ResourceConfig saxDriverConfig) {
-        super(execContext, saxDriverConfig);
-    }
+	public DOMParser(ExecutionContext executionContext, ResourceConfig saxDriverConfig) {
+		super(executionContext, saxDriverConfig);
+	}
 
-    /**
+	/**
 	 * Document parser.
+	 *
 	 * @param source Source content stream to be parsed.
 	 * @return W3C ownerDocument.
 	 * @throws SAXException Unable to parse the content.
-	 * @throws IOException Unable to read the input stream.
+	 * @throws IOException  Unable to read the input stream.
 	 */
 	public Document parse(Source source) throws IOException, SAXException {
-	   	DOMBuilder contentHandler = new DOMBuilder(getExecutionContext());
+		DOMBuilderContentHandler contentHandler = new DOMBuilderContentHandler(getExecutionContext());
 
-	   	parse(source, contentHandler);
+		parse(source, contentHandler);
 
 		return contentHandler.getDocument();
 	}
 
-      /**
-  	 * Append the content, behind the supplied input stream, to suplied
-  	 * document element.
-  	 * <p/>
-  	 * Used to merge document fragments into a document.
-  	 * @param source Source content stream to be parsed.
-  	 * @param appendElement DOM element to which the content fragment is to
-  	 * be added.
-  	 * @throws SAXException Unable to parse the content.
-  	 * @throws IOException Unable to read the input stream.
-  	 */
-  	public void append(Source source, Element appendElement) throws IOException, SAXException {
-  	   	DOMBuilder contentHandler = new DOMBuilder(getExecutionContext());
+	/**
+	 * Append the content, behind the supplied input stream, to suplied
+	 * document element.
+	 * <p/>
+	 * Used to merge document fragments into a document.
+	 *
+	 * @param source        Source content stream to be parsed.
+	 * @param appendElement DOM element to which the content fragment is to
+	 *                      be added.
+	 * @throws SAXException Unable to parse the content.
+	 * @throws IOException  Unable to read the input stream.
+	 */
+	public void append(Source source, Element appendElement) throws IOException, SAXException {
+		DOMBuilderContentHandler contentHandler = new DOMBuilderContentHandler(getExecutionContext());
 
-  		contentHandler.setAppendElement(appendElement);
-  	   	parse(source, contentHandler);
-  	}
+		contentHandler.setAppendElement(appendElement);
+		parse(source, contentHandler);
+	}
 
-      /**
-  	 * Perform the actual parse into the supplied content handler.
-  	 * @param source Source content stream to be parsed.
-  	 * @param contentHandler Content handler instance that will build/append-to the DOM.
-  	 * @throws SAXException Unable to parse the content.
-  	 * @throws IOException Unable to read the input stream.
-  	 */
-  	private void parse(Source source, DOMBuilder contentHandler) throws SAXException, IOException {
-  		ExecutionContext executionContext = getExecutionContext();
-  		
-  		if(executionContext != null) {
+	/**
+	 * Perform the actual parse into the supplied content handler.
+	 *
+	 * @param source         Source content stream to be parsed.
+	 * @param contentHandler Content handler instance that will build/append-to the DOM.
+	 * @throws SAXException Unable to parse the content.
+	 * @throws IOException  Unable to read the input stream.
+	 */
+	private void parse(Source source, DOMBuilderContentHandler contentHandler) throws SAXException, IOException {
+		ExecutionContext executionContext = getExecutionContext();
+
+		if (executionContext != null) {
 			ReaderPool readerPool = executionContext.getContentDeliveryRuntime().getReaderPool();
 
-	  		XMLReader domReader = getXMLReader(executionContext);
+			XMLReader domReader = getXMLReader(executionContext);
 
-	  		try {
-                if(domReader == null) {
-                    domReader = readerPool.borrowXMLReader();
-                }
-                if(domReader == null) {
-                    domReader = createXMLReader();
-                }
+			try {
+				if (domReader == null) {
+					domReader = readerPool.borrowXMLReader();
+				}
+				if (domReader == null) {
+					domReader = createXMLReader();
+				}
 
-                if(domReader instanceof HierarchyChangeReader) {
-                    ((HierarchyChangeReader)domReader).setHierarchyChangeListener(new XMLReaderHierarchyChangeListener(executionContext));
-                }
+				if (domReader instanceof HierarchyChangeReader) {
+					((HierarchyChangeReader) domReader).setHierarchyChangeListener(new XMLReaderHierarchyChangeListener(executionContext));
+				}
 
-                NamespaceDeclarationStack namespaceDeclarationStack = new NamespaceDeclarationStack();
-                executionContext.put(NamespaceManager.NAMESPACE_DECLARATION_STACK_TYPED_KEY, namespaceDeclarationStack);
-                attachNamespaceDeclarationStack(domReader, executionContext);
+				NamespaceDeclarationStack namespaceDeclarationStack = new NamespaceDeclarationStack();
+				executionContext.put(NamespaceManager.NAMESPACE_DECLARATION_STACK_TYPED_KEY, namespaceDeclarationStack);
+				attachNamespaceDeclarationStack(domReader, executionContext);
 
-                attachXMLReader(domReader, executionContext);
-                configureReader(domReader, contentHandler, executionContext, source);
-		        domReader.parse(createInputSource(source, executionContext.getContentEncoding()));
-	  		} finally {
-                try {
-                    if(domReader instanceof HierarchyChangeReader) {
-                        ((HierarchyChangeReader)domReader).setHierarchyChangeListener(null);
-                    }
-                } finally {
-                    try {
-                        try {
-                            detachXMLReader(executionContext);
-                        } finally {
-                            if(domReader != null) {
+				attachXMLReader(domReader, executionContext);
+				configureReader(domReader, contentHandler, executionContext, source);
+				domReader.parse(createInputSource(source, executionContext.getContentEncoding()));
+			} finally {
+				try {
+					if (domReader instanceof HierarchyChangeReader) {
+						((HierarchyChangeReader) domReader).setHierarchyChangeListener(null);
+					}
+				} finally {
+					try {
+						try {
+							detachXMLReader(executionContext);
+						} finally {
+							if (domReader != null) {
 								readerPool.returnXMLReader(domReader);
-                            }
-                        }
-                    } finally {
-                        contentHandler.detachHandler();
-                    }
-                }
-	  		}
-  		} else {
-	  		XMLReader domReader = createXMLReader();
-	        configureReader(domReader, contentHandler, null, source);
-	        domReader.parse(createInputSource(source, Charset.defaultCharset().name()));
-  		}
-  	}
+							}
+						}
+					} finally {
+						contentHandler.detachHandler();
+					}
+				}
+			}
+		} else {
+			XMLReader domReader = createXMLReader();
+			configureReader(domReader, contentHandler, null, source);
+			domReader.parse(createInputSource(source, Charset.defaultCharset().name()));
+		}
+	}
 }

--- a/core/src/main/java/org/smooks/engine/delivery/event/ResourceTargetingExecutionEvent.java
+++ b/core/src/main/java/org/smooks/engine/delivery/event/ResourceTargetingExecutionEvent.java
@@ -79,7 +79,7 @@ public class ResourceTargetingExecutionEvent<T> extends FragmentExecutionEvent<T
      * @param resourceConfig The resource configuration.
      * @param metadata Optional event metadata.
      */
-    public ResourceTargetingExecutionEvent(Fragment fragment, ResourceConfig resourceConfig, VisitSequence sequence, Object... metadata) {
+    public ResourceTargetingExecutionEvent(Fragment<T> fragment, ResourceConfig resourceConfig, VisitSequence sequence, Object... metadata) {
         this(fragment, resourceConfig, metadata);
         this.sequence = sequence;
     }

--- a/core/src/main/java/org/smooks/engine/delivery/interceptor/ExecutionEventInterceptor.java
+++ b/core/src/main/java/org/smooks/engine/delivery/interceptor/ExecutionEventInterceptor.java
@@ -63,7 +63,7 @@ public class ExecutionEventInterceptor extends AbstractInterceptorVisitor implem
     public void visitBefore(Element element, ExecutionContext executionContext) {
         if (getTarget().getContentHandler() instanceof BeforeVisitor) {
             for (ExecutionEventListener executionEventListener : executionContext.getContentDeliveryRuntime().getExecutionEventListeners()) {
-                executionEventListener.onEvent(new ResourceTargetingExecutionEvent(new NodeFragment(element), getTarget().getResourceConfig(), VisitSequence.BEFORE));
+                executionEventListener.onEvent(new ResourceTargetingExecutionEvent<>(new NodeFragment(element), getTarget().getResourceConfig(), VisitSequence.BEFORE));
             }
             intercept(visitBeforeInvocation, element, executionContext);
             onEvent(executionContext, new NodeFragment(element), VisitSequence.BEFORE);

--- a/core/src/main/java/org/smooks/engine/delivery/interceptor/InterceptorVisitorDefinition.java
+++ b/core/src/main/java/org/smooks/engine/delivery/interceptor/InterceptorVisitorDefinition.java
@@ -73,11 +73,27 @@ public class InterceptorVisitorDefinition {
         return clazz;
     }
 
-    public void setClass(Class<? extends InterceptorVisitor> clazz) {
+    public ResourceConfig getResourceConfig() {
+        return resourceConfig;
+    }
+
+    public Class<? extends InterceptorVisitor> getClazz() {
+        return clazz;
+    }
+
+    public void setClazz(Class<? extends InterceptorVisitor> clazz) {
         this.clazz = clazz;
     }
 
-    public ResourceConfig getResourceConfig() {
-        return resourceConfig;
+    public ApplicationContext getApplicationContext() {
+        return applicationContext;
+    }
+
+    public void setApplicationContext(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    public void setResourceConfig(ResourceConfig resourceConfig) {
+        this.resourceConfig = resourceConfig;
     }
 }

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgContentHandler.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgContentHandler.java
@@ -81,7 +81,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
 
-public class SaxNgHandler extends SmooksContentHandler {
+public class SaxNgContentHandler extends SmooksContentHandler {
     
     private final StringBuilder cdataNodeBuilder = new StringBuilder();
     private final ExecutionContext executionContext;
@@ -101,11 +101,11 @@ public class SaxNgHandler extends SmooksContentHandler {
     private NodeFragment currentNodeFragment;
     private Document document;
 
-    public SaxNgHandler(final ExecutionContext executionContext, final DocumentBuilder documentBuilder) {
+    public SaxNgContentHandler(final ExecutionContext executionContext, final DocumentBuilder documentBuilder) {
         this(executionContext, documentBuilder, null);
     }
 
-    public SaxNgHandler(final ExecutionContext executionContext, final DocumentBuilder documentBuilder, final SmooksContentHandler parentContentHandler) {
+    public SaxNgContentHandler(final ExecutionContext executionContext, final DocumentBuilder documentBuilder, final SmooksContentHandler parentContentHandler) {
         super(executionContext, parentContentHandler);
 
         this.executionContext = executionContext;

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgFilter.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgFilter.java
@@ -96,11 +96,11 @@ public class SaxNgFilter extends AbstractFilter {
 
     protected void doFilter(final Source source, final Result result) {
         if (!(source instanceof StreamSource || source instanceof JavaSource || source instanceof DOMSource)) {
-            throw new IllegalArgumentException("Unsupported " + source.getClass().getName() + " source type: SAX NG filter supports StreamSource, JavaSource, and DOMSource");
+            throw new SmooksException(String.format("Unsupported [%s] source type: SAX NG filter supports StreamSource, JavaSource, and DOMSource", source.getClass().getName()));
         }
         if (!(result instanceof FilterResult)) {
             if (result != null && !(result instanceof StreamResult) && !(result instanceof DOMResult)) {
-                throw new IllegalArgumentException("Unsupported " + result.getClass().getName() + " result type: SAX NG filter supports StreamResult and DOMResult.");
+                throw new SmooksException(String.format("Unsupported [%s] result type: SAX NG filter supports StreamResult and DOMResult", result.getClass().getName()));
             }
         }
 
@@ -116,7 +116,7 @@ public class SaxNgFilter extends AbstractFilter {
             }
         } catch (TerminateException e) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Terminated filtering on element '" + DomUtils.getXPath(e.getElement()) + "'.");
+                LOGGER.debug("Terminated filtering on element {}", DomUtils.getXPath(e.getElement()));
             }
         } catch (Exception e) {
             throw new SmooksException("Failed to filter source", e);

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/terminate/TerminateException.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/terminate/TerminateException.java
@@ -42,9 +42,10 @@
  */
 package org.smooks.engine.delivery.sax.ng.terminate;
 
+import org.smooks.api.SmooksException;
 import org.w3c.dom.Element;
 
-public class TerminateException extends RuntimeException {
+public class TerminateException extends SmooksException {
 	
 	private final Element element;
 

--- a/core/src/main/java/org/smooks/engine/lifecycle/PostFilterLifecyclePhase.java
+++ b/core/src/main/java/org/smooks/engine/lifecycle/PostFilterLifecyclePhase.java
@@ -1,0 +1,61 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Core
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.engine.lifecycle;
+
+import org.smooks.api.ExecutionContext;
+import org.smooks.api.lifecycle.FilterLifecycle;
+import org.smooks.api.lifecycle.LifecyclePhase;
+
+public class PostFilterLifecyclePhase implements LifecyclePhase {
+
+    private final ExecutionContext executionContext;
+
+    public PostFilterLifecyclePhase(ExecutionContext executionContext) {
+        this.executionContext = executionContext;
+    }
+
+    @Override
+    public void apply(Object o) {
+        ((FilterLifecycle) o).onPostFilter(executionContext);
+    }
+}

--- a/core/src/main/java/org/smooks/engine/lifecycle/PreFilterLifecyclePhase.java
+++ b/core/src/main/java/org/smooks/engine/lifecycle/PreFilterLifecyclePhase.java
@@ -1,0 +1,61 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Core
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.engine.lifecycle;
+
+import org.smooks.api.ExecutionContext;
+import org.smooks.api.lifecycle.FilterLifecycle;
+import org.smooks.api.lifecycle.LifecyclePhase;
+
+public class PreFilterLifecyclePhase implements LifecyclePhase {
+
+    private final ExecutionContext executionContext;
+
+    public PreFilterLifecyclePhase(ExecutionContext executionContext) {
+        this.executionContext = executionContext;
+    }
+
+    @Override
+    public void apply(Object o) {
+        ((FilterLifecycle) o).onPreFilter(executionContext);
+    }
+}

--- a/core/src/main/java/org/smooks/engine/lookup/CustomResourceConfigSeqLookup.java
+++ b/core/src/main/java/org/smooks/engine/lookup/CustomResourceConfigSeqLookup.java
@@ -59,14 +59,14 @@ public class CustomResourceConfigSeqLookup implements Function<Map<Object, Objec
     
     @Override
     public ResourceConfigSeq apply(final Map<Object, Object> registryEntries) {
-        ResourceConfigSeq userDefinedResources = new DefaultResourceConfigSeq("userDefinedResources");
+        ResourceConfigSeq customResourceConfigSeq = new DefaultResourceConfigSeq("customResources");
 
-        for (ResourceConfigSeq configList : registry.lookup(new ResourceConfigSeqsLookup())) {
-            if (!configList.isSystem()) {
-                userDefinedResources.addAll(configList);
+        for (ResourceConfigSeq resourceConfigSeq : registry.lookup(new ResourceConfigSeqsLookup())) {
+            if (!resourceConfigSeq.isSystem()) {
+                customResourceConfigSeq.addAll(resourceConfigSeq);
             }
         }
 
-        return userDefinedResources;
+        return customResourceConfigSeq;
     }
 }

--- a/core/src/main/java/org/smooks/engine/report/AbstractReportGenerator.java
+++ b/core/src/main/java/org/smooks/engine/report/AbstractReportGenerator.java
@@ -166,7 +166,7 @@ public abstract class AbstractReportGenerator extends BasicExecutionEventListene
     }
 
     @Override
-    public void onStarted(ExecutionContext executionContext) {
+    public void onPreFilter(ExecutionContext executionContext) {
         ContentDeliveryConfig contentDeliveryConfig = executionContext.getContentDeliveryRuntime().getContentDeliveryConfig();
         if (contentDeliveryConfig instanceof DOMContentDeliveryConfig) {
             report = new DOMReport();
@@ -178,7 +178,7 @@ public abstract class AbstractReportGenerator extends BasicExecutionEventListene
     }
 
     @Override
-    public void onFinished(ExecutionContext executionContext) {
+    public void onPostFilter(ExecutionContext executionContext) {
         try {
             processFinishEvent(executionContext);
         } catch (IOException e) {

--- a/core/src/main/java/org/smooks/engine/resource/config/DefaultResourceConfig.java
+++ b/core/src/main/java/org/smooks/engine/resource/config/DefaultResourceConfig.java
@@ -81,21 +81,21 @@ public class DefaultResourceConfig implements ResourceConfig {
      * Logger.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultResourceConfig.class);
-    
+
     /**
      * URI resource locator.
      */
     private static final URIResourceLocator uriResourceLocator = new URIResourceLocator();
-    
+
     /**
      * Selector steps.
      */
     private SelectorPath selectorPath;
-    
+
     /**
      * Target profile.
      */
-    private String targetProfile;
+    private String profile;
     /**
      * List of device/profile names on which the Content Delivery Resource is to be applied
      * for instances of selector.
@@ -115,18 +115,18 @@ public class DefaultResourceConfig implements ResourceConfig {
      * referenced through a URI.
      */
     private boolean isInline;
-  
+
     /**
      * The type of the resource.  "class", "groovy", "xsl" etc....
      */
     private String resourceType;
-   
+
     /**
      * ResourceConfig parameters - String name and String value.
      */
     private LinkedHashMap<String, Object> parameters = new LinkedHashMap<>();
     private int parameterCount;
-   
+
     /**
      * Flag indicating whether or not the resource is a default applied resource
      * e.g. {@link DefaultDOMSerializerVisitor} or
@@ -143,32 +143,32 @@ public class DefaultResourceConfig implements ResourceConfig {
      * Public default constructor.
      *
      * @see #setSelector(String)
-     * @see #setTargetProfile(String)
+     * @see #setProfile(String)
      * @see #setResource(String)
      * @see #setResourceType(String)
      * @see #setParameter(String, Object)
      */
     public DefaultResourceConfig() {
         setSelector(SELECTOR_NONE, new Properties());
-        setTargetProfile(Profile.DEFAULT_PROFILE);
+        setProfile(Profile.DEFAULT_PROFILE);
     }
 
     /**
      * Public constructor.
      *
      * @param selector The selector definition.
-     * @see #setTargetProfile(String)
+     * @see #setProfile(String)
      * @see #setResource(String)
      * @see #setResourceType(String)
      * @see #setParameter(String, Object)
      */
     public DefaultResourceConfig(String selector, Properties namespaces) {
         setSelector(selector, namespaces);
-        setTargetProfile(Profile.DEFAULT_PROFILE);
+        setProfile(Profile.DEFAULT_PROFILE);
     }
-    
+
     public DefaultResourceConfig(ResourceConfig resourceConfig) {
-        setTargetProfile(resourceConfig.getTargetProfile());
+        setProfile(resourceConfig.getProfile());
         setResource(resourceConfig.getResource());
         setSelectorPath(SelectorPathFactory.newSelectorPath(resourceConfig.getSelectorPath()));
         setSystem(resourceConfig.isSystem());
@@ -179,7 +179,7 @@ public class DefaultResourceConfig implements ResourceConfig {
      *
      * @param selector The selector definition.
      * @param resource The resource.
-     * @see #setTargetProfile(String)
+     * @see #setProfile(String)
      * @see #setResourceType(String)
      * @see #setParameter(String, Object)
      */
@@ -191,16 +191,16 @@ public class DefaultResourceConfig implements ResourceConfig {
      * Public constructor.
      *
      * @param selector      The selector definition.
-     * @param targetProfile Target Profile(s).  Comma separated list of
+     * @param profile Target Profile(s).  Comma separated list of
      *                      {@link ProfileTargetingExpression ProfileTargetingExpressions}.
      * @param resource      The resource.
      * @see #setResourceType(String)
      * @see #setParameter(String, Object)
      */
-    public DefaultResourceConfig(String selector, Properties namespaces, String targetProfile, String resource) {
+    public DefaultResourceConfig(String selector, Properties namespaces, String profile, String resource) {
         this(selector, namespaces);
 
-        setTargetProfile(targetProfile);
+        setProfile(profile);
         setResource(resource);
     }
 
@@ -210,7 +210,7 @@ public class DefaultResourceConfig implements ResourceConfig {
         DefaultResourceConfig copyResourceConfig = new DefaultResourceConfig();
 
         copyResourceConfig.selectorPath = SelectorPathFactory.newSelectorPath(selectorPath);
-        copyResourceConfig.targetProfile = targetProfile;
+        copyResourceConfig.profile = profile;
         copyResourceConfig.defaultResource = defaultResource;
         copyResourceConfig.profileTargetingExpressionStrings = profileTargetingExpressionStrings;
         copyResourceConfig.profileTargetingExpressions = profileTargetingExpressions;
@@ -225,7 +225,7 @@ public class DefaultResourceConfig implements ResourceConfig {
         return copyResourceConfig;
     }
 
-	@Override
+    @Override
     public void addParameters(ResourceConfig resourceConfig) {
         parameters.putAll(resourceConfig.getParameters());
     }
@@ -269,18 +269,18 @@ public class DefaultResourceConfig implements ResourceConfig {
     }
 
     @Override
-    public String getTargetProfile() {
-        return targetProfile;
+    public String getProfile() {
+        return profile;
     }
 
     @Override
-    public void setTargetProfile(String targetProfile) {
-        if (targetProfile == null || targetProfile.trim().isEmpty()) {
+    public void setProfile(String profile) {
+        if (profile == null || profile.trim().isEmpty()) {
             // Default the target profile to everything if not specified.
-            targetProfile = Profile.DEFAULT_PROFILE;
+            profile = Profile.DEFAULT_PROFILE;
         }
-        this.targetProfile = targetProfile;
-        parseTargetingExpressions(targetProfile);
+        this.profile = profile;
+        parseTargetingExpressions(profile);
     }
 
     @Override
@@ -425,7 +425,7 @@ public class DefaultResourceConfig implements ResourceConfig {
         } else if (parameter instanceof Parameter) {
             return (Parameter<T>) parameter;
         }
-        
+
         return null;
     }
 
@@ -489,7 +489,7 @@ public class DefaultResourceConfig implements ResourceConfig {
     public void removeParameter(String name) {
         parameters.remove(name);
     }
-    
+
     @Override
     public String toString() {
         return "Target Profile: [" + Arrays.asList(profileTargetingExpressionStrings) + "], Selector: [" + selectorPath.getSelector() + "], Resource: [" + resource + "], Num Params: [" + getParameterCount() + "]";
@@ -499,7 +499,7 @@ public class DefaultResourceConfig implements ResourceConfig {
     public byte[] getBytes() {
         // Defines the resource in a resource element, so it can be used to specify a path
         // or inlined resourcec data ala the "resdata" parameter in the 1.0 DTD.
-        
+
         if (resource != null) {
             InputStream resStream;
             try {
@@ -539,7 +539,7 @@ public class DefaultResourceConfig implements ResourceConfig {
      * Returns the resource as a Java Class instance.
      *
      * @return The Java Class instance refered to be this resource configuration, or null
-     *         if the resource doesn't refer to a Java Class.
+     * if the resource doesn't refer to a Java Class.
      */
     protected Class<?> toJavaResource() {
         String className;
@@ -558,11 +558,11 @@ public class DefaultResourceConfig implements ResourceConfig {
 
             return null;
         } catch (IllegalArgumentException e) {
-    		if (resource.equals(className)) {
-    			LOGGER.debug("The string [" + resource + "] contains unescaped characters that are illegal in a Java resource name.");
-    		}
+            if (resource.equals(className)) {
+                LOGGER.debug("The string [" + resource + "] contains unescaped characters that are illegal in a Java resource name.");
+            }
 
-    		return null;
+            return null;
         }
     }
 
@@ -586,12 +586,12 @@ public class DefaultResourceConfig implements ResourceConfig {
         StringBuilder builder = new StringBuilder();
 
         builder.append("<resource-config selector=\"")
-               .append(selectorPath.getSelector())
-               .append("\"");
-        if (targetProfile != null && !targetProfile.equals(Profile.DEFAULT_PROFILE)) {
+                .append(selectorPath.getSelector())
+                .append("\"");
+        if (profile != null && !profile.equals(Profile.DEFAULT_PROFILE)) {
             builder.append(" target-profile=\"")
-                   .append(targetProfile)
-                   .append("\"");
+                    .append(profile)
+                    .append("\"");
         }
         builder.append(">\n");
 
@@ -604,19 +604,19 @@ public class DefaultResourceConfig implements ResourceConfig {
             }
 
             builder.append("\t")
-                   .append(resourceStartEl);
+                    .append(resourceStartEl);
             if (resource.length() < 300) {
-               builder.append(resource)
-                       .append("</resource>\n");
+                builder.append(resource)
+                        .append("</resource>\n");
             } else {
-               builder.append(resource, 0, 300)
-                       .append(" ... more</resource>\n");
+                builder.append(resource, 0, 300)
+                        .append(" ... more</resource>\n");
             }
         }
 
         if (selectorPath.getConditionEvaluator() != null) {
             builder.append("\t<condition evaluator=\"").append(selectorPath.getConditionEvaluator().getClass().getName()).append("\">").append(selectorPath.getConditionEvaluator().getExpression())
-                   .append("</condition>\n");
+                    .append("</condition>\n");
         }
 
         if (parameters != null) {
@@ -633,10 +633,10 @@ public class DefaultResourceConfig implements ResourceConfig {
                         value = ((Parameter) param).getValue();
                     }
                     builder.append("\t<param name=\"")
-                           .append(paramName)
-                           .append("\">")
-                           .append(value)
-                           .append("</param>\n");
+                            .append(paramName)
+                            .append("\">")
+                            .append(value)
+                            .append("</param>\n");
                 }
             }
         }
@@ -657,16 +657,16 @@ public class DefaultResourceConfig implements ResourceConfig {
         Properties properties = new Properties();
         Set<String> names = parameters.keySet();
 
-        for(String name : names) {
+        for (String name : names) {
             properties.setProperty(name, getParameterValue(name).toString());
         }
 
         return properties;
     }
 
-    private void fireChangedEvent() {
-        if(!changeListeners.isEmpty()) {
-            for(ResourceConfigChangeListener listener : changeListeners) {
+    protected void fireChangedEvent() {
+        if (!changeListeners.isEmpty()) {
+            for (ResourceConfigChangeListener listener : changeListeners) {
                 listener.changed(this);
             }
         }

--- a/core/src/main/java/org/smooks/engine/resource/config/GenericReaderConfigurator.java
+++ b/core/src/main/java/org/smooks/engine/resource/config/GenericReaderConfigurator.java
@@ -104,7 +104,7 @@ public class GenericReaderConfigurator implements ReaderConfigurator {
         }
 
         if (targetProfile != null) {
-            resourceConfig.setTargetProfile(targetProfile);
+            resourceConfig.setProfile(targetProfile);
         }
 
         // Add the parameters...

--- a/core/src/main/java/org/smooks/engine/resource/extension/ExtensionContext.java
+++ b/core/src/main/java/org/smooks/engine/resource/extension/ExtensionContext.java
@@ -161,7 +161,7 @@ public class ExtensionContext {
      * @return The active resource configuration list.
      */
     public ResourceConfigSeq getResourceList() {
-        return xmlConfigDigester.getResourceList();
+        return xmlConfigDigester.getResourceConfigSeq();
     }
 
     public ResourceConfig getCurrentConfig() {
@@ -206,6 +206,6 @@ public class ExtensionContext {
      * @return List of matches resources, or an empty List if no matches are found.
      */
     public List<ResourceConfig> lookupResource(ConfigSearch searchCriteria) {
-        return xmlConfigDigester.getResourceList().lookupResource(searchCriteria);
+        return xmlConfigDigester.getResourceConfigSeq().lookupResource(searchCriteria);
     }
 }

--- a/core/src/main/java/org/smooks/engine/resource/extension/ResourceConfigUtil.java
+++ b/core/src/main/java/org/smooks/engine/resource/extension/ResourceConfigUtil.java
@@ -71,7 +71,7 @@ public final class ResourceConfigUtil {
         } else if (setOn.equals("defaultResource")) {
             resourceConfig.setSystem(Boolean.parseBoolean((String) value));
         } else if (setOn.equals("targetProfile")) {
-            resourceConfig.setTargetProfile((String) value);
+            resourceConfig.setProfile((String) value);
         } else if (setOn.equals("conditionRef")) {
             ExtensionContext extensionContext = executionContext.get(ExtensionContext.EXTENSION_CONTEXT_TYPED_KEY);
             resourceConfig.getSelectorPath().setConditionEvaluator(extensionContext.getXmlConfigDigester().getConditionEvaluator((String) value));
@@ -97,7 +97,7 @@ public final class ResourceConfigUtil {
         } else if (property.equals("defaultResource")) {
             resourceConfig.setSystem(false);
         } else if (property.equals("targetProfile")) {
-            resourceConfig.setTargetProfile(null);
+            resourceConfig.setProfile(null);
         } else if (property.equals("condition")) {
             resourceConfig.getSelectorPath().setConditionEvaluator(null);
         } else if (property.equals("conditionRef")) {
@@ -117,7 +117,7 @@ public final class ResourceConfigUtil {
         } else if (fromProperty.equals("defaultResource")) {
             setProperty(toResourceConfig, toProperty, fromResourceConfig.isSystem(), executionContext);
         } else if (fromProperty.equals("targetProfile")) {
-            setProperty(toResourceConfig, toProperty, fromResourceConfig.getTargetProfile(), executionContext);
+            setProperty(toResourceConfig, toProperty, fromResourceConfig.getProfile(), executionContext);
         } else if (fromProperty.equals("condition")) {
             toResourceConfig.getSelectorPath().setConditionEvaluator(fromResourceConfig.getSelectorPath().getConditionEvaluator());
         } else if (fromProperty.equals("conditionRef")) {

--- a/core/src/main/resources/META-INF/services/org.smooks.api.delivery.ReaderPoolFactory
+++ b/core/src/main/resources/META-INF/services/org.smooks.api.delivery.ReaderPoolFactory
@@ -1,0 +1,1 @@
+org.smooks.engine.delivery.DefaultReaderPoolFactory

--- a/core/src/test/java/org/smooks/DefaultApplicationContextBuilderTestCase.java
+++ b/core/src/test/java/org/smooks/DefaultApplicationContextBuilderTestCase.java
@@ -43,13 +43,16 @@
 package org.smooks;
 
 import org.junit.jupiter.api.Test;
+import org.smooks.api.SmooksConfigException;
 import org.smooks.api.SmooksException;
 import org.smooks.engine.DefaultApplicationContextBuilder;
 
 import java.net.URL;
 import java.util.Enumeration;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 public class DefaultApplicationContextBuilderTestCase {
 
@@ -71,7 +74,7 @@ public class DefaultApplicationContextBuilderTestCase {
                 };
             }
         }).build());
-        assertEquals("org.smooks.api.delivery.ContentHandlerFactory not found for content of type [class]. Hint: ensure the Smooks application context has the correct class loader set", smooksException.getCause().getMessage());
+        assertEquals("org.smooks.api.delivery.ReaderPoolFactory service not found. Hint: ensure the Smooks application context has the correct class loader set", smooksException.getCause().getMessage());
     }
 
     @Test

--- a/core/src/test/java/org/smooks/engine/delivery/DefaultReaderPoolTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/DefaultReaderPoolTestCase.java
@@ -1,0 +1,99 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Core
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.engine.delivery;
+
+import org.junit.jupiter.api.Test;
+import org.smooks.api.delivery.ReaderPool;
+import org.smooks.engine.resource.reader.NullSourceXMLReader;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DefaultReaderPoolTestCase {
+
+    @Test
+    public void testGetProperties() {
+        ReaderPool readerPool = new DefaultReaderPool(5);
+        Map<String, String> properties = readerPool.getProperties();
+        assertEquals("5", properties.get("maxReadersSize"));
+        assertEquals("5", properties.get("unallocatedReaders"));
+        assertEquals("0", properties.get("activeReaders"));
+    }
+
+    @Test
+    public void testGetPropertiesAfterBorrowXMLReader() {
+        ReaderPool readerPool = new DefaultReaderPool(5);
+        readerPool.borrowXMLReader();
+
+        Map<String, String> properties = readerPool.getProperties();
+        assertEquals("5", properties.get("maxReadersSize"));
+        assertEquals("5", properties.get("unallocatedReaders"));
+        assertEquals("0", properties.get("activeReaders"));
+    }
+
+    @Test
+    public void testGetPropertiesAfterBorrowXMLReaderThenReturnXMLReader() {
+        ReaderPool readerPool = new DefaultReaderPool(5);
+        readerPool.borrowXMLReader();
+        readerPool.returnXMLReader(new NullSourceXMLReader());
+
+        Map<String, String> properties = readerPool.getProperties();
+        assertEquals("5", properties.get("maxReadersSize"));
+        assertEquals("5", properties.get("unallocatedReaders"));
+        assertEquals("0", properties.get("activeReaders"));
+    }
+
+    @Test
+    public void testGetPropertiesAfterBorrowXMLReaderThenReturnXMLReaderTheBorrowXMLReader() {
+        ReaderPool readerPool = new DefaultReaderPool(5);
+        readerPool.borrowXMLReader();
+        readerPool.returnXMLReader(new NullSourceXMLReader());
+        readerPool.borrowXMLReader();
+
+        Map<String, String> properties = readerPool.getProperties();
+        assertEquals("5", properties.get("maxReadersSize"));
+        assertEquals("4", properties.get("unallocatedReaders"));
+        assertEquals("1", properties.get("activeReaders"));
+    }
+}

--- a/core/src/test/java/org/smooks/engine/delivery/DynamicReaderPoolTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/DynamicReaderPoolTestCase.java
@@ -1,0 +1,99 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Core
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.engine.delivery;
+
+import org.junit.jupiter.api.Test;
+import org.smooks.api.delivery.ReaderPool;
+import org.smooks.engine.resource.reader.NullSourceXMLReader;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DynamicReaderPoolTestCase {
+
+    @Test
+    public void testGetProperties() {
+        ReaderPool readerPool = new DynamicReaderPool();
+        Map<String, String> properties = readerPool.getProperties();
+        assertEquals("16", properties.get("readerPoolSize"));
+        assertEquals("16", properties.get("unallocatedReaders"));
+        assertEquals("0", properties.get("activeReaders"));
+    }
+
+    @Test
+    public void testGetPropertiesAfterBorrowXMLReader() {
+        ReaderPool readerPool = new DynamicReaderPool();
+        readerPool.borrowXMLReader();
+
+        Map<String, String> properties = readerPool.getProperties();
+        assertEquals("16", properties.get("readerPoolSize"));
+        assertEquals("16", properties.get("unallocatedReaders"));
+        assertEquals("0", properties.get("activeReaders"));
+    }
+
+    @Test
+    public void testGetPropertiesAfterBorrowXMLReaderThenReturnXMLReader() {
+        ReaderPool readerPool = new DynamicReaderPool();
+        readerPool.borrowXMLReader();
+        readerPool.returnXMLReader(new NullSourceXMLReader());
+
+        Map<String, String> properties = readerPool.getProperties();
+        assertEquals("16", properties.get("readerPoolSize"));
+        assertEquals("16", properties.get("unallocatedReaders"));
+        assertEquals("0", properties.get("activeReaders"));
+    }
+
+    @Test
+    public void testGetPropertiesAfterBorrowXMLReaderThenReturnXMLReaderTheBorrowXMLReader() {
+        ReaderPool readerPool = new DynamicReaderPool();
+        readerPool.borrowXMLReader();
+        readerPool.returnXMLReader(new NullSourceXMLReader());
+        readerPool.borrowXMLReader();
+
+        Map<String, String> properties = readerPool.getProperties();
+        assertEquals("16", properties.get("readerPoolSize"));
+        assertEquals("15", properties.get("unallocatedReaders"));
+        assertEquals("1", properties.get("activeReaders"));
+    }
+}

--- a/core/src/test/java/org/smooks/engine/delivery/SaxNgContentHandlerTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/SaxNgContentHandlerTestCase.java
@@ -53,6 +53,7 @@ import org.smooks.api.SmooksException;
 import org.smooks.api.delivery.fragment.Fragment;
 import org.smooks.api.lifecycle.PostFragmentLifecycle;
 import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
+import org.smooks.engine.delivery.sax.ng.SaxNgContentHandler;
 import org.w3c.dom.Element;
 
 import javax.xml.namespace.QName;
@@ -64,15 +65,15 @@ import java.util.Properties;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.*;
-import static org.smooks.engine.delivery.SaxNgHandlerTestCase.SAXMatchers.isSaxElementWithQName;
-import static org.smooks.engine.delivery.SaxNgHandlerTestCase.SAXMatchers.isSaxFragmentWithQName;
+import static org.smooks.engine.delivery.SaxNgContentHandlerTestCase.SAXMatchers.isSaxElementWithQName;
+import static org.smooks.engine.delivery.SaxNgContentHandlerTestCase.SAXMatchers.isSaxFragmentWithQName;
 
 /**
- * Test for {@link org.smooks.engine.delivery.sax.ng.SaxNgHandler}.
+ * Test for {@link SaxNgContentHandler}.
  *
  * @author Michael Kr&uuml;ske
  */
-public class SaxNgHandlerTestCase {
+public class SaxNgContentHandlerTestCase {
     private static final String SIMPLE_SAMPLE_XML = "SAXHandlerTest.xml";
 
     private static final String URN_SIMPLE = "urn:simple";
@@ -139,7 +140,7 @@ public class SaxNgHandlerTestCase {
     }
 
     private StreamSource createSource() {
-        final InputStream inputStream = SaxNgHandlerTestCase.class
+        final InputStream inputStream = SaxNgContentHandlerTestCase.class
                 .getResourceAsStream(SIMPLE_SAMPLE_XML);
         StreamSource source = new StreamSource(inputStream);
         return source;

--- a/core/src/test/java/org/smooks/engine/delivery/java/JavaSourceTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/java/JavaSourceTestCase.java
@@ -44,8 +44,8 @@ package org.smooks.engine.delivery.java;
 
 import org.junit.jupiter.api.Test;
 import org.smooks.Smooks;
-import org.smooks.api.SmooksException;
 import org.smooks.api.ExecutionContext;
+import org.smooks.api.SmooksException;
 import org.smooks.io.payload.JavaSource;
 import org.smooks.io.payload.StringResult;
 import org.xml.sax.SAXException;
@@ -53,7 +53,11 @@ import org.xml.sax.SAXException;
 import javax.xml.transform.stream.StreamResult;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -144,7 +148,7 @@ public class JavaSourceTestCase {
         try {
             smooks.filterSource(javaSource);
         } catch(SmooksException e) {
-            assertEquals("Invalid Smooks configuration.  Feature '" + JavaSource.FEATURE_GENERATE_EVENT_STREAM + "' is explicitly configured 'on' in the Smooks configuration, while the supplied JavaSource has explicitly configured event streaming to be off (through a call to JavaSource.setEventStreamRequired).", e.getCause().getMessage());
+            assertEquals("Invalid Smooks configuration. Feature [" + JavaSource.FEATURE_GENERATE_EVENT_STREAM + "] is explicitly configured 'on' in the Smooks configuration, while the supplied JavaSource has explicitly configured event streaming to be off (through a call to JavaSource.setEventStreamRequired).", e.getCause().getMessage());
         }
     }
 

--- a/core/src/test/java/org/smooks/engine/delivery/sax/ng/SaxNgFilterProviderTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/sax/ng/SaxNgFilterProviderTestCase.java
@@ -44,6 +44,7 @@ package org.smooks.engine.delivery.sax.ng;
 
 import org.junit.jupiter.api.Test;
 import org.smooks.api.Registry;
+import org.smooks.api.TypedKey;
 import org.smooks.api.delivery.ContentHandlerBinding;
 import org.smooks.api.resource.config.ResourceConfig;
 import org.smooks.api.resource.config.ResourceConfigSeq;
@@ -106,6 +107,11 @@ public class SaxNgFilterProviderTestCase {
 
             @Override
             public <T> T lookup(Object key) {
+                return null;
+            }
+
+            @Override
+            public <T> T lookup(TypedKey<T> key) {
                 return null;
             }
 

--- a/core/src/test/java/org/smooks/engine/resource/xsd20/readertests/ReaderConfigTestCase.java
+++ b/core/src/test/java/org/smooks/engine/resource/xsd20/readertests/ReaderConfigTestCase.java
@@ -71,7 +71,7 @@ public class ReaderConfigTestCase {
 
         assertEquals("com.ZZZZReader", readerConfig.getResource());
 
-        assertEquals("A", readerConfig.getTargetProfile());
+        assertEquals("A", readerConfig.getProfile());
 
         List handlers = readerConfig.getParameters("sax-handler");
         assertEquals("[com.X, com.Y]", handlers.toString());

--- a/management/pom.xml
+++ b/management/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.smooks</groupId>
+        <artifactId>smooks</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <name>Management</name>
+    <artifactId>smooks-management</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.smooks</groupId>
+            <artifactId>smooks-core</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/management/src/main/java/org/smooks/management/DefaultInstrumentationAgent.java
+++ b/management/src/main/java/org/smooks/management/DefaultInstrumentationAgent.java
@@ -1,0 +1,136 @@
+/*-
+ * ========================LICENSE_START=================================
+ * management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ *
+ * ======================================================================
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ======================================================================
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.smooks.api.SmooksException;
+import org.smooks.api.management.InstrumentationAgent;
+
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+import javax.management.NotCompliantMBeanException;
+import javax.management.ObjectName;
+import javax.management.modelmbean.InvalidTargetObjectTypeException;
+import javax.management.modelmbean.ModelMBeanInfo;
+import javax.management.modelmbean.RequiredModelMBean;
+import java.lang.management.ManagementFactory;
+import java.util.List;
+
+public class DefaultInstrumentationAgent implements InstrumentationAgent {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultInstrumentationAgent.class);
+
+    private final MBeanServer mBeanServer;
+
+    public DefaultInstrumentationAgent(boolean usePlatformMBeanServer, String mBeanServerDefaultDomain) {
+        mBeanServer = createOrFindMBeanServer(usePlatformMBeanServer, mBeanServerDefaultDomain);
+    }
+
+    @Override
+    public void register(Object object, ObjectName objectName) {
+        try {
+            registerMBeanWithServer(object, objectName, false);
+        } catch (NotCompliantMBeanException e) {
+            ModelMBeanAssembler modelMBeanAssembler = new ModelMBeanAssembler();
+            ModelMBeanInfo modelMBeanInfo = modelMBeanAssembler.getModelMbeanInfo(object.getClass());
+            register(object, objectName, modelMBeanInfo, false);
+        } catch (JMException e) {
+            throw new SmooksException(e);
+        }
+    }
+
+    @Override
+    public MBeanServer getMBeanServer() {
+        return mBeanServer;
+    }
+
+    @Override
+    public RequiredModelMBean register(Object object, ObjectName objectName, ModelMBeanInfo modelMBeanInfo, boolean forceRegistration) {
+        final RequiredModelMBean requiredModelMBean;
+        try {
+            requiredModelMBean = (RequiredModelMBean) mBeanServer.instantiate("javax.management.modelmbean.RequiredModelMBean");
+            requiredModelMBean.setModelMBeanInfo(modelMBeanInfo);
+            requiredModelMBean.setManagedResource(object, "ObjectReference");
+            registerMBeanWithServer(requiredModelMBean, objectName, forceRegistration);
+        } catch (InvalidTargetObjectTypeException | JMException e) {
+            throw new SmooksException(e);
+        }
+
+        return requiredModelMBean;
+    }
+
+    private void registerMBeanWithServer(Object object, ObjectName objectName, boolean forceRegistration) throws JMException {
+        try {
+            LOGGER.info("Registering MBean {}: {}", objectName, object);
+            mBeanServer.registerMBean(object, objectName);
+        } catch (InstanceAlreadyExistsException e) {
+            if (forceRegistration) {
+                mBeanServer.unregisterMBean(objectName);
+                mBeanServer.registerMBean(object, objectName);
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    protected MBeanServer createOrFindMBeanServer(boolean usePlatformMBeanServer, String mBeanServerDefaultDomain) {
+        if (usePlatformMBeanServer) {
+            return ManagementFactory.getPlatformMBeanServer();
+        }
+
+        List<MBeanServer> servers = MBeanServerFactory.findMBeanServer(null);
+
+        for (MBeanServer mBeanServer : servers) {
+            LOGGER.debug("Found MBeanServer with default domain {}", mBeanServer.getDefaultDomain());
+
+            if (mBeanServerDefaultDomain.equals(mBeanServer.getDefaultDomain())) {
+                return mBeanServer;
+            }
+        }
+
+        return MBeanServerFactory.createMBeanServer(mBeanServerDefaultDomain);
+    }
+}

--- a/management/src/main/java/org/smooks/management/DefaultInstrumentationAgentFactory.java
+++ b/management/src/main/java/org/smooks/management/DefaultInstrumentationAgentFactory.java
@@ -1,0 +1,53 @@
+/*-
+ * ========================LICENSE_START=================================
+ * management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management;
+
+import org.smooks.api.management.InstrumentationAgent;
+import org.smooks.api.management.InstrumentationAgentFactory;
+
+public class DefaultInstrumentationAgentFactory implements InstrumentationAgentFactory {
+
+    public InstrumentationAgent create(boolean usePlatformMBeanServer, String mBeanServerDefaultDomain) {
+        return new DefaultInstrumentationAgent(usePlatformMBeanServer, mBeanServerDefaultDomain);
+    }
+}

--- a/management/src/main/java/org/smooks/management/DefaultInstrumentationResource.java
+++ b/management/src/main/java/org/smooks/management/DefaultInstrumentationResource.java
@@ -1,0 +1,154 @@
+/*-
+ * ========================LICENSE_START=================================
+ * management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management;
+
+import jakarta.annotation.PostConstruct;
+import org.smooks.api.ApplicationContext;
+import org.smooks.api.ExecutionContext;
+import org.smooks.api.SmooksConfigException;
+import org.smooks.api.delivery.ReaderPool;
+import org.smooks.api.lifecycle.ContentDeliveryConfigLifecycle;
+import org.smooks.api.lifecycle.FilterLifecycle;
+import org.smooks.api.management.InstrumentationAgent;
+import org.smooks.api.management.InstrumentationAgentFactory;
+import org.smooks.api.management.InstrumentationResource;
+import org.smooks.api.resource.config.ResourceConfig;
+import org.smooks.api.resource.config.ResourceConfigSeq;
+import org.smooks.engine.lookup.ResourceConfigSeqsLookup;
+import org.smooks.management.mbean.ManagedReaderPool;
+import org.smooks.management.mbean.ManagedResourceConfig;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ServiceLoader;
+
+public class DefaultInstrumentationResource implements FilterLifecycle, ContentDeliveryConfigLifecycle, InstrumentationResource {
+
+    private final List<ReaderPool> managedReaderPools = new ArrayList<>(1);
+
+    @Inject
+    private ApplicationContext applicationContext;
+
+    @Inject
+    private Boolean usePlatformMBeanServer;
+
+    @Inject
+    private String mBeanServerDefaultDomain;
+
+    @Inject
+    private String mBeanObjectDomainName;
+
+    @Inject
+    private Boolean includeHostName;
+
+    private InstrumentationAgent instrumentationAgent;
+
+    @PostConstruct
+    public void postConstruct() {
+        Iterator<InstrumentationAgentFactory> instrumentationAgentFactoryIterator = ServiceLoader.load(InstrumentationAgentFactory.class, applicationContext.getClassLoader()).iterator();
+        if (instrumentationAgentFactoryIterator.hasNext()) {
+            InstrumentationAgentFactory instrumentationAgentFactory = instrumentationAgentFactoryIterator.next();
+            instrumentationAgent = instrumentationAgentFactory.create(usePlatformMBeanServer, mBeanServerDefaultDomain);
+            applicationContext.getRegistry().registerObject(INSTRUMENTATION_RESOURCE_TYPED_KEY, this);
+        } else {
+            throw new SmooksConfigException(String.format("%s service not found. Hint: ensure the Smooks application context has the correct class loader set", InstrumentationAgentFactory.class.getName()));
+        }
+    }
+
+    @Override
+    public void onPreFilter(ExecutionContext executionContext) {
+        ReaderPool readerPool = executionContext.getContentDeliveryRuntime().getReaderPool();
+        if (!managedReaderPools.contains(readerPool)) {
+            synchronized (this) {
+                if (!managedReaderPools.contains(executionContext.getContentDeliveryRuntime().getReaderPool())) {
+                    managedReaderPools.add(readerPool);
+                    ManagedReaderPool managedReaderPool = new ManagedReaderPool(executionContext.getContentDeliveryRuntime().getReaderPool(), this);
+                    instrumentationAgent.register(managedReaderPool, managedReaderPool.getObjectName());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onPostFilter(ExecutionContext executionContext) {
+
+    }
+
+    @Override
+    public void onContentHandlersCreated() {
+        List<ResourceConfigSeq> resourceConfigSeqs = applicationContext.getRegistry().lookup(new ResourceConfigSeqsLookup());
+        for (ResourceConfigSeq resourceConfigSeq : resourceConfigSeqs) {
+            for (ResourceConfig resourceConfig : resourceConfigSeq) {
+                ManagedResourceConfig managedResourceConfig = new ManagedResourceConfig(resourceConfigSeq, resourceConfig, this);
+                instrumentationAgent.register(managedResourceConfig, managedResourceConfig.getObjectName());
+            }
+        }
+    }
+
+    @Override
+    public void onContentDeliveryBuilderCreated() {
+
+    }
+
+    @Override
+    public void onContentDeliveryConfigCreated() {
+
+    }
+
+    @Override
+    public String getMBeanObjectDomainName() {
+        return mBeanObjectDomainName;
+    }
+
+    @Override
+    public Boolean getIncludeHostName() {
+        return includeHostName;
+    }
+
+    @Override
+    public InstrumentationAgent getInstrumentationAgent() {
+        return instrumentationAgent;
+    }
+}

--- a/management/src/main/java/org/smooks/management/InstrumentationInterceptor.java
+++ b/management/src/main/java/org/smooks/management/InstrumentationInterceptor.java
@@ -1,0 +1,122 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Core
+ * %%
+ * Copyright (C) 2020 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ *
+ * ======================================================================
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ======================================================================
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management;
+
+import jakarta.annotation.PostConstruct;
+import org.smooks.api.ExecutionContext;
+import org.smooks.api.SmooksConfigException;
+import org.smooks.api.SmooksException;
+import org.smooks.api.management.InstrumentationResource;
+import org.smooks.api.resource.visitor.Visitor;
+import org.smooks.api.resource.visitor.sax.ng.AfterVisitor;
+import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
+import org.smooks.api.resource.visitor.sax.ng.ChildrenVisitor;
+import org.smooks.api.resource.visitor.sax.ng.ElementVisitor;
+import org.smooks.engine.delivery.interceptor.AbstractInterceptorVisitor;
+import org.smooks.management.mbean.ManagedVisitor;
+import org.w3c.dom.CharacterData;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import java.util.Date;
+
+public class InstrumentationInterceptor extends AbstractInterceptorVisitor implements ElementVisitor {
+
+    private ManagedVisitor managedVisitor;
+
+    @PostConstruct
+    public void postConstruct() {
+        InstrumentationResource instrumentationResource = applicationContext.getRegistry().lookup(InstrumentationResource.INSTRUMENTATION_RESOURCE_TYPED_KEY);
+        if (instrumentationResource == null) {
+            throw new SmooksConfigException("Instrumentation resource not found. Hint: have you declared the instrumentation resource => <management:instrumentationResource/>");
+        }
+
+        managedVisitor = new ManagedVisitor(instrumentationResource, getTarget().getResourceConfig(), getTarget().getContentHandler());
+    }
+
+    @Override
+    public void visitBefore(final Element element, final ExecutionContext executionContext) throws SmooksException {
+        if (visitorBinding.getContentHandler() instanceof BeforeVisitor) {
+            managedVisitor.incrementVisitBeforeCounter();
+            manageVisit(visitBeforeInvocation, element, executionContext);
+        }
+    }
+
+    @Override
+    public void visitAfter(final Element element, final ExecutionContext executionContext) throws SmooksException {
+        if (visitorBinding.getContentHandler() instanceof AfterVisitor) {
+            managedVisitor.incrementVisitAfterCounter();
+            manageVisit(visitAfterInvocation, element, executionContext);
+        }
+    }
+
+    @Override
+    public void visitChildText(final CharacterData characterData, final ExecutionContext executionContext) throws SmooksException {
+        if (visitorBinding.getContentHandler() instanceof ChildrenVisitor) {
+            managedVisitor.incrementVisitChildTextCounter();
+            manageVisit(visitChildTextInvocation, characterData, executionContext);
+        }
+    }
+
+    @Override
+    public void visitChildElement(Element childElement, ExecutionContext executionContext) {
+        if (visitorBinding.getContentHandler() instanceof ChildrenVisitor) {
+            managedVisitor.incrementVisitChildTextCounter();
+            manageVisit( visitChildElementInvocation, childElement, executionContext);
+        }
+    }
+
+    protected <T extends Visitor> void manageVisit(Invocation<T> invocation, Node node, ExecutionContext executionContext) {
+        long startTime = new Date().getTime();
+        try {
+            intercept(invocation, node, executionContext);
+        } catch (RuntimeException e) {
+            managedVisitor.incrementFailedVisitCounter();
+            throw e;
+        } finally {
+            long visitProcessingTime = new Date().getTime() - startTime;
+            managedVisitor.addTotalProcessingTime(visitProcessingTime);
+            managedVisitor.sendNotification(node, visitProcessingTime);
+        }
+    }
+}

--- a/management/src/main/java/org/smooks/management/ModelMBeanAssembler.java
+++ b/management/src/main/java/org/smooks/management/ModelMBeanAssembler.java
@@ -1,0 +1,277 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management;
+
+import org.smooks.management.annotation.ManagedAttribute;
+import org.smooks.management.annotation.ManagedNotification;
+import org.smooks.management.annotation.ManagedNotifications;
+import org.smooks.management.annotation.ManagedOperation;
+import org.smooks.management.annotation.ManagedResource;
+
+import javax.management.Descriptor;
+import javax.management.modelmbean.ModelMBeanInfo;
+import java.lang.reflect.Method;
+
+/**
+ * A Smooks-specific {@link javax.management.MBeanInfo} assembler that reads the details from the
+ * {@link ManagedResource}, {@link ManagedAttribute}, {@link ManagedOperation}, {@link ManagedNotification}, and
+ * {@link ManagedNotifications} annotations.
+ */
+public class ModelMBeanAssembler {
+
+    private final ModelMBeanInfoHelper modelMBeanInfoHelper = new ModelMBeanInfoHelper();
+
+    public ManagedResource getManagedResource(Class<?> clazz) {
+        return clazz.getAnnotation(ManagedResource.class);
+    }
+
+    public ManagedAttribute getManagedAttribute(Method method) {
+        return method.getAnnotation(ManagedAttribute.class);
+    }
+
+    public ManagedOperation getManagedOperation(Method method) {
+        return method.getAnnotation(ManagedOperation.class);
+    }
+
+    public ManagedNotification[] getManagedNotifications(Class<?> clazz) {
+        ManagedNotifications managedNotifications = clazz.getAnnotation(ManagedNotifications.class);
+        return null != managedNotifications ? managedNotifications.value() : new ManagedNotification[0];
+    }
+
+    public String getAttributeName(String methodName) {
+        if (methodName.indexOf("set") == 0) {
+            return methodName.substring(3);
+        }
+        if (methodName.indexOf("get") == 0) {
+            return methodName.substring(3);
+        }
+        if (methodName.indexOf("is") == 0) {
+            return methodName.substring(2);
+        }
+        return null;
+    }
+
+    public static boolean checkMethod(Method[] methods, String methodName) {
+        boolean result = false;
+        for (Method method : methods) {
+            if (method.getName().compareTo(methodName) == 0) {
+                result = true;
+                break;
+            }
+        }
+        return result;
+    }
+
+    public static String getAttributeType(Method[] methods, String attributeName) {
+        String result = null;
+        String searchMethod = "get" + attributeName;
+        for (Method value : methods) {
+            if (value.getName().compareTo(searchMethod) == 0) {
+                result = value.getReturnType().getName();
+                break;
+            }
+        }
+        // check it is "is " attribute
+        if (null == result) {
+            searchMethod = "is" + attributeName;
+            for (Method method : methods) {
+                if (method.getName().compareTo(searchMethod) == 0) {
+                    result = method.getReturnType().getName();
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+    static class ManagedAttributeInfo {
+        String fname;
+        String ftype;
+        String description;
+        boolean read;
+        boolean write;
+        boolean is;
+    };
+
+
+    public ManagedAttributeInfo getAttributeInfo(Method[] methods,
+                                                 String attributName,
+                                                 String attributType,
+                                                 ManagedAttribute managedAttribute) {
+        ManagedAttributeInfo managedAttributeInfo = new ManagedAttributeInfo();
+        managedAttributeInfo.fname = attributName;
+        managedAttributeInfo.ftype = attributType;
+        managedAttributeInfo.description = managedAttribute.description();
+        managedAttributeInfo.is = checkMethod(methods, "is" + attributName);
+        managedAttributeInfo.write = checkMethod(methods, "set" + attributName);
+
+        if (managedAttributeInfo.is) {
+            managedAttributeInfo.read = true;
+        } else {
+            managedAttributeInfo.read = checkMethod(methods, "get" + attributName);
+        }
+
+        return managedAttributeInfo;
+
+    }
+
+    Method findMethodByName(Method[] methods, String methodName) {
+        for (Method method : methods) {
+            if (method.getName().compareTo(methodName) == 0) {
+                return method;
+            }
+        }
+        return null;
+    }
+
+    void addAttributeOperation(Method method) {
+        Descriptor operationDescriptor = modelMBeanInfoHelper.buildAttributeOperationDescriptor(method.getName());
+
+        Class<?>[] types = method.getParameterTypes();
+
+        String[] paramTypes = new String[types.length];
+        String[] paramNames = new String[types.length];
+        String[] paramDescs = new String[types.length];
+
+        for (int j = 0; j < types.length; j++) {
+            paramTypes[j] = types[j].getName();
+            paramDescs[j] = "";
+            paramNames[j] = types[j].getName();
+        }
+
+        modelMBeanInfoHelper.addModelMBeanMethod(method.getName(),
+                paramTypes,
+                paramNames,
+                paramDescs,
+                "",
+                method.getReturnType().getName(),
+                operationDescriptor);
+    }
+
+    public ModelMBeanInfo getModelMbeanInfo(Class<?> clazz) {
+        modelMBeanInfoHelper.clear();
+        ManagedResource managedResource = getManagedResource(clazz);
+        if (managedResource == null) {
+            return null;
+        }
+        String mbeanDescriptor = managedResource.description();
+
+        ManagedNotification[] managedNotifications = getManagedNotifications(clazz);
+        for (ManagedNotification managedNotification : managedNotifications) {
+            modelMBeanInfoHelper.addModelMBeanNotification(managedNotification.notificationTypes(),
+                    managedNotification.name(),
+                    managedNotification.description(), null);
+        }
+
+        Method[] methods = clazz.getDeclaredMethods();
+
+        for (Method value : methods) {
+            ManagedAttribute managedAttribute = getManagedAttribute(value);
+            //add Attribute to the ModelMBean
+            if (managedAttribute != null) {
+                String attributeName = getAttributeName(value.getName());
+                if (!modelMBeanInfoHelper.checkAttribute(attributeName)) {
+                    String attributeType = getAttributeType(methods, attributeName);
+                    ManagedAttributeInfo managedAttributeInfo = getAttributeInfo(methods,
+                            attributeName,
+                            attributeType,
+                            managedAttribute);
+                    Descriptor attributeDescriptor = modelMBeanInfoHelper.buildAttributeDescriptor(attributeName,
+                            managedAttributeInfo.is, managedAttributeInfo.read, managedAttributeInfo.write);
+
+                    // should setup the description
+                    modelMBeanInfoHelper.addModelMBeanAttribute(managedAttributeInfo.fname,
+                            managedAttributeInfo.ftype,
+                            managedAttributeInfo.read,
+                            managedAttributeInfo.write,
+                            managedAttributeInfo.is,
+                            managedAttributeInfo.description,
+                            attributeDescriptor);
+
+                    Method method;
+                    // add the attribute methode to operation
+                    if (managedAttributeInfo.read) {
+                        if (managedAttributeInfo.is) {
+                            method = findMethodByName(methods, "is" + attributeName);
+                        } else {
+                            method = findMethodByName(methods, "get" + attributeName);
+                        }
+                        addAttributeOperation(method);
+                    }
+                    if (managedAttributeInfo.write) {
+                        method = findMethodByName(methods, "set" + attributeName);
+                        addAttributeOperation(method);
+                    }
+                }
+
+            } else {
+                ManagedOperation managedOperation = getManagedOperation(value);
+
+                if (managedOperation != null) {
+                    Class<?>[] types = value.getParameterTypes();
+                    String[] paramTypes = new String[types.length];
+                    String[] paramNames = new String[types.length];
+                    String[] paramDescs = new String[types.length];
+
+                    for (int j = 0; j < types.length; j++) {
+                        paramTypes[j] = types[j].getName();
+                        paramDescs[j] = "";
+                        paramNames[j] = types[j].getName();
+                    }
+                    Descriptor operationDescriptor =
+                            modelMBeanInfoHelper.buildOperationDescriptor(managedOperation, value.getName());
+                    modelMBeanInfoHelper.addModelMBeanMethod(value.getName(),
+                            paramTypes,
+                            paramNames,
+                            paramDescs,
+                            managedOperation.description(),
+                            value.getReturnType().getName(),
+                            operationDescriptor);
+                }
+            }
+
+        }
+        return modelMBeanInfoHelper.buildModelMBeanInfo(mbeanDescriptor);
+    }
+
+}

--- a/management/src/main/java/org/smooks/management/ModelMBeanInfoHelper.java
+++ b/management/src/main/java/org/smooks/management/ModelMBeanInfoHelper.java
@@ -1,0 +1,196 @@
+/*-
+ * ========================LICENSE_START=================================
+ * management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ *
+ * ======================================================================
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ======================================================================
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management;
+
+import org.smooks.management.annotation.ManagedAttribute;
+import org.smooks.management.annotation.ManagedOperation;
+import org.smooks.management.annotation.ManagedResource;
+
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.management.Descriptor;
+import javax.management.MBeanOperationInfo;
+import javax.management.MBeanParameterInfo;
+import javax.management.modelmbean.DescriptorSupport;
+import javax.management.modelmbean.ModelMBeanAttributeInfo;
+import javax.management.modelmbean.ModelMBeanConstructorInfo;
+import javax.management.modelmbean.ModelMBeanInfo;
+import javax.management.modelmbean.ModelMBeanInfoSupport;
+import javax.management.modelmbean.ModelMBeanNotificationInfo;
+import javax.management.modelmbean.ModelMBeanOperationInfo;
+
+public class ModelMBeanInfoHelper {
+    protected Map<String, ModelMBeanAttributeInfo> attributes = new HashMap<>();
+    protected Map<Constructor<?>, ModelMBeanConstructorInfo> constructors = new HashMap<>();
+    protected Map<String, ModelMBeanOperationInfo> operations = new HashMap<>();
+    protected Map<String, ModelMBeanNotificationInfo> notifications = new HashMap<>();
+
+    public void clear() {
+        attributes.clear();
+        notifications.clear();
+        constructors.clear();
+        operations.clear();
+    }
+
+    public void addModelMBeanMethod(String name, String[] paramTypes, String[] paramNames, String[] paramDescs,
+                                    String description, String rtype, Descriptor desc) {
+        MBeanParameterInfo[] params = null;
+        if (paramTypes != null) {
+            params = new MBeanParameterInfo[paramTypes.length];
+            for (int i = 0; i < paramTypes.length; i++) {
+                params[i] = new MBeanParameterInfo(paramNames[i],
+                        paramTypes[i], paramDescs[i]);
+            }
+        }
+
+        operations.put(name,
+                new ModelMBeanOperationInfo(name,
+                        description,
+                        params,
+                        rtype,
+                        MBeanOperationInfo.ACTION,
+                        desc));
+    }
+
+    public boolean checkAttribute(String attributeName) {
+        return attributes.containsKey(attributeName);
+    }
+
+    public void addModelMBeanAttribute(String fname,
+                                       String ftype,
+                                       boolean read,
+                                       boolean write,
+                                       boolean is,
+                                       String description,
+                                       Descriptor desc) {
+        attributes.put(fname, new ModelMBeanAttributeInfo(fname,
+                ftype,
+                description,
+                read,
+                write,
+                is,
+                desc));
+    }
+
+    public void addModelMBeanNotification(String[] type,
+                                          String className,
+                                          String description,
+                                          Descriptor desc) {
+        notifications.put(className, new ModelMBeanNotificationInfo(type, className, description, desc));
+    }
+
+    public void addModelMBeanConstructor(Constructor<?> c,
+                                         String description,
+                                         Descriptor desc) {
+        this.constructors.put(c,
+                new ModelMBeanConstructorInfo(description,
+                        c,
+                        desc));
+    }
+
+    public ModelMBeanInfo buildModelMBeanInfo(String description) {
+
+        ModelMBeanOperationInfo[] modelMBeanOperationInfos = operations.values().toArray(new ModelMBeanOperationInfo[operations.values().size()]);
+        ModelMBeanAttributeInfo[] modelMBeanAttributeInfos = attributes.values().toArray(new ModelMBeanAttributeInfo[attributes.values().size()]);
+        ModelMBeanConstructorInfo[] modelMBeanConstructorInfos = constructors.values().toArray(new ModelMBeanConstructorInfo[constructors.values().size()]);
+        ModelMBeanNotificationInfo[] modelMBeanNotificationInfos = notifications.values().toArray(new ModelMBeanNotificationInfo[notifications.values().size()]);
+
+        return new ModelMBeanInfoSupport("javax.management.modelmbean.ModelMBeanInfo",
+                description,
+                modelMBeanAttributeInfos,
+                modelMBeanConstructorInfos,
+                modelMBeanOperationInfos,
+                modelMBeanNotificationInfos);
+    }
+
+
+    public Descriptor buildAttributeDescriptor(String attributeName, boolean is, boolean read, boolean write) {
+        Descriptor descriptor = new DescriptorSupport();
+        descriptor.setField("name", attributeName);
+        descriptor.setField("descriptorType", "attribute");
+
+        if (read) {
+            if (is) {
+                descriptor.setField("getMethod", "is" + attributeName);
+            } else {
+                descriptor.setField("getMethod", "get" + attributeName);
+            }
+        }
+
+        if (write) {
+            descriptor.setField("setMethod", "set" + attributeName);
+        }
+
+        return descriptor;
+    }
+
+    public Descriptor buildOperationDescriptor(ManagedOperation managedOperation, String operationName) {
+        Descriptor descriptor = new DescriptorSupport();
+        descriptor.setField("name", operationName);
+        descriptor.setField("descriptorType", "operation");
+        descriptor.setField("role", "operation");
+
+        if (managedOperation.description() != null) {
+            descriptor.setField("displayName", managedOperation.description());
+        }
+
+        return descriptor;
+    }
+
+    public Descriptor buildAttributeOperationDescriptor(String operationName) {
+        Descriptor descriptor = new DescriptorSupport();
+        descriptor.setField("name", operationName);
+
+        descriptor.setField("descriptorType", "operation");
+
+        if (operationName.indexOf("set") == 0) {
+            descriptor.setField("role", "setter");
+        } else {
+            descriptor.setField("role", "getter");
+        }
+
+        return descriptor;
+    }
+}

--- a/management/src/main/java/org/smooks/management/annotation/ManagedAttribute.java
+++ b/management/src/main/java/org/smooks/management/annotation/ManagedAttribute.java
@@ -1,0 +1,58 @@
+/*-
+ * ========================LICENSE_START=================================
+ * management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+public @interface ManagedAttribute {
+    String description() default "";
+}

--- a/management/src/main/java/org/smooks/management/annotation/ManagedNotification.java
+++ b/management/src/main/java/org/smooks/management/annotation/ManagedNotification.java
@@ -1,0 +1,84 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.smooks.management.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+public @interface ManagedNotification {
+
+    String name();
+
+    String description() default "";
+
+    String[] notificationTypes();
+
+}

--- a/management/src/main/java/org/smooks/management/annotation/ManagedNotifications.java
+++ b/management/src/main/java/org/smooks/management/annotation/ManagedNotifications.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * Core
+ * Management
  * %%
  * Copyright (C) 2020 - 2024 Smooks
  * %%
@@ -40,22 +40,40 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.lifecycle;
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-import org.smooks.api.ExecutionContext;
-import org.smooks.api.lifecycle.FilterLifecycle;
-import org.smooks.api.lifecycle.LifecyclePhase;
+package org.smooks.management.annotation;
 
-public class FilterFinishedLifecyclePhase implements LifecyclePhase {
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-    private final ExecutionContext executionContext;
 
-    public FilterFinishedLifecyclePhase(ExecutionContext executionContext) {
-        this.executionContext = executionContext;
-    }
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+public @interface ManagedNotifications {
 
-    @Override
-    public void apply(Object o) {
-        ((FilterLifecycle) o).onFinished(executionContext);
-    }
+    ManagedNotification[] value();
 }

--- a/management/src/main/java/org/smooks/management/annotation/ManagedOperation.java
+++ b/management/src/main/java/org/smooks/management/annotation/ManagedOperation.java
@@ -1,0 +1,58 @@
+/*-
+ * ========================LICENSE_START=================================
+ * management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+public @interface ManagedOperation {
+    String description() default "";
+}

--- a/management/src/main/java/org/smooks/management/annotation/ManagedResource.java
+++ b/management/src/main/java/org/smooks/management/annotation/ManagedResource.java
@@ -1,0 +1,61 @@
+/*-
+ * ========================LICENSE_START=================================
+ * management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ *
+ * ======================================================================
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ======================================================================
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A class level annotation to mark the class as being managed in the JMX server.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+public @interface ManagedResource {
+    String description() default "";
+}

--- a/management/src/main/java/org/smooks/management/mbean/AbstractMBean.java
+++ b/management/src/main/java/org/smooks/management/mbean/AbstractMBean.java
@@ -1,0 +1,107 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management.mbean;
+
+import org.smooks.api.SmooksException;
+import org.smooks.api.management.InstrumentationResource;
+import org.smooks.api.management.MBean;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public abstract class AbstractMBean implements MBean {
+
+    final InstrumentationResource instrumentationResource;
+    protected String hostName = "localhost";
+
+    public AbstractMBean(InstrumentationResource instrumentationResource) {
+        this.instrumentationResource = instrumentationResource;
+        try {
+            hostName = getLocalHostName();
+        } catch (UnknownHostException ex) {
+            // ignore, use the default "localhost"
+        }
+    }
+
+    protected String getLocalHostName() throws UnknownHostException {
+        try {
+            return (InetAddress.getLocalHost()).getHostName();
+        } catch (UnknownHostException uhe) {
+            String host = uhe.getMessage();
+            if (host != null) {
+                return host.contains(":") ? host.substring(0, host.indexOf(":") - 1) : null;
+            }
+            throw uhe;
+        }
+    }
+
+    @Override
+    public ObjectName getObjectName() {
+        StringBuilder objectNameStringBuilder = new StringBuilder();
+        objectNameStringBuilder.append(instrumentationResource.getMBeanObjectDomainName()).append(":");
+        if (instrumentationResource.getIncludeHostName()) {
+            objectNameStringBuilder.append("context=").append(ObjectName.quote(getContext() != null ? hostName + "/" + getContext() : hostName)).append(",");
+        } else if (getContext() != null) {
+            objectNameStringBuilder.append("context=").append(ObjectName.quote(getContext())).append(",");
+        }
+
+        objectNameStringBuilder.append("type=").append(getType()).append(",");
+        objectNameStringBuilder.append("name=").append(getName());
+
+        try {
+            return new ObjectName(objectNameStringBuilder.toString());
+        } catch (MalformedObjectNameException e) {
+            throw new SmooksException(e);
+        }
+    }
+
+    protected abstract String getName();
+
+    protected abstract String getType();
+
+    protected String getContext() {
+        return null;
+    }
+}

--- a/management/src/main/java/org/smooks/management/mbean/ManagedReaderPool.java
+++ b/management/src/main/java/org/smooks/management/mbean/ManagedReaderPool.java
@@ -1,0 +1,84 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management.mbean;
+
+import jakarta.annotation.Resource;
+import org.smooks.api.SmooksException;
+import org.smooks.api.delivery.ReaderPool;
+import org.smooks.api.management.InstrumentationResource;
+import org.smooks.api.management.MBean;
+import org.smooks.management.annotation.ManagedAttribute;
+import org.smooks.management.annotation.ManagedResource;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+@ManagedResource
+public class ManagedReaderPool extends AbstractMBean {
+    private final ReaderPool readerPool;
+    public ManagedReaderPool(ReaderPool readerPool, InstrumentationResource instrumentationResource) {
+        super(instrumentationResource);
+        this.readerPool = readerPool;
+    }
+    @ManagedAttribute(description = "Reader pool properties")
+    public Map<String, String> getReaderPoolProperties() {
+        return readerPool.getProperties();
+    }
+
+    @Override
+    protected String getName() {
+        if (readerPool.getClass().getAnnotation(Resource.class) != null) {
+            return readerPool.getClass().getAnnotation(Resource.class).name();
+        } else {
+            return readerPool.toString();
+        }
+    }
+
+    @Override
+    protected String getType() {
+        return "readerPool";
+    }
+}

--- a/management/src/main/java/org/smooks/management/mbean/ManagedResourceConfig.java
+++ b/management/src/main/java/org/smooks/management/mbean/ManagedResourceConfig.java
@@ -1,0 +1,127 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management.mbean;
+
+import org.smooks.api.SmooksException;
+import org.smooks.api.management.InstrumentationResource;
+import org.smooks.api.management.MBean;
+import org.smooks.api.resource.config.Parameter;
+import org.smooks.api.resource.config.ResourceConfig;
+import org.smooks.api.resource.config.ResourceConfigSeq;
+import org.smooks.management.annotation.ManagedAttribute;
+import org.smooks.management.annotation.ManagedResource;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+@ManagedResource
+public class ManagedResourceConfig extends AbstractMBean {
+
+    private final ResourceConfig resourceConfig;
+    private final ResourceConfigSeq resourceConfigSeq;
+
+    public ManagedResourceConfig(ResourceConfigSeq resourceConfigSeq, ResourceConfig resourceConfig, InstrumentationResource instrumentationResource) {
+        super(instrumentationResource);
+        this.resourceConfig = resourceConfig;
+        this.resourceConfigSeq = resourceConfigSeq;
+    }
+
+    @ManagedAttribute(description = "Parameters")
+    public Map<String, Object> getParameters() {
+        Map<String, Object> parametersAsMap = new HashMap<>(resourceConfig.getParameterCount());
+        List<?> parameters = resourceConfig.getParameterValues();
+        for (Object parameter : parameters) {
+            if (parameter instanceof Parameter ) {
+                parametersAsMap.put(((Parameter<?>) parameter).getName(), ((Parameter<?>) parameter).getValue());
+            } else if (parameter instanceof List) {
+                List<Object> paramList = new ArrayList<>(((List<?>) parameter).size());
+                for (Parameter<?> o : ((List<Parameter<?>>) parameter)) {
+                    paramList.add(o.getValue());
+                }
+                parametersAsMap.put(((List<Parameter>) parameter).get(0).getName(), paramList);
+            }
+        }
+
+        return parametersAsMap;
+    }
+
+    @ManagedAttribute(description = "Resource type")
+    public String getResourceType() {
+        return resourceConfig.getResourceType();
+    }
+
+    @ManagedAttribute(description = "Selector")
+    public String getSelector() {
+        return resourceConfig.getSelectorPath().getSelector();
+    }
+
+    @ManagedAttribute(description = "Selector namespaces")
+    public Properties getSelectorNamespaces() {
+        return resourceConfig.getSelectorPath().getNamespaces();
+    }
+
+    @ManagedAttribute(description = "Resource")
+    public String getResource() {
+        return resourceConfig.getResource();
+    }
+
+    @Override
+    protected String getName() {
+        return resourceConfig.getClass().getName() + "@" + Integer.toHexString(hashCode());
+    }
+
+    @Override
+    protected String getType() {
+        return "resourceConfig";
+    }
+
+    @Override
+    public String getContext() {
+        return resourceConfigSeq.getName();
+    }
+}

--- a/management/src/main/java/org/smooks/management/mbean/ManagedVisitor.java
+++ b/management/src/main/java/org/smooks/management/mbean/ManagedVisitor.java
@@ -1,0 +1,200 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management.mbean;
+
+import jakarta.annotation.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.smooks.api.management.InstrumentationAgent;
+import org.smooks.api.management.InstrumentationResource;
+import org.smooks.api.resource.config.ResourceConfig;
+import org.smooks.api.resource.visitor.Visitor;
+import org.smooks.management.ModelMBeanAssembler;
+import org.smooks.management.annotation.ManagedAttribute;
+import org.smooks.management.annotation.ManagedNotification;
+import org.smooks.management.annotation.ManagedResource;
+import org.w3c.dom.Node;
+
+import javax.management.MBeanException;
+import javax.management.Notification;
+import javax.management.modelmbean.ModelMBeanInfo;
+import javax.management.modelmbean.RequiredModelMBean;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongUnaryOperator;
+
+@ManagedResource
+@ManagedNotification(name = "org.smooks.api.resource.visitor", notificationTypes = {"javax.management.Notification"})
+public class ManagedVisitor extends AbstractMBean {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ManagedVisitor.class);
+    private static final char PATH_SEPARATOR = '/';
+
+    private final AtomicLong seqNo = new AtomicLong();
+    private final AtomicLong visitBeforeCounter = new AtomicLong();
+    private final AtomicLong visitChildElementCounter = new AtomicLong();
+    private final AtomicLong visitChildTextCounter = new AtomicLong();
+    private final AtomicLong visitAfterCounter = new AtomicLong();
+    private final AtomicLong failedVisitCounter = new AtomicLong();
+    private final AtomicLong totalProcessingTime = new AtomicLong();
+
+    private final LongUnaryOperator incrementOrReset = operand -> operand == Long.MAX_VALUE ? 0 : operand + 1;
+    private final ResourceConfig visitorResourceConfig;
+    private final Visitor visitor;
+    private final RequiredModelMBean requiredModelMBean;
+
+    public ManagedVisitor(InstrumentationResource instrumentationResource, ResourceConfig visitorResourceConfig, Visitor visitor) {
+        super(instrumentationResource);
+        this.visitorResourceConfig = visitorResourceConfig;
+        this.visitor = visitor;
+
+        ModelMBeanAssembler modelMBeanAssembler = new ModelMBeanAssembler();
+        ModelMBeanInfo modelMBeanInfo = modelMBeanAssembler.getModelMbeanInfo(this.getClass());
+        InstrumentationAgent instrumentationAgent = instrumentationResource.getInstrumentationAgent();
+        this.requiredModelMBean = instrumentationAgent.register(this, this.getObjectName(), modelMBeanInfo, false);
+    }
+
+    @ManagedAttribute(description = "Selector")
+    public String getSelector() {
+        return visitorResourceConfig.getSelectorPath().getSelector();
+    }
+
+    @ManagedAttribute(description = "Number of visited start events")
+    public long getVisitBeforeCount() {
+        return visitBeforeCounter.get();
+    }
+
+    @ManagedAttribute(description = "Number of visited child events")
+    public long getVisitChildElementCount() {
+        return visitChildElementCounter.get();
+    }
+
+    @ManagedAttribute(description = "Number of visited text events")
+    public long getVisitChildTextCount() {
+        return visitChildTextCounter.get();
+    }
+
+    @ManagedAttribute(description = "Number of visited end events")
+    public long getVisitAfterCount() {
+        return visitAfterCounter.get();
+    }
+
+    @ManagedAttribute(description = "Total visit processing time (in milliseconds)")
+    public long getTotalProcessingTime() {
+        return totalProcessingTime.get();
+    }
+
+    @ManagedAttribute(description = "Number of failed visits")
+    public long getFailedVisitCount() {
+        return failedVisitCounter.get();
+    }
+
+    public void incrementVisitBeforeCounter() {
+        visitBeforeCounter.updateAndGet(incrementOrReset);
+    }
+
+    public void incrementVisitAfterCounter() {
+        visitAfterCounter.updateAndGet(incrementOrReset);
+    }
+
+    public void incrementVisitChildElementCounter() {
+        visitChildElementCounter.updateAndGet(incrementOrReset);
+    }
+
+    public void incrementVisitChildTextCounter() {
+        visitChildTextCounter.updateAndGet(incrementOrReset);
+    }
+
+    public void incrementFailedVisitCounter() {
+        failedVisitCounter.updateAndGet(incrementOrReset);
+    }
+
+    public void addTotalProcessingTime(long visitProcessingTime) {
+        totalProcessingTime.addAndGet(visitProcessingTime);
+    }
+
+    public void sendNotification(Node node, long visitProcessingTime) {
+        Notification notification = new Notification("org.smooks.api.resource.visitor", requiredModelMBean, seqNo.updateAndGet(incrementOrReset), new Date().getTime(), "visitBefore");
+        Map<String, Object> userData = new HashMap<>();
+        userData.put("path", toPath(node));
+        userData.put("processingTimeMs", visitProcessingTime);
+        notification.setUserData(userData);
+        try {
+            requiredModelMBean.sendNotification(notification);
+        } catch (MBeanException e) {
+            LOGGER.warn(e.getMessage(), e);
+        }
+    }
+
+    protected String toPath(Node node) {
+        StringBuilder path = new StringBuilder(node.getNodeName());
+        node = node.getParentNode();
+        while (node != null) {
+            path.insert(0, node.getNodeName() + PATH_SEPARATOR);
+            node = node.getParentNode();
+        }
+
+        return path.toString();
+    }
+
+    @Override
+    protected String getName() {
+        if (visitor.getClass().getAnnotation(Resource.class) != null) {
+            return visitor.getClass().getAnnotation(Resource.class).name() + "@" + Integer.toHexString(visitor.hashCode());
+        } else {
+            return visitor.toString();
+        }
+    }
+
+    @Override
+    protected String getType() {
+        return "visitor";
+    }
+
+    @Override
+    protected String getContext() {
+        return visitorResourceConfig.getSelectorPath().getSelector();
+    }
+
+}

--- a/management/src/main/resources/META-INF/services/org.smooks.api.management.InstrumentationAgentFactory
+++ b/management/src/main/resources/META-INF/services/org.smooks.api.management.InstrumentationAgentFactory
@@ -1,0 +1,1 @@
+org.smooks.management.DefaultInstrumentationAgentFactory

--- a/management/src/main/resources/META-INF/xsd/smooks/management-1.0.xsd
+++ b/management/src/main/resources/META-INF/xsd/smooks/management-1.0.xsd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:smooks="https://www.smooks.org/xsd/smooks-2.0.xsd"
+			xmlns:management="https://www.smooks.org/xsd/smooks/management-1.0.xsd"
+			targetNamespace="https://www.smooks.org/xsd/smooks/management-1.0.xsd"
+			elementFormDefault="qualified">
+
+    <xsd:import namespace="https://www.smooks.org/xsd/smooks-2.0.xsd"/>
+
+    <xsd:annotation>
+        <xsd:documentation xml:lang="en">Smooks Management Configuration</xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:element name="instrumentationResource" substitutionGroup="smooks:abstract-resource-config"
+                 type="management:instrumentationResource"/>
+    <xsd:complexType name="instrumentationResource">
+        <xsd:complexContent>
+            <xsd:extension base="smooks:abstract-resource-config">
+                <xsd:attribute name="usePlatformMBeanServer" type="xsd:boolean" default="true">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">
+                            Whether to use the MBeanServer from this JVM.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="mBeanServerDefaultDomain" type="xsd:string" default="org.smooks">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">
+                            The default JMX domain of the MBeanServer.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="mBeanObjectDomainName" type="xsd:string" default="org.smooks">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">
+                            The JMX domain that all object names will use.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="includeHostName" type="xsd:boolean" default="false">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">
+                            Whether to include the hostname in the MBean naming.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+</xsd:schema>

--- a/management/src/main/resources/META-INF/xsd/smooks/management-1.0.xsd-smooks.xml
+++ b/management/src/main/resources/META-INF/xsd/smooks/management-1.0.xsd-smooks.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<!--
+  ========================LICENSE_START=================================
+  Management
+  %%
+  Copyright (C) 2020 - 2024 Smooks
+  %%
+  Licensed under the terms of the Apache License Version 2.0, or
+  the GNU Lesser General Public License version 3.0 or later.
+  
+  SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+  
+  ======================================================================
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  
+  ======================================================================
+  
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+  =========================LICENSE_END==================================
+  -->
+
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+                      xmlns:management="https://www.smooks.org/xsd/smooks/management-1.0.xsd">
+
+    <resource-config selector="management:instrumentationResource">
+        <resource>org.smooks.engine.resource.extension.NewResourceConfig</resource>
+        <param name="resource">org.smooks.management.DefaultInstrumentationResource</param>
+    </resource-config>
+
+    <resource-config selector="management:instrumentationResource">
+        <resource>org.smooks.engine.resource.extension.MapToResourceConfigFromAttribute</resource>
+        <param name="attribute">usePlatformMBeanServer</param>
+        <param name="defaultValue">true</param>
+    </resource-config>
+
+    <resource-config selector="management:instrumentationResource">
+        <resource>org.smooks.engine.resource.extension.MapToResourceConfigFromAttribute</resource>
+        <param name="attribute">mBeanServerDefaultDomain</param>
+        <param name="defaultValue">org.smooks</param>
+    </resource-config>
+
+    <resource-config selector="management:instrumentationResource">
+        <resource>org.smooks.engine.resource.extension.MapToResourceConfigFromAttribute</resource>
+        <param name="attribute">mBeanObjectDomainName</param>
+        <param name="defaultValue">org.smooks</param>
+    </resource-config>
+
+    <resource-config selector="management:instrumentationResource">
+        <resource>org.smooks.engine.resource.extension.MapToResourceConfigFromAttribute</resource>
+        <param name="attribute">includeHostName</param>
+        <param name="defaultValue">false</param>
+    </resource-config>
+
+</smooks-resource-list>

--- a/management/src/test/java/org/smooks/management/BarVisitor.java
+++ b/management/src/test/java/org/smooks/management/BarVisitor.java
@@ -1,0 +1,74 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management;
+
+import jakarta.annotation.Resource;
+import org.smooks.api.ExecutionContext;
+import org.smooks.api.resource.visitor.sax.ng.AfterVisitor;
+import org.smooks.api.resource.visitor.sax.ng.ChildrenVisitor;
+import org.smooks.api.resource.visitor.sax.ng.ElementVisitor;
+import org.w3c.dom.CharacterData;
+import org.w3c.dom.Element;
+
+@Resource(name = "Bar")
+public class BarVisitor implements ElementVisitor {
+    @Override
+    public void visitChildText(CharacterData characterData, ExecutionContext executionContext) {
+
+    }
+
+    @Override
+    public void visitChildElement(Element childElement, ExecutionContext executionContext) {
+
+    }
+
+    @Override
+    public void visitAfter(Element element, ExecutionContext executionContext) {
+
+    }
+
+    @Override
+    public void visitBefore(Element element, ExecutionContext executionContext) {
+
+    }
+}

--- a/management/src/test/java/org/smooks/management/FooVisitor.java
+++ b/management/src/test/java/org/smooks/management/FooVisitor.java
@@ -1,0 +1,56 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management;
+
+import jakarta.annotation.Resource;
+import org.smooks.api.ExecutionContext;
+import org.smooks.api.resource.visitor.sax.ng.BeforeVisitor;
+import org.w3c.dom.Element;
+
+@Resource(name = "Foo")
+public class FooVisitor implements BeforeVisitor {
+    @Override
+    public void visitBefore(Element element, ExecutionContext executionContext) {
+
+    }
+}

--- a/management/src/test/java/org/smooks/management/ManagementFunctionalTestCase.java
+++ b/management/src/test/java/org/smooks/management/ManagementFunctionalTestCase.java
@@ -1,0 +1,123 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management;
+
+import org.junit.jupiter.api.Test;
+import org.smooks.Smooks;
+import org.smooks.api.Registry;
+import org.smooks.api.management.InstrumentationAgent;
+import org.smooks.api.management.InstrumentationResource;
+import org.smooks.api.resource.visitor.Visitor;
+import org.smooks.engine.lookup.InstanceLookup;
+import org.smooks.io.payload.StringSource;
+import org.xml.sax.SAXException;
+
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.IntrospectionException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanException;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ManagementFunctionalTestCase {
+    @Test
+    public void test() throws IOException, SAXException, MalformedObjectNameException, ReflectionException, AttributeNotFoundException, InstanceNotFoundException, IntrospectionException, MBeanException, InterruptedException {
+        Smooks smooks = new Smooks("smooks-config.xml");
+        smooks.filterSource(new StringSource("<a><b>bar</b></a>"));
+
+        Visitor fooVisitor = smooks.getApplicationContext().getRegistry().lookup("Foo");
+        Map<String, Object> fooVisitorAttributes = getAttributes(new ObjectName("org.smooks:context=\"/a\",type=visitor,name=Foo@" + Integer.toHexString(fooVisitor.hashCode())), smooks.getApplicationContext().getRegistry());
+        assertEquals(7, fooVisitorAttributes.size());
+        assertEquals("/a", fooVisitorAttributes.get("Selector"));
+        assertEquals(1L, fooVisitorAttributes.get("VisitBeforeCount"));
+        assertEquals(0L, fooVisitorAttributes.get("VisitAfterCount"));
+        assertEquals(0L, fooVisitorAttributes.get("VisitChildElementCount"));
+        assertEquals(0L, fooVisitorAttributes.get("FailedVisitCount"));
+        assertEquals(0L, fooVisitorAttributes.get("VisitChildTextCount"));
+
+        Visitor quuzVisitor = smooks.getApplicationContext().getRegistry().lookup("Quuz");
+        Map<String, Object> quuzVisitorAttributes = getAttributes(new ObjectName("org.smooks:context=\"/a/b\",type=visitor,name=Quuz@" + Integer.toHexString(quuzVisitor.hashCode())), smooks.getApplicationContext().getRegistry());
+        assertEquals(7, quuzVisitorAttributes.size());
+        assertEquals("/a/b", quuzVisitorAttributes.get("Selector"));
+        assertEquals(0L, quuzVisitorAttributes.get("VisitBeforeCount"));
+        assertEquals(1L, quuzVisitorAttributes.get("VisitAfterCount"));
+        assertEquals(0L, quuzVisitorAttributes.get("VisitChildElementCount"));
+        assertEquals(0L, quuzVisitorAttributes.get("FailedVisitCount"));
+        assertEquals(0L, quuzVisitorAttributes.get("VisitChildTextCount"));
+
+        Visitor barVisitor = smooks.getApplicationContext().getRegistry().lookup("Bar");
+        Map<String, Object> barVisitorAttributes = getAttributes(new ObjectName("org.smooks:context=\"/a/b\",type=visitor,name=Bar@" + Integer.toHexString(barVisitor.hashCode())), smooks.getApplicationContext().getRegistry());
+        assertEquals(7, barVisitorAttributes.size());
+        assertEquals("/a/b", barVisitorAttributes.get("Selector"));
+        assertEquals(1L, barVisitorAttributes.get("VisitBeforeCount"));
+        assertEquals(1L, barVisitorAttributes.get("VisitAfterCount"));
+        assertEquals(0L, barVisitorAttributes.get("VisitChildElementCount"));
+        assertEquals(0L, barVisitorAttributes.get("FailedVisitCount"));
+        assertEquals(1L, barVisitorAttributes.get("VisitChildTextCount"));
+    }
+
+    protected Map<String, Object> getAttributes(ObjectName objectName, Registry registry) throws ReflectionException, InstanceNotFoundException, IntrospectionException, AttributeNotFoundException, MBeanException {
+        InstrumentationAgent instrumentationAgent = registry.lookup(InstrumentationResource.INSTRUMENTATION_RESOURCE_TYPED_KEY).getInstrumentationAgent();
+        MBeanServer mBeanServer = instrumentationAgent.getMBeanServer();
+        MBeanInfo mBeanInfo = mBeanServer.getMBeanInfo(objectName);
+
+        MBeanAttributeInfo[] mBeanAttributeInfos = mBeanInfo.getAttributes();
+        Map<String, Object> attributes = new HashMap<>();
+        for (MBeanAttributeInfo mBeanAttributeInfo : mBeanAttributeInfos) {
+            if (mBeanAttributeInfo.isReadable()) {
+                attributes.put(mBeanAttributeInfo.getName(), mBeanServer.getAttribute(objectName, mBeanAttributeInfo.getName()));
+            }
+        }
+
+        return attributes;
+    }
+}

--- a/management/src/test/java/org/smooks/management/QuuzVisitor.java
+++ b/management/src/test/java/org/smooks/management/QuuzVisitor.java
@@ -1,0 +1,57 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Management
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.management;
+
+import jakarta.annotation.Resource;
+import org.smooks.api.ExecutionContext;
+import org.smooks.api.resource.visitor.sax.ng.AfterVisitor;
+import org.w3c.dom.Element;
+
+@Resource(name = "Quuz")
+public class QuuzVisitor implements AfterVisitor {
+
+    @Override
+    public void visitAfter(Element element, ExecutionContext executionContext) {
+
+    }
+}

--- a/management/src/test/resources/smooks-config.xml
+++ b/management/src/test/resources/smooks-config.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!--
+  ========================LICENSE_START=================================
+  Management
+  %%
+  Copyright (C) 2020 - 2024 Smooks
+  %%
+  Licensed under the terms of the Apache License Version 2.0, or
+  the GNU Lesser General Public License version 3.0 or later.
+  
+  SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+  
+  ======================================================================
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  
+  ======================================================================
+  
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+  =========================LICENSE_END==================================
+  -->
+
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+                      xmlns:core="https://www.smooks.org/xsd/smooks/smooks-core-1.6.xsd"
+                      xmlns:management="https://www.smooks.org/xsd/smooks/management-1.0.xsd">
+
+    <params>
+        <param name="reader.pool.size">25</param>
+    </params>
+
+    <core:interceptors>
+        <core:interceptor class="org.smooks.management.InstrumentationInterceptor"/>
+    </core:interceptors>
+
+    <management:instrumentationResource/>
+
+    <resource-config selector="/a">
+        <resource>org.smooks.management.FooVisitor</resource>
+    </resource-config>
+
+    <resource-config selector="/a">
+        <resource>org.smooks.management.FooVisitor</resource>
+    </resource-config>
+
+    <resource-config selector="/a/b">
+        <resource>org.smooks.management.QuuzVisitor</resource>
+    </resource-config>
+
+    <resource-config selector="/a/b">
+        <resource>org.smooks.management.BarVisitor</resource>
+    </resource-config>
+
+</smooks-resource-list>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,7 @@
     <url>https://www.smooks.org</url>
 
     <description>
-        Smooks is an extensible data integration Java framework for building XML and non-XML fragment-based
-        applications.
+        Smooks is an extensible data integration Java framework for building XML and non-XML fragment-based applications.
     </description>
 
     <licenses>
@@ -79,6 +78,7 @@
         <module>api</module>
         <module>commons</module>
         <module>core</module>
+        <module>management</module>
         <module>tck</module>
         <module>benchmark</module>
     </modules>


### PR DESCRIPTION
create org.smooks.api.delivery.ReaderPoolFactory SPI to support custom reader pool factories

add method to org.smooks.api.Registry to lookup by typed key so that the compiler can infer the typed key generic parameter

annotate org.smooks.api.delivery.ContentDeliveryRuntimeFactory and org.smooks.api.delivery.ReaderPool as thread-safe

BREAKING CHANGE:

* rename org.smooks.api.resource.config.ResourceConfig#getTargetProfile to getProfile
* rename org.smooks.api.resource.config.ResourceConfig#setTargetProfile to setProfile
* rename org.smooks.api.lifecycle.FilterLifecycle#onStarted method to onPreFilter
* rename org.smooks.api.lifecycle.FilterLifecycle#onFinished method to onPostFilter
* inherit org.smooks.api.resource.config.ParameterDecoderException from org.smooks.api.SmooksException instead from java.lang.RuntimeException

Refs: https://groups.google.com/g/smooks-dev/c/ZK2QoTwOco8