### PR TITLE
refactor: deprecate BeanId.setCreateResourceConfiguration and BeanId.…

### DIFF
--- a/api/src/main/java/org/smooks/api/bean/repository/BeanId.java
+++ b/api/src/main/java/org/smooks/api/bean/repository/BeanId.java
@@ -61,9 +61,18 @@ import org.smooks.api.bean.context.BeanIdStore;
  */
 public interface BeanId {
 
+    /**
+     * @deprecated  Resource config can be retrieved from the application context
+     *              registry so there is no need keep this method around
+     */
+    @Deprecated
+    BeanId setCreateResourceConfiguration(ResourceConfig resourceConfig);
 
-    BeanId setCreateResourceConfiguration(ResourceConfig createResourceConfig);
-
+    /**
+     * @deprecated  Resource config can be retrieved from the application context
+     *              registry so there is no need keep this method around
+     */
+    @Deprecated
     ResourceConfig getCreateResourceConfiguration();
 
     int getIndex();

--- a/core/src/main/java/org/smooks/engine/bean/repository/DefaultBeanId.java
+++ b/core/src/main/java/org/smooks/engine/bean/repository/DefaultBeanId.java
@@ -53,7 +53,7 @@ public class DefaultBeanId implements BeanId {
 
     private final BeanIdStore beanIdStore;
 
-    private ResourceConfig createResourceConfig;
+    private ResourceConfig resourceConfig;
 
     /**
      * @param index
@@ -70,12 +70,12 @@ public class DefaultBeanId implements BeanId {
      * {@link BeanInstanceCreator} that is creating the bean with which this
      * {@link BeanId} instance is associated.
      *
-     * @param createResourceConfig The {@link ResourceConfig} of the creator.
+     * @param resourceConfig The {@link ResourceConfig} of the creator.
      * @return This object instance.
      */
     @Override
-    public BeanId setCreateResourceConfiguration(ResourceConfig createResourceConfig) {
-        this.createResourceConfig = createResourceConfig;
+    public BeanId setCreateResourceConfiguration(ResourceConfig resourceConfig) {
+        this.resourceConfig = resourceConfig;
         return this;
     }
 
@@ -88,7 +88,7 @@ public class DefaultBeanId implements BeanId {
      */
     @Override
     public ResourceConfig getCreateResourceConfiguration() {
-        return createResourceConfig;
+        return resourceConfig;
     }
 
     /**


### PR DESCRIPTION
…getCreateResourceConfiguration since the resource config can be easily obtain from the app context registry