### PR TITLE
fix: solve issue where the NestedSmooksVisitor child execution event …

### DIFF
--- a/core/src/main/java/org/smooks/engine/delivery/interceptor/EventPointerStaticProxyInterceptor.java
+++ b/core/src/main/java/org/smooks/engine/delivery/interceptor/EventPointerStaticProxyInterceptor.java
@@ -40,13 +40,13 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * =========================LICENSE_END==================================
  */
-package org.smooks.engine.delivery.sax.ng.pointer;
+package org.smooks.engine.delivery.interceptor;
 
 import org.smooks.api.ExecutionContext;
 import org.smooks.api.delivery.fragment.Fragment;
 import org.smooks.engine.delivery.event.VisitSequence;
 import org.smooks.engine.delivery.fragment.NodeFragment;
-import org.smooks.engine.delivery.interceptor.StaticProxyInterceptor;
+import org.smooks.engine.delivery.sax.ng.pointer.EventPointer;
 import org.w3c.dom.CharacterData;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;

--- a/core/src/main/java/org/smooks/engine/delivery/interceptor/ExceptionInterceptor.java
+++ b/core/src/main/java/org/smooks/engine/delivery/interceptor/ExceptionInterceptor.java
@@ -97,22 +97,22 @@ public class ExceptionInterceptor extends AbstractInterceptorVisitor implements 
     }
 
     @Override
-    public void visitBefore(Element element, ExecutionContext executionContext) {
+    public void visitBefore(final Element element, final ExecutionContext executionContext) {
         intercept(visitBeforeInvocation, executionContext, visitBeforeExceptionMessage, new NodeFragment(element), VisitSequence.BEFORE, element, executionContext);
     }
 
     @Override
-    public void visitAfter(Element element, ExecutionContext executionContext) {
+    public void visitAfter(final Element element, final ExecutionContext executionContext) {
         intercept(visitAfterInvocation, executionContext, visitAfterExceptionMessage, new NodeFragment(element), VisitSequence.AFTER, element, executionContext);
     }
 
     @Override
-    public void visitChildText(CharacterData characterData, ExecutionContext executionContext) {
+    public void visitChildText(final CharacterData characterData, final ExecutionContext executionContext) {
         intercept(visitChildTextInvocation, executionContext, visitChildTextExceptionMessage, new NodeFragment(characterData), VisitSequence.AFTER, characterData, executionContext);
     }
 
     @Override
-    public void visitChildElement(Element childElement, ExecutionContext executionContext) {
+    public void visitChildElement(final Element childElement, final ExecutionContext executionContext) {
         try {
             intercept(visitChildElementInvocation, childElement, executionContext);
         } catch (Throwable t) {
@@ -137,7 +137,9 @@ public class ExceptionInterceptor extends AbstractInterceptorVisitor implements 
             throw (TerminateException) t;
         }
 
-        executionContext.setTerminationError(t);
+        if (executionContext.getTerminationError() == null) {
+            executionContext.setTerminationError(t);
+        }
         String completeExceptionMessage = String.format(exceptionMessage, toPath((Node) fragment.unwrap()));
         if (terminateOnVisitorException) {
             if (t instanceof SmooksException) {
@@ -161,7 +163,7 @@ public class ExceptionInterceptor extends AbstractInterceptorVisitor implements 
         return path.toString();
     }
 
-    protected String stackTraceToString(Throwable e) {
+    protected String stackTraceToString(final Throwable e) {
         final StringWriter writer = new StringWriter();
         final PrintWriter printWriter = new PrintWriter(writer, true);
         e.printStackTrace(printWriter);

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgContentHandler.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/SaxNgContentHandler.java
@@ -191,7 +191,7 @@ public class SaxNgContentHandler extends SmooksContentHandler {
     @Override
     public void endElement(final EndElementEvent endEvent) throws SAXException {
         if (!contentDeliveryRuntime.getExecutionEventListeners().isEmpty()) {
-            final EndFragmentExecutionEvent endFragmentEvent = new EndFragmentExecutionEvent(currentNodeFragment);
+            final EndFragmentExecutionEvent<Node> endFragmentEvent = new EndFragmentExecutionEvent<>(currentNodeFragment);
             for (ExecutionEventListener executionEventListener : contentDeliveryRuntime.getExecutionEventListeners()) {
                 executionEventListener.onEvent(endFragmentEvent);
             }

--- a/core/src/main/java/org/smooks/engine/delivery/sax/ng/pointer/EventPointer.java
+++ b/core/src/main/java/org/smooks/engine/delivery/sax/ng/pointer/EventPointer.java
@@ -46,6 +46,7 @@ import org.smooks.api.SmooksException;
 import org.smooks.api.ExecutionContext;
 import org.smooks.api.TypedKey;
 import org.smooks.engine.delivery.event.VisitSequence;
+import org.smooks.engine.delivery.interceptor.EventPointerStaticProxyInterceptor;
 import org.smooks.engine.xml.Namespace;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;

--- a/core/src/main/resources/pipeline-interceptors.xml
+++ b/core/src/main/resources/pipeline-interceptors.xml
@@ -48,7 +48,7 @@
 
     <core:interceptors>
         <core:interceptor class="org.smooks.engine.delivery.interceptor.ExceptionInterceptor" selector="*"/>
-        <core:interceptor class="org.smooks.engine.delivery.sax.ng.pointer.EventPointerStaticProxyInterceptor" selector="*"/>
+        <core:interceptor class="org.smooks.engine.delivery.interceptor.EventPointerStaticProxyInterceptor" selector="*"/>
     </core:interceptors>
 
 </smooks-resource-list>


### PR DESCRIPTION
…listener clean up doesn't happen following an exception which could lead to another exception when the terminateOnException filter setting is false

refactor: relocate EventPointerStaticProxyInterceptor class to `org.smooks.engine.delivery.interceptor` package