### PR TITLE
feat: add NotAppContextScoped annotation to indicate that the class a…

### DIFF
--- a/api/src/main/java/org/smooks/api/NotAppContextScoped.java
+++ b/api/src/main/java/org/smooks/api/NotAppContextScoped.java
@@ -1,0 +1,64 @@
+/*-
+ * ========================LICENSE_START=================================
+ * API
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.api;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Indicates that the class annotated with this annotation can have its instances safely referenced from different application
+ * contexts. A class should have this annotation when you want to allow the pipeline to inherit instances of the class
+ * from the registry of the parent application context.
+ */
+@Target({TYPE})
+@Retention(RUNTIME)
+@Inherited
+@Documented
+public @interface NotAppContextScoped {
+}

--- a/core/src/test/java/org/smooks/engine/resource/visitor/smooks/MyClass.java
+++ b/core/src/test/java/org/smooks/engine/resource/visitor/smooks/MyClass.java
@@ -1,0 +1,49 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Core
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.engine.resource.visitor.smooks;
+
+import org.smooks.api.NotAppContextScoped;
+
+@NotAppContextScoped
+public class MyClass {
+}

--- a/core/src/test/java/org/smooks/engine/resource/visitor/smooks/NestedSmooksVisitorFunctionalTestCase.java
+++ b/core/src/test/java/org/smooks/engine/resource/visitor/smooks/NestedSmooksVisitorFunctionalTestCase.java
@@ -61,8 +61,7 @@ public class NestedSmooksVisitorFunctionalTestCase {
 	@Test
 	public void test() throws IOException, SAXException {
 		Smooks smooks = new Smooks(getClass().getResourceAsStream("nested-smooks-visitor-config.xml"));
-		StringSink stringSink = new StringSink();
-		smooks.filterSource(new StringSource("<a><b><c></c></b></a>"), stringSink);
+		smooks.filterSource(new StringSource("<a><b><c></c></b></a>"));
 		NestedSmooksVisitor smooksVisitor = smooks.getApplicationContext().getRegistry().lookup(new InstanceLookup<>(NestedSmooksVisitor.class)).values().stream().findFirst().get();
 		Registry registry = smooksVisitor.getNestedSmooks().getApplicationContext().getRegistry();
 		assertEquals(0, registry.lookup(new InstanceLookup<>(BarBeforeVisitor.class)).values().stream().findFirst().get().getCountDownLatch().getCount());

--- a/core/src/test/java/org/smooks/engine/resource/visitor/smooks/NestedSmooksVisitorTestCase.java
+++ b/core/src/test/java/org/smooks/engine/resource/visitor/smooks/NestedSmooksVisitorTestCase.java
@@ -95,7 +95,7 @@ public class NestedSmooksVisitorTestCase {
     }
 
     @Test
-    public void testPostConstructInheritsRegistry() throws IOException, URISyntaxException, ClassNotFoundException, SAXException {
+    public void testPostConstructCopiesNonAppContextScopedEntriesFromParentAppContextRegistry() throws IOException, URISyntaxException, ClassNotFoundException, SAXException {
         NestedSmooksVisitor nestedSmooksVisitor = new NestedSmooksVisitor();
         Smooks nestedSmooks = new Smooks(new DefaultApplicationContextBuilder().withSystemResources(false).build());
 
@@ -105,11 +105,11 @@ public class NestedSmooksVisitorTestCase {
         nestedSmooksVisitor.setNestedSmooks(nestedSmooks);
 
         ApplicationContext applicationContext = new DefaultApplicationContextBuilder().build();
-        applicationContext.getRegistry().registerObject("Bar", "Foo");
+        applicationContext.getRegistry().registerObject("MyClass", new MyClass());
         nestedSmooksVisitor.setApplicationContext(applicationContext);
 
         nestedSmooksVisitor.postConstruct();
-        assertEquals("Foo", nestedSmooksVisitor.getNestedSmooks().getApplicationContext().getRegistry().lookup("Bar"));
+        assertEquals("org.smooks.engine.resource.visitor.smooks.MyClass", nestedSmooksVisitor.getNestedSmooks().getApplicationContext().getRegistry().lookup("MyClass").getClass().getName());
     }
 
     @Test


### PR DESCRIPTION
…nnotated with this annotation can have its instances safely referenced from different application contexts. A class should have this annotation when you want to allow the pipeline to inherit instances of the class from the registry of the parent application context.