### PR TITLE
Added Fix for flaky test-case DefaultContentDeliveryConfigBuilderTestCase#testUnsupportedVisitor 

### DIFF
--- a/core/src/main/java/org/smooks/engine/delivery/DefaultContentDeliveryConfigBuilder.java
+++ b/core/src/main/java/org/smooks/engine/delivery/DefaultContentDeliveryConfigBuilder.java
@@ -78,7 +78,6 @@ import org.smooks.engine.resource.config.DefaultResourceConfigSortComparator;
 import org.smooks.engine.resource.config.ParameterAccessor;
 import org.smooks.engine.resource.config.xpath.step.ElementSelectorStep;
 
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -239,14 +238,21 @@ public class DefaultContentDeliveryConfigBuilder implements ContentDeliveryConfi
         }
 
         stringBuf.append("\t\t ");
-        Map<String, Boolean> supportedFilterProviders = filterProviders.stream().map(s -> new AbstractMap.SimpleEntry<>(s.getName(), s.isProvider(Collections.singletonList(contentHandlerBinding)))).
-                collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+        Map<String, Boolean> supportedFilterProviders = getOrderedSupportedFilterProviders(contentHandlerBinding);
         for (Entry<String, Boolean> supportedFilterProvider : supportedFilterProviders.entrySet()) {
             stringBuf.append(supportedFilterProvider.getValue() ? supportedFilterProvider.getKey() : " ").append("     ");
         }
 
         stringBuf.append(contentHandlerBinding.getResourceConfig())
                 .append("\n");
+    }
+
+    private Map<String, Boolean> getOrderedSupportedFilterProviders(ContentHandlerBinding<Visitor> contentHandlerBinding) {
+        Map<String, Boolean> supportedFilterProviders = new LinkedHashMap<>();
+        filterProviders.forEach(
+                s -> supportedFilterProviders.put(s.getName(), s.isProvider(Collections.singletonList(contentHandlerBinding)))
+        );
+        return supportedFilterProviders;
     }
 
     /**


### PR DESCRIPTION
Fixed flaky test case in the following class: `org.smooks.engine.delivery.DefaultContentDeliveryConfigBuilderTestCase#testUnsupportedVisitor`

Assertion called in: `DefaultContentDeliveryConfigBuilderTestCase#testUnsupportedVisitor`

### POINT OF FAILURE
In class `DefaultContentDeliveryConfigBuilder`, the method `printHandlerCharacteristics()` writes the keys: `SAX NG` or `DOM` from the **HashMap** `supportedFiltersProvider`, which is built by streaming the List `filterProviders` (By default, `Collectors.toMap()` returns an instance of HashMap). As **entries in HashMap is unorder**, iterating over it gives non-deterministic results, which can result in the following output on a different jvm: (*pretty representation*)
```tsv
ambiguous resource config set. all content handlers must support processing on the sax and/or dom filter:
dom   sax    resource  ('x' equals supported)
---------------------------------------------------------------------
sax ng     dom     target profile: [[*]], selector: [smooks:context-object], resource: [org.smooks.engine.delivery.dom.serialize.contextobjectserializervisitor], num params: [0]
dom     sax ng     target profile: [[*]], selector: [smooks:ghost-element], resource: [org.smooks.engine.delivery.dom.serialize.ghostelementserializervisitor], num params: [0]
dom     sax ng     target profile: [[*]], selector: [smooks:text], resource: [org.smooks.engine.delivery.dom.serialize.textserializervisitor], num params: [1]
sax ng     dom     target profile: [[*]], selector: [*], resource: [org.smooks.engine.delivery.sax.ng.systemconsumeserializervisitor], num params: [0]
dom           target profile: [[org.smooks.api.profile.profile#default_profile]], selector: [a], resource: [org.smooks.engine.delivery.dom.processorvisitor1], num params: [0]
sax ng     target profile: [[org.smooks.api.profile.profile#default_profile]], selector: [b], resource: [org.smooks.engine.delivery.sax.ng.visitor01], num params: [0]
target profile: [[org.smooks.api.profile.profile#default_profile]], selector: [c], resource: [org.smooks.engine.delivery.defaultcontentdeliveryconfigbuildertestcase$unsupportedvisitor], num params: [0]

```
The above is different than the expected: (*pretty representation*)
```tsv
ambiguous resource config set. all content handlers must support processing on the sax and/or dom filter:
dom   sax    resource  ('x' equals supported)
---------------------------------------------------------------------
sax ng     dom     target profile: [[*]], selector: [smooks:context-object], resource: [org.smooks.engine.delivery.dom.serialize.contextobjectserializervisitor], num params: [0]
sax ng     dom     target profile: [[*]], selector: [smooks:ghost-element], resource: [org.smooks.engine.delivery.dom.serialize.ghostelementserializervisitor], num params: [0]
sax ng     dom     target profile: [[*]], selector: [smooks:text], resource: [org.smooks.engine.delivery.dom.serialize.textserializervisitor], num params: [1]
sax ng     dom     target profile: [[*]], selector: [*], resource: [org.smooks.engine.delivery.sax.ng.systemconsumeserializervisitor], num params: [0]
dom     target profile: [[org.smooks.api.profile.profile#default_profile]], selector: [a], resource: [org.smooks.engine.delivery.dom.processorvisitor1], num params: [0]
sax ng           target profile: [[org.smooks.api.profile.profile#default_profile]], selector: [b], resource: [org.smooks.engine.delivery.sax.ng.visitor01], num params: [0]
target profile: [[org.smooks.api.profile.profile#default_profile]], selector: [c], resource: [org.smooks.engine.delivery.defaultcontentdeliveryconfigbuildertestcase$unsupportedvisitor], num params: [0]

```
*Note how positions of **SAX NG** and **DOM** interchange*

### FIX
`filterProviders` is a List, whose order is preserved in `LinkedHashMap`, thus ensuring correct output.

### Fixed using NonDex
Suggested command to check all flaky tests :
> mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex

For the particular test class:
```sh
mvn -pl ./core edu.illinois:nondex-maven-plugin:2.1.7:nondex \
-Dtest=org.smooks.engine.delivery.DefaultContentDeliveryConfigBuilderTestCase#testUnsupportedVisitor \
-DnondexMode=ONE -DnondexRuns=5
```
For more information: https://github.com/TestingResearchIllinois/NonDex