### PR TITLE
fix: add position counter visitor when creating content delivery conf…

### DIFF
--- a/api/src/main/java/org/smooks/api/delivery/ordering/Producer.java
+++ b/api/src/main/java/org/smooks/api/delivery/ordering/Producer.java
@@ -69,7 +69,7 @@ public interface Producer extends Visitor {
     /**
      * Get the set of products produced by this producer instance.
      *
-     * @return The set the set of products produced by this producer instance.
+     * @return The set of products produced by this producer instance.
      */
     Set<?> getProducts();
 }

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgVisitorBindings.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgVisitorBindings.java
@@ -57,7 +57,7 @@ class SaxNgVisitorBindings {
     private List<ContentHandlerBinding<BeforeVisitor>> beforeVisitors;
     private List<ContentHandlerBinding<ChildrenVisitor>> childVisitors;
     private List<ContentHandlerBinding<AfterVisitor>> afterVisitors;
-    public List<ContentHandlerBinding<? extends Visitor>> visitors;
+    public volatile List<ContentHandlerBinding<? extends Visitor>> visitors;
 
     public List<ContentHandlerBinding<BeforeVisitor>> getBeforeVisitors() {
         return beforeVisitors;

--- a/core/src/main/java/org/smooks/engine/resource/config/xpath/AbstractSelectorPath.java
+++ b/core/src/main/java/org/smooks/engine/resource/config/xpath/AbstractSelectorPath.java
@@ -58,9 +58,10 @@ import java.util.ListIterator;
 import java.util.Properties;
 
 public abstract class AbstractSelectorPath implements SelectorPath {
-    protected ExpressionEvaluator expressionEvaluator;
+
     protected final Properties namespaces = new Properties();
     protected final List<SelectorStep> selectorSteps = new ArrayList<>();
+    protected ExpressionEvaluator expressionEvaluator;
     protected String selector;
 
     @Override
@@ -216,7 +217,7 @@ public abstract class AbstractSelectorPath implements SelectorPath {
     @Override
     public void setConditionEvaluator(ExpressionEvaluator expressionEvaluator) {
         if (expressionEvaluator != null && !(expressionEvaluator instanceof ExecutionContextExpressionEvaluator)) {
-            throw new UnsupportedOperationException("Unsupported ExpressionEvaluator type '" + expressionEvaluator.getClass().getName() + "'.  Currently only support '" + ExecutionContextExpressionEvaluator.class.getName() + "' implementations.");
+            throw new SmooksException("Unsupported ExpressionEvaluator type '" + expressionEvaluator.getClass().getName() + "'.  Currently only support '" + ExecutionContextExpressionEvaluator.class.getName() + "' implementations.");
         }
         this.expressionEvaluator = expressionEvaluator;
     }

--- a/core/src/main/java/org/smooks/engine/resource/config/xpath/ElementPositionCounter.java
+++ b/core/src/main/java/org/smooks/engine/resource/config/xpath/ElementPositionCounter.java
@@ -42,6 +42,7 @@
  */
 package org.smooks.engine.resource.config.xpath;
 
+import jakarta.annotation.Priority;
 import org.smooks.api.ExecutionContext;
 import org.smooks.api.SmooksException;
 import org.smooks.api.TypedKey;
@@ -59,18 +60,10 @@ import org.w3c.dom.Node;
  *
  * @author <a href="mailto:tom.fennelly@jboss.com">tom.fennelly@jboss.com</a>
  */
+@Priority(Integer.MAX_VALUE)
 public class ElementPositionCounter implements BeforeVisitor {
 
-    private final SelectorStep selectorStep;
     private final TypedKey<String> positionMementoTypedKey = TypedKey.of();
-
-    public ElementPositionCounter(SelectorStep selectorStep) {
-        this.selectorStep = selectorStep;
-    }
-
-    public SelectorStep getSelectorStep() {
-        return selectorStep;
-    }
 
     @Override
     public void visitBefore(Element element, ExecutionContext executionContext) throws SmooksException {

--- a/core/src/main/java/org/smooks/engine/resource/config/xpath/SelectorPathFactory.java
+++ b/core/src/main/java/org/smooks/engine/resource/config/xpath/SelectorPathFactory.java
@@ -114,7 +114,7 @@ public final class SelectorPathFactory {
         }
 
         SelectorPathJaxenHandler xpathHandler = new SelectorPathJaxenHandler(xpathExpression, namespaces);
-        if (xpathExpression.trim().length() > 0) {
+        if (!xpathExpression.trim().isEmpty()) {
             reader.setXPathHandler(xpathHandler);
             try {
                 reader.parse(xpathExpression);

--- a/core/src/main/java/org/smooks/engine/resource/config/xpath/step/AbstractSelectorStep.java
+++ b/core/src/main/java/org/smooks/engine/resource/config/xpath/step/AbstractSelectorStep.java
@@ -61,7 +61,6 @@ public abstract class AbstractSelectorStep implements SelectorStep {
         return namespaces;
     }
 
-
     @Override
     public boolean evaluate(final Fragment<?> fragment, final ExecutionContext executionContext) {
         for (Predicate predicate : predicates) {

--- a/core/src/main/java/org/smooks/engine/resource/config/xpath/step/DocumentSelectorStep.java
+++ b/core/src/main/java/org/smooks/engine/resource/config/xpath/step/DocumentSelectorStep.java
@@ -50,9 +50,4 @@ public class DocumentSelectorStep extends ElementSelectorStep {
     public DocumentSelectorStep() {
         super(XMLConstants.NULL_NS_URI, "#document", XMLConstants.DEFAULT_NS_PREFIX);
     }
-
-    @Override
-    public QName getQName() {
-        return qName;
-    }
 }

--- a/core/src/test/java/org/smooks/engine/resource/config/xpath/SelectorSaxNgFilterFunctionalTestCase.java
+++ b/core/src/test/java/org/smooks/engine/resource/config/xpath/SelectorSaxNgFilterFunctionalTestCase.java
@@ -234,6 +234,18 @@ public class SelectorSaxNgFilterFunctionalTestCase {
     }
 
     @Test
+    @DisplayName("items/item[2]")
+    public void testAddVisitorSelectorsGivenIndexInLastStep() {
+        Smooks smooks = new Smooks();
+        smooks.setFilterSettings(FilterSettings.DEFAULT_SAX_NG);
+        smooks.addVisitor(new XPathVisitor(), "items/item[2]");
+        smooks.filterSource(new StreamSource(getClass().getResourceAsStream("order.xml")));
+
+        assertNotNull(XPathVisitor.domVisitedBeforeElementStatic);
+        assertNotNull(XPathVisitor.domVisitedAfterElementStatic);
+    }
+
+    @Test
     @DisplayName("items/item[3]/units")
     public void testSelectorGivenWrongIndex() throws Exception {
         Smooks smooks = new Smooks(getClass().getResourceAsStream("config-08.xml"));


### PR DESCRIPTION
…ig instead of adding it during optimisation phase in order to eliminate situations where one can obtain a ConcurrentModificationException

solve possible race condition in SaxNgVisitorBindings#getAll

throw SmooksException instead of UnsupportedOperationException when condition evaluator cannot be found

feat: use @Priority to decide which visitors are fired first

Refs: https://github.com/smooks/smooks/issues/769