### PR TITLE
Added rectified approach for assertions in flaky tests from JavaSourceTestCase 

### DIFF
--- a/core/src/test/java/org/smooks/engine/delivery/java/JavaSourceTestCase.java
+++ b/core/src/test/java/org/smooks/engine/delivery/java/JavaSourceTestCase.java
@@ -51,6 +51,7 @@ import org.smooks.io.source.JavaSource;
 import org.smooks.io.sink.StringSink;
 import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.stream.StreamResult;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -62,6 +63,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
@@ -70,17 +72,17 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 public class JavaSourceTestCase {
 
 	@Test
-    public void test_dom() throws IOException, SAXException {
+    public void test_dom() throws IOException, SAXException, ParserConfigurationException {
         test("smooks-config-dom.xml", SOURCE_1, EXPECTED_1);
     }
 
 	@Test
-    public void test_sax() throws IOException, SAXException {
+    public void test_sax() throws IOException, SAXException, ParserConfigurationException {
         test("smooks-config-sax.xml", SOURCE_1, EXPECTED_1);
     }
 
 	@Test
-    public void test_includeEnclosingDocument() throws IOException, SAXException {
+    public void test_includeEnclosingDocument() throws IOException, SAXException, ParserConfigurationException {
         // Not sure what that "includeEnclosingDocument" flag on the XStream SaxWriter is supposed to do.
         // Seems to do the same thing whether it's on or off???...
         test("smooks-config-inc-encl-doc-on.xml", SOURCE_1, EXPECTED_1);
@@ -153,14 +155,14 @@ public class JavaSourceTestCase {
         }
     }
 
-    private void test(String config, List<Object> sourceObjects, String expected) throws IOException, SAXException {
+    private void test(String config, List<Object> sourceObjects, String expected) throws IOException, SAXException, ParserConfigurationException {
         Smooks smooks = new Smooks(getClass().getResourceAsStream(config));
         ExecutionContext execContext = smooks.createExecutionContext();
         JavaSource source = new JavaSource(sourceObjects);
         StringWriter stringWriter = new StringWriter();
 
         smooks.filterSource(execContext, source, new WriterSink(stringWriter));
-        assertEquals(expected, stringWriter.toString());
+        assertTrue(XmlCompareUtil.compare(expected, stringWriter.toString()));
     }
 
     private static final List<Object> SOURCE_1;

--- a/core/src/test/java/org/smooks/engine/delivery/java/XmlCompareUtil.java
+++ b/core/src/test/java/org/smooks/engine/delivery/java/XmlCompareUtil.java
@@ -1,0 +1,112 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Smooks Core
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ *
+ * ======================================================================
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ======================================================================
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.engine.delivery.java;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class XmlCompareUtil {
+
+    public static boolean compare(String xmlString1, String xmlString2) throws ParserConfigurationException, IOException, SAXException {
+        Document xml1 = parseXML(xmlString1);
+        Document xml2 = parseXML(xmlString2);
+        return compareChildren(xml1.getDocumentElement(), xml2.getDocumentElement());
+    }
+
+    private static Document parseXML(String xml) throws ParserConfigurationException, IOException, SAXException {
+        String transformedXML = "<root>" + xml + "</root>";
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        return builder.parse(new ByteArrayInputStream(transformedXML.getBytes()));
+    }
+
+
+    private static boolean compareChildren(Element element1, Element element2) { //
+        List<Node> children1 = getOrderedChildren(element1.getChildNodes());
+        List<Node> children2 = getOrderedChildren(element2.getChildNodes());
+        if (children1.size() != children2.size()) {
+            return false;
+        }
+        if (children1.isEmpty()) {
+            return true;
+        }
+
+        for (int iterator = 0; iterator < children1.size(); iterator++) {
+            Node child1 = children1.get(iterator);
+            Node child2 = children2.get(iterator);
+            if (!child1.getNodeName().equals(child2.getNodeName())) {
+                return false;
+            }
+            if (child1.hasChildNodes()) {
+                if (!compareChildren((Element) child1, (Element) child2)) {
+                    return false;
+                }
+            } else if (!child1.getNodeValue().equals(child2.getNodeValue())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static List<Node> getOrderedChildren(NodeList children) {
+        List<Node> result = new ArrayList<>(children.getLength());
+        for (int iterator = 0; iterator < children.getLength(); iterator++) {
+            result.add(children.item(iterator));
+        }
+        result.sort(Comparator.comparing(Node::getNodeName));
+        return result;
+    }
+}


### PR DESCRIPTION
Fixed flaky tests case in the following class: `org.smooks.engine.delivery.java.JavaSourceTestCase` mentioned in https://github.com/smooks/smooks/issues/892

Assertion called in:
|Test methods|
|-|
| test_sax |
| test_includeEnclosingDocument|
| test_dom|

### POINT OF FAILURE
In class `org.smooks.engine.resource.reader.XStreamXMLReader`, an input bean is converted to its XML form using the `XStream` library, which is an external dependency. Internally, XStream uses `PureJavaReflection`. It basically accesses the `Class` of the source bean being converted, accesses it's **`Fields`** using `getDeclaredFields()` method. According to [this](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--), getDeclaredFields() cannot guarantee a fixed order of elements. https://github.com/smooks/smooks/issues/892 shows the similar but different XMLs generated but XStream.

### FIX
In all the failing test cases, assertion fails due to the differently ordered XML's string representations. The utility `XmlCompareUtil` converts the output strings to their DOM representation and **compares the DOM representation for equality**.

### Fixed using NonDex
Suggested command to check all flaky tests :
> mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex

For the particular test class:
```sh
mvn -pl ./core edu.illinois:nondex-maven-plugin:2.1.7:nondex \
-Dtest=org.smooks.engine.delivery.java.JavaSourceTestCase \
-DnondexMode=ONE -DnondexRuns=5
```
For more information: https://github.com/TestingResearchIllinois/NonDex